### PR TITLE
Actually enable the bot honeypot field

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
   around_action :set_time_zone
 
@@ -17,6 +18,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:bot_field])
+  end
 
   def set_time_zone
     if current_user && current_user.time_zone.present?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,7 @@
     <%= f.input :email, required: true, autofocus: true %>
     <%= f.input :password, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) %>
     <%= f.input :password_confirmation, required: true %>
-    <%= f.input :bot_field %>
+    <%= f.input :bot_field, label: "Fill out this field if you are a bot" %>
   </div>
 
   <div class="alert alert-danger">

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+describe 'sign up' do
+  context 'normal user' do
+    let(:user_params) { { email: 'user@example.com', password: 'password', password_confirmation: 'password' } }
+    it 'creates a user' do
+      expect do
+        post "/users", params: { user: user_params }
+        expect(response).to be_redirect
+      end.to change { User.where(bot: false).count }.by(1)
+    end
+
+    it 'sends the confirmation email' do
+      expect do
+        post "/users", params: { user: user_params }
+        expect(response).to be_redirect
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  context 'bot user' do
+    let(:user_params) { { email: 'user@example.com', password: 'password', password_confirmation: 'password', bot_field: '1' } }
+
+    it 'creates a bot user' do
+      expect do
+        post "/users", params: { user: user_params }
+        expect(response).to be_redirect
+      end.to change { User.where(bot: true).count }.by(1)
+    end
+
+    it 'does not send an email' do
+      expect do
+        post "/users", params: { user: user_params }
+        expect(response).to be_redirect
+      end.to_not change { ActionMailer::Base.deliveries.count }
+    end
+  end
+end


### PR DESCRIPTION
It turns out that my previous PR (#760) didn't even activate the bot honeybot due to the Rails strong params. I had to add the extra field to the whitelist.

