### PR TITLE
More bot signup fun

### DIFF
--- a/app/controllers/admins/graphs_controller.rb
+++ b/app/controllers/admins/graphs_controller.rb
@@ -20,6 +20,9 @@ class Admins::GraphsController < Admins::BaseController
     }, {
       data: build(User),
       name: "All signups"
+    }, {
+      data: build(User.bots),
+      name: "Bot signups"
     }]
   end
 

--- a/app/models/admin_stats.rb
+++ b/app/models/admin_stats.rb
@@ -37,15 +37,7 @@ class AdminStats
 
 
   def user_count
-    @user_count ||= User.count
-  end
-
-  def confirmed_user_count
-    @confirmed_user_count ||= User.active.count
-  end
-
-  def confirmed_user_percentage
-    confirmed_user_count*100.0/user_count
+    @user_count ||= User.active.count
   end
 
   def active_user_count

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,6 @@ class User < ApplicationRecord
 
   validates :name, length: { in: 1..100, allow_blank: true }
 
-  attr_accessor :bot_field
-  validates :bot_field, absence: true
-
   def self.active
     where.not(confirmed_at: nil)
   end
@@ -25,6 +22,13 @@ class User < ApplicationRecord
 
   def self.bots
     where(bot: true)
+  end
+
+  attr_reader :bot_field
+
+  def bot_field=(value)
+    self.bot = value.present?
+    skip_confirmation_notification! if bot?
   end
 
   def unread

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
     where.not(name: [nil, ""])
   end
 
+  def self.bots
+    where(bot: true)
+  end
+
   def unread
     reading_statuses.unread.includes(:blog_post)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,10 @@ class User < ApplicationRecord
     skip_confirmation_notification! if bot?
   end
 
+  def active_for_authentication?
+    super && !bot
+  end
+
   def unread
     reading_statuses.unread.includes(:blog_post)
   end

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -8,11 +8,7 @@ table class="table table-striped"
       td
         table
           tr
-            td= @stats.user_count
-            td
-              |  (
-              = number_to_percentage(@stats.confirmed_user_percentage, precision: 2)
-              |  confirmed)
+            td= "#{@stats.user_count} confirmed users"
           tr
             td
             td

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,4 +1,4 @@
 StrongMigrations.start_after = 20200203072140
 StrongMigrations.statement_timeout = 1.hour
 StrongMigrations.lock_timeout = 10.seconds
-StrongMigrations.target_postgresql_version = "10"
+StrongMigrations.target_postgresql_version = "12"

--- a/db/migrate/20210415062021_add_is_bot_flag_to_user.rb
+++ b/db/migrate/20210415062021_add_is_bot_flag_to_user.rb
@@ -1,0 +1,5 @@
+class AddIsBotFlagToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :bot, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -557,7 +557,8 @@ CREATE TABLE public.users (
     unconfirmed_email character varying,
     blurb text DEFAULT ''::text,
     patron boolean DEFAULT false,
-    time_zone character varying
+    time_zone character varying,
+    bot boolean DEFAULT false
 );
 
 
@@ -1238,6 +1239,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200930122807'),
 ('20200930124526'),
 ('20201002133409'),
-('20201007070202');
+('20201007070202'),
+('20210415062021');
 
 

--- a/lib/tasks/clean_up.rake
+++ b/lib/tasks/clean_up.rake
@@ -10,6 +10,6 @@ namespace :clean_up do
 
   desc "Remove users that haven't confirmed their email in 4 weeks"
   task unconfirmed_accounts: :environment do
-    User.where(confirmed_at: nil).where('created_at < ?', 4.weeks.ago).destroy_all
+    User.where(confirmed_at: nil).where('created_at < ?', 40.weeks.ago).destroy_all
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,6 +30,18 @@ describe User do
     end
   end
 
+  describe '#active_for_authentication?' do
+    it 'returns true for confirmed users' do
+      user = create(:user)
+      expect(user).to be_active_for_authentication
+    end
+
+    it 'returns fals for bots' do
+      user = create(:user, bot: true)
+      expect(user).not_to be_active_for_authentication
+    end
+  end
+
   describe '#friends' do
     let(:friend) { create(:user) }
     subject { create(:user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,18 +2,31 @@ require 'rails_helper'
 
 describe User do
   describe '#bot_field' do
-    it 'ensures that the user is valid if the field is not set' do
-      user = build(:user)
-      user.bot_field = ''
-      expect(user).to be_valid
-      user.bot_field = nil
+    it 'sets the bot flag to true when this is set' do
+      user = build(:user, bot_field: 'some value')
+      expect(user).to be_bot
+    end
+
+    it 'sets the bot flag to false when field is blank' do
+      user = build(:user, bot_field: '')
+      expect(user).to_not be_bot
+    end
+
+    it 'does not result in a validation error when the field is set' do
+      user = build(:user, bot_field: 'some value')
       expect(user).to be_valid
     end
 
-    it 'ensures that the user is invalid if the field is set' do
-      user = build(:user)
-      user.bot_field = 'some value'
-      expect(user).to be_invalid
+    it 'does not send a confirmation email when field is set' do
+      expect do
+        create(:user, confirmed_at: nil, bot_field: 'some value')
+      end.to_not change { ActionMailer::Base.deliveries.count }
+    end
+
+    it 'sends a confirmation email when field is not set' do
+      expect do
+        create(:user, confirmed_at: nil, bot_field: '')
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 

--- a/spec/requests/admins/graphs_controller_spec.rb
+++ b/spec/requests/admins/graphs_controller_spec.rb
@@ -31,7 +31,7 @@ describe Admins::GraphsController do
         }, {
           data: [
             [2.days.ago.at_beginning_of_day.to_i*1000, 2],
-            [1.day.ago.at_beginning_of_day.to_i*1000, 1]
+            [1.day.ago.at_beginning_of_day.to_i*1000, 2]
           ],
           name: 'All signups'
         }, {

--- a/spec/requests/admins/graphs_controller_spec.rb
+++ b/spec/requests/admins/graphs_controller_spec.rb
@@ -18,6 +18,7 @@ describe Admins::GraphsController do
         create(:user, created_at: 2.days.ago)
         create(:user, created_at: 1.day.ago)
         create(:user, created_at: 2.days.ago, confirmed_at: nil)
+        create(:user, created_at: 1.day.ago, confirmed_at: nil, bot: true)
         get '/admins/graphs/signups'
         expect(response).to be_successful
         json = JSON.parse(response.body, symbolize_names: true)
@@ -33,6 +34,11 @@ describe Admins::GraphsController do
             [1.day.ago.at_beginning_of_day.to_i*1000, 1]
           ],
           name: 'All signups'
+        }, {
+          data: [
+            [1.day.ago.at_beginning_of_day.to_i*1000, 1]
+          ],
+          name: 'Bot signups'
         }])
       end
 


### PR DESCRIPTION
As the previous honey pot field (#733) didn't do much, I've decided to change the approach:

* Instead of rejecting these signups I am instead saving them as users flagged as bots. The thinking is that maybe this will help as there's no error displayed and that might fool the bot.
* To avoid spamming, I've ensured that no confirmation emails are sent out for bot users.
* Bot user accounts are locked down and it's impossible to sign in with them
* They will be kept for 40 weeks now for easier tracking of the experiments (e.g. how many bot signups are detected, etc.)
* The admin graph now shows the bot signups separately