### PR TITLE
Tighten up rules around marking as a bot

### DIFF
--- a/db/migrate/20210521072307_add_bot_reason_to_user.rb
+++ b/db/migrate/20210521072307_add_bot_reason_to_user.rb
@@ -1,0 +1,5 @@
+class AddBotReasonToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :bot_reason, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -560,7 +560,8 @@ CREATE TABLE public.users (
     time_zone character varying,
     bot boolean DEFAULT false,
     sign_up_user_agent text,
-    sign_up_ip character varying
+    sign_up_ip character varying,
+    bot_reason character varying
 );
 
 
@@ -1245,6 +1246,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210415062021'),
 ('20210419191331'),
 ('20210420100740'),
-('20210422204021');
+('20210422204021'),
+('20210521072307');
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,6 +33,11 @@ describe User do
         create(:user, confirmed_at: nil, bot_field: '')
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    it 'correctly sets bot_reason when marking as a bot via this method' do
+      user = build(:user, bot_field: 'some value')
+      expect(user.bot_reason).to eq('bot_field')
+    end
   end
 
   describe '#sign_up_ip=' do
@@ -52,6 +57,23 @@ describe User do
       user = build(:user)
       user.sign_up_ip = User::BLACKLIST.first
       expect(user.bot).to be true
+    end
+
+    it 'does not send a confirmation email when blacklisted' do
+      expect do
+        create(:user, confirmed_at: nil, sign_up_ip: User::BLACKLIST.first)
+      end.to_not change { ActionMailer::Base.deliveries.count }
+    end
+
+    it 'marks as a bot when blacklisted, but not triggering the bot_field' do
+      user = build(:user, sign_up_ip: User::BLACKLIST.first)
+      user.bot_field = ''
+      expect(user.bot).to be true
+    end
+
+    it 'correctly sets the bot_reason when marking as a bot via this method' do
+      user = build(:user, sign_up_ip: User::BLACKLIST.first)
+      expect(user.bot_reason).to eq('sign_up_ip_blacklist')
     end
   end
 


### PR DESCRIPTION
* Skip confirmation when one of the two criteria have been met
* Do not reset to "no bot" when bot_field used after the ip check
* Track the reason for marking as a bot