### PR TITLE
Add maker column

### DIFF
--- a/app/controllers/collected_inks_controller.rb
+++ b/app/controllers/collected_inks_controller.rb
@@ -55,6 +55,7 @@ class CollectedInksController < ApplicationController
       :swabbed,
       :used,
       :comment,
+      :maker
     )
   end
 

--- a/app/javascript/src/collected_inks/actions.js
+++ b/app/javascript/src/collected_inks/actions.js
@@ -169,6 +169,11 @@ export const updateComment = (id, value) => (dispatch, getState) => {
   dispatch(filterData());
 }
 
+export const updateMaker = (id, value) => (dispatch, getState) => {
+  dispatch(updateField(id, "maker", value));
+  dispatch(filterData());
+}
+
 export const updateInk = (id, value) => (dispatch, getState) => {
   dispatch(updateField(id, "ink_name", value));
   dispatch(updateSuggestions());

--- a/app/javascript/src/collected_inks/components/ink_table.jsx
+++ b/app/javascript/src/collected_inks/components/ink_table.jsx
@@ -17,6 +17,7 @@ const Header = ({entries}) => <thead>
     <th>Brand</th>
     <th>Line</th>
     <th>Name</th>
+    <th>Maker</th>
     <th>Type</th>
     <th>Color</th>
     <th>Swabbed</th>
@@ -38,6 +39,7 @@ const Footer = ({brands, inks, bottles, samples, cartridges, newEntryForm}) => <
     <th>{brands} brands</th>
     <th></th>
     <th>{inks} inks</th>
+    <th></th>
     <th>
       {bottles}x bottle
       <br />

--- a/app/javascript/src/collected_inks/components/new_entry.jsx
+++ b/app/javascript/src/collected_inks/components/new_entry.jsx
@@ -12,6 +12,7 @@ import Color from "./row/color";
 import Swabbed from "./row/swabbed";
 import Used from "./row/used";
 import Comment from "./row/comment";
+import Maker from "./row/maker";
 
 class NewEntry extends React.Component {
 
@@ -32,6 +33,7 @@ class NewEntry extends React.Component {
       used: false,
       comment: '',
       archived: false,
+      maker: ''
     };
   }
 
@@ -85,6 +87,10 @@ class NewEntry extends React.Component {
     this.setState({comment: value})
   }
 
+  onChangeMaker = (value) => {
+    this.setState({maker: value})
+  }
+
   render() {
     const state = this.state;
     return <tr>
@@ -92,6 +98,7 @@ class NewEntry extends React.Component {
       <td className="new-entry"><Brand onlyEdit brand={state.brand_name} onChange={this.onChangeBrand}/></td>
       <td className="new-entry"><Line onlyEdit line={state.line_name} onChange={this.onChangeLine} /></td>
       <td className="new-entry"><Ink onlyEdit ink={state.ink_name} onChange={this.onChangeInk} /></td>
+      <td className="new-entry"><Maker onlyEdit maker={state.maker} onChange={this.onChangeMaker} /></td>
       <td><Kind kind={state.kind} onChange={this.onChangeKind}/></td>
       <td><Color color={state.color} onChange={this.onChangeColor}/></td>
       <td><Swabbed swabbed={state.swabbed} onClick={this.onToggleSwabbed}/></td>

--- a/app/javascript/src/collected_inks/components/row/index.jsx
+++ b/app/javascript/src/collected_inks/components/row/index.jsx
@@ -13,6 +13,7 @@ import {
   updateInk,
   updateKind,
   updateLine,
+  updateMaker
 } from "src/collected_inks/actions";
 import ActionButtons from "./action_buttons";
 import Brand from "./brand";
@@ -21,6 +22,7 @@ import Comment from "./comment";
 import Ink from "./ink";
 import Kind from "./kind";
 import Line from "./line";
+import Maker from "./maker";
 import Privacy from "./privacy";
 import Swabbed from "./swabbed";
 import Usage from "./usage";
@@ -70,6 +72,7 @@ class Row extends React.Component {
       <td><Brand brand={props.brand_name} onChange={props.onChangeBrand}/></td>
       <td><Line line={props.line_name} onChange={props.onChangeLine} /></td>
       <td><Ink ink={props.ink_name} onChange={props.onChangeInk} /></td>
+      <td><Maker maker={props.maker} onChange={props.onChangeMaker} /></td>
       <td><Kind kind={props.kind} onChange={props.onChangeKind}/></td>
       <td><Color color={props.color} onChange={props.onChangeColor}/></td>
       <td><Swabbed swabbed={props.swabbed} onClick={props.onToggleSwabbed}/></td>
@@ -109,6 +112,9 @@ const mapDispatchToProps = (dispatch, {id}) => ({
   },
   onChangeLine(value) {
     dispatch(updateLine(id, value))
+  },
+  onChangeMaker(value) {
+    dispatch(updateMaker(id, value))
   },
   onDelete() {
     dispatch(deleteEntry(id))

--- a/app/javascript/src/collected_inks/components/row/maker.jsx
+++ b/app/javascript/src/collected_inks/components/row/maker.jsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import FancyInput from "./fancy_input";
+
+class Maker extends FancyInput {
+  constructor(props) {
+    super(props);
+  }
+
+  valueFieldName() {
+    return "maker";
+  }
+
+  required() {
+    return false;
+  }
+
+}
+
+export default Maker;

--- a/app/serializable/serializable_collected_ink.rb
+++ b/app/serializable/serializable_collected_ink.rb
@@ -14,6 +14,7 @@ class SerializableCollectedInk < JSONAPI::Serializable::Resource
   attribute :ink_name
   attribute :kind
   attribute :line_name
+  attribute :maker
   attribute :private
   attribute :simplified_brand_name
   attribute :simplified_ink_name

--- a/db/migrate/20180907143946_add_maker_to_collected_ink.rb
+++ b/db/migrate/20180907143946_add_maker_to_collected_ink.rb
@@ -1,0 +1,5 @@
+class AddMakerToCollectedInk < ActiveRecord::Migration[5.2]
+  def change
+    add_column :collected_inks, :maker, :text, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_01_054458) do
+ActiveRecord::Schema.define(version: 2018_09_07_143946) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "fuzzystrmatch"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2018_08_01_054458) do
     t.boolean "used", default: false, null: false
     t.date "archived_on"
     t.bigint "ink_brand_id"
+    t.text "maker", default: ""
     t.index ["brand_name"], name: "index_collected_inks_on_brand_name"
     t.index ["ink_brand_id"], name: "index_collected_inks_on_ink_brand_id"
     t.index ["ink_name"], name: "index_collected_inks_on_ink_name"


### PR DESCRIPTION
Apparently some people also want to track who manufactured the ink (e.g. Sailor does a lot of custom inks for other companies) and people just use the existing columns for that which of course makes the matching harder. Hopefully adding this column will make it clearer where to put data. The downside is of course that this will make the mobile experience even worse. I'll have to work on that soon.