### PR TITLE
Remove empty clusters

### DIFF
--- a/lib/tasks/clean_up.rake
+++ b/lib/tasks/clean_up.rake
@@ -1,0 +1,7 @@
+namespace :clean_up do
+  desc "Clean up empty ink and brand clusters"
+  task clusters: :environment do
+    NewInkName.where("collected_inks_count <= 0").find_each {|nin| nin.destroy }
+    InkBrand.where("new_ink_names_count <= 0").find_each {|ib| ib.destroy }
+  end
+end


### PR DESCRIPTION
This removes ink and brand clusters that have no members. Will be run regularly on the production system using the Heroku Scheduler add-on.