### PR TITLE
Proper without_review

### DIFF
--- a/app/controllers/admins/reviews_controller.rb
+++ b/app/controllers/admins/reviews_controller.rb
@@ -16,7 +16,8 @@ class Admins::ReviewsController < Admins::BaseController
   end
 
   def missing
-    @macro_clusters = MacroCluster.without_review.joins(
+    unreviewed_ids = MacroCluster.without_review.pluck(:id)
+    @macro_clusters = MacroCluster.where(id: unreviewed_ids).joins(
       micro_clusters: :collected_inks
     ).includes(
       :brand_cluster

--- a/spec/factories/ink_reviews.rb
+++ b/spec/factories/ink_reviews.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :ink_review do
     title { "MyText" }
-    url { "http://example.com" }
+    sequence(:url) { |n| "http://example#{n}.com" }
     description { "MyText" }
     image { "MyText" }
     macro_cluster

--- a/spec/models/macro_cluster_spec.rb
+++ b/spec/models/macro_cluster_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe MacroCluster do
+  describe '#without_review' do
+    let!(:macro_cluster) { create(:macro_cluster) }
+
+    subject { described_class.without_review }
+
+    it 'returns clusters without any ink reviews' do
+      expect(subject).to eq([macro_cluster])
+    end
+
+    it 'does not return a cluster with a new ink review' do
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: nil, rejected_at: nil)
+      expect(subject).to be_empty
+    end
+
+    it 'does not return a cluster with an approved ink review' do
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: Time.now, rejected_at: nil)
+      expect(subject).to be_empty
+    end
+
+    it 'returns a cluster with a rejected review' do
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: nil, rejected_at: Time.now)
+      expect(subject).to eq([macro_cluster])
+    end
+
+    it 'returns a cluster with multiple rejected reviews' do
+      create_list(:ink_review, 2, macro_cluster: macro_cluster, approved_at: nil, rejected_at: Time.now)
+      expect(subject.count).to eq(1)
+      expect(subject).to eq([macro_cluster])
+    end
+
+    it 'does not return a cluster with an approved and a reject review' do
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: Time.now, rejected_at: nil)
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: nil, rejected_at: Time.now)
+      expect(subject).to be_empty
+    end
+
+    it 'does not return a cluster with a new and a rejected review' do
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: nil, rejected_at: nil)
+      create(:ink_review, macro_cluster: macro_cluster, approved_at: nil, rejected_at: Time.now)
+      expect(subject).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Also return macro clusters that have _only_ rejected reviews.