### PR TITLE
Preserve nib

### DIFF
--- a/app/models/collected_pen.rb
+++ b/app/models/collected_pen.rb
@@ -1,6 +1,7 @@
 class CollectedPen < ApplicationRecord
 
   include Archivable
+  include PenName
 
   belongs_to :user
   has_many :currently_inkeds
@@ -15,9 +16,13 @@ class CollectedPen < ApplicationRecord
   end
 
   def name
-    n = [brand, model, nib, color].reject {|f| f.blank?}.join(' ')
-    n = "#{n} (archived)" if archived?
-    n
+    pen_name_generator(
+      brand: brand,
+      model: model,
+      nib: nib,
+      color: color,
+      archived: archived?
+    )
   end
 
   def brand=(value)

--- a/app/models/concerns/pen_name.rb
+++ b/app/models/concerns/pen_name.rb
@@ -1,0 +1,11 @@
+module PenName
+
+  extend ActiveSupport::Concern
+
+  def pen_name_generator(brand:, model:, nib:, color:, archived: )
+    n = [brand, model, nib, color].reject {|f| f.blank?}.join(' ')
+    n = "#{n} (archived)" if archived
+    n
+  end
+
+end

--- a/app/models/currently_inked.rb
+++ b/app/models/currently_inked.rb
@@ -1,6 +1,7 @@
 class CurrentlyInked < ApplicationRecord
 
   include Archivable
+  include PenName
 
   belongs_to :collected_ink
   belongs_to :collected_pen
@@ -9,7 +10,6 @@ class CurrentlyInked < ApplicationRecord
   delegate :collected_inks_for_select, to: :user
   delegate :collected_pens_for_select, to: :user
   delegate :name, to: :collected_ink, prefix: 'ink', allow_nil: true
-  delegate :name, to: :collected_pen, prefix: 'pen', allow_nil: true
   delegate :color, to: :collected_ink, prefix: 'ink'
 
   validate :collected_ink_belongs_to_user
@@ -24,12 +24,19 @@ class CurrentlyInked < ApplicationRecord
     "#{ink_name} - #{pen_name}"
   end
 
-  def ink_name
-    collected_ink.name
-  end
-
   def pen_name
-    collected_pen.name
+    nib = if self.nib.present?
+      self.nib
+    else
+      collected_pen.nib
+    end
+    pen_name_generator(
+      brand: collected_pen.brand,
+      model: collected_pen.model,
+      nib: nib,
+      color: collected_pen.color,
+      archived: collected_pen.archived?
+    )
   end
 
   def unarchivable?

--- a/app/models/currently_inked.rb
+++ b/app/models/currently_inked.rb
@@ -18,6 +18,7 @@ class CurrentlyInked < ApplicationRecord
   validates :inked_on, presence: true
 
   after_initialize :set_default_inked_on
+  before_save :update_nib
 
   def name
     "#{collected_ink.name} - #{collected_pen.name}"
@@ -40,6 +41,15 @@ class CurrentlyInked < ApplicationRecord
 
   def set_default_inked_on
     self.inked_on ||= Date.today
+  end
+
+  def update_nib
+    return unless archived_on_changed?
+    if archived?
+      self.nib = collected_pen.nib
+    else
+      self.nib = ""
+    end
   end
 
   def collected_ink_belongs_to_user

--- a/app/models/currently_inked.rb
+++ b/app/models/currently_inked.rb
@@ -21,7 +21,15 @@ class CurrentlyInked < ApplicationRecord
   before_save :update_nib
 
   def name
-    "#{collected_ink.name} - #{collected_pen.name}"
+    "#{ink_name} - #{pen_name}"
+  end
+
+  def ink_name
+    collected_ink.name
+  end
+
+  def pen_name
+    collected_pen.name
   end
 
   def unarchivable?

--- a/db/migrate/20180507062204_add_nib_to_currently_inked.rb
+++ b/db/migrate/20180507062204_add_nib_to_currently_inked.rb
@@ -1,0 +1,5 @@
+class AddNibToCurrentlyInked < ActiveRecord::Migration[5.2]
+  def change
+    add_column :currently_inked, :nib, :string, limit: 100, default: ""
+  end
+end

--- a/db/migrate/20180507063532_update_nib_in_existing_currently_inked_entries.rb
+++ b/db/migrate/20180507063532_update_nib_in_existing_currently_inked_entries.rb
@@ -1,0 +1,7 @@
+class UpdateNibInExistingCurrentlyInkedEntries < ActiveRecord::Migration[5.2]
+  def change
+    CurrentlyInked.archived.find_each do |ci|
+      ci.update(nib: ci.collected_pen.nib)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_17_144312) do
+ActiveRecord::Schema.define(version: 2018_05_07_062204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2018_04_17_144312) do
     t.bigint "user_id", null: false
     t.date "archived_on"
     t.date "inked_on", null: false
+    t.string "nib", limit: 100, default: ""
     t.index ["collected_ink_id"], name: "index_currently_inked_on_collected_ink_id"
     t.index ["collected_pen_id"], name: "index_currently_inked_on_collected_pen_id"
     t.index ["user_id"], name: "index_currently_inked_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_07_062204) do
+ActiveRecord::Schema.define(version: 2018_05_07_063532) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "cube"

--- a/spec/models/currently_inked_spec.rb
+++ b/spec/models/currently_inked_spec.rb
@@ -146,4 +146,37 @@ describe CurrentlyInked do
     end
   end
 
+  describe "nib" do
+
+    let(:ink) { collected_inks(:monis_marine) }
+    let(:pen) { collected_pens(:monis_pilot_custom_74) }
+
+    before(:each) do
+      subject.collected_pen = pen
+      subject.collected_ink = ink
+      subject.save!
+    end
+
+    it 'sets the nib if entry is archived' do
+      expect do
+        subject.update(archived_on: Date.today)
+      end.to change { subject.nib }.from("").to(pen.nib)
+    end
+
+    it 'does not change the nib when already archived' do
+      subject.update(archived_on: Date.today)
+      subject.update(nib: "other value")
+      expect(subject.nib).to eq("other value")
+      expect do
+        subject.update(comment: 'new comment')
+      end.to_not change { subject.reload; subject.nib }
+    end
+
+    it 'clears the nib when unarchiving' do
+      subject.update(archived_on: Date.today)
+      expect do
+        subject.update(archived_on: nil)
+      end.to change { subject.nib }.from(pen.nib).to("")
+    end
+  end
 end

--- a/spec/models/currently_inked_spec.rb
+++ b/spec/models/currently_inked_spec.rb
@@ -179,4 +179,19 @@ describe CurrentlyInked do
       end.to change { subject.nib }.from(pen.nib).to("")
     end
   end
+
+  describe '#pen_name' do
+    before(:each) do
+      subject.collected_pen = collected_pens(:monis_pilot_custom_74)
+    end
+
+    it 'uses the nib from the pen' do
+      expect(subject.pen_name).to eq('Pilot Custom 74 M orange')
+    end
+
+    it 'uses the nib from self' do
+      subject.nib = 'my nib'
+      expect(subject.pen_name).to eq('Pilot Custom 74 my nib orange')
+    end
+  end
 end


### PR DESCRIPTION
When the nib of a `CollectedPen` is changed all the data for the historic `CurrentlyInked` entries is also changed. It makes sense to keep that information though as nibs are often changed on pens.