### PR TITLE
Include current ink when editing currently inked

### DIFF
--- a/app/models/currently_inked.rb
+++ b/app/models/currently_inked.rb
@@ -98,7 +98,7 @@ class CurrentlyInked < ApplicationRecord
   end
 
   def collected_inks_for_active_select
-    user.active_collected_inks
+    user.active_collected_inks + [collected_ink]
   end
 
   private

--- a/spec/models/currently_inked_spec.rb
+++ b/spec/models/currently_inked_spec.rb
@@ -268,4 +268,12 @@ describe CurrentlyInked do
       expect(subject).to_not be_used_today
     end
   end
+
+  describe '#collected_inks_for_active_select' do
+    it 'includes the current ink even if it is archived' do
+      currently_inked = create(:currently_inked)
+      currently_inked.collected_ink.archive!
+      expect(currently_inked.collected_inks_for_active_select).to include(currently_inked.collected_ink)
+    end
+  end
 end


### PR DESCRIPTION
Even when an ink has been archived it should still be included in the set
of inks available when editing a currently inked entry. If not, then a
random ink gets chosen and you can't really edit a currently inked entry
with an archived ink without changing the ink.