### PR TITLE
Put reviews on a separate queue

### DIFF
--- a/app/workers/fetch_reviews/generic_rss.rb
+++ b/app/workers/fetch_reviews/generic_rss.rb
@@ -2,6 +2,7 @@ class FetchReviews
   class GenericRss
     include Sidekiq::Worker
     include FetchReviews::ViaRss
+    sidekiq_options queue: 'reviews'
 
     attr_accessor :feed_url
 

--- a/app/workers/fetch_reviews/mountain_of_ink.rb
+++ b/app/workers/fetch_reviews/mountain_of_ink.rb
@@ -2,6 +2,7 @@ class FetchReviews
   class MountainOfInk
     include Sidekiq::Worker
     include FetchReviews::ViaRss
+    sidekiq_options queue: 'reviews'
 
     def feed_url
       'https://mountainofink.com/?format=rss'

--- a/app/workers/fetch_reviews/pen_addict.rb
+++ b/app/workers/fetch_reviews/pen_addict.rb
@@ -2,6 +2,7 @@ class FetchReviews
   class PenAddict
     include Sidekiq::Worker
     include FetchReviews::ViaRss
+    sidekiq_options queue: 'reviews'
 
     def feed_url
       'https://penaddict.com/blog?format=rss'

--- a/app/workers/fetch_reviews/recalculate_all.rb
+++ b/app/workers/fetch_reviews/recalculate_all.rb
@@ -1,6 +1,7 @@
 class FetchReviews
   class RecalculateAll
     include Sidekiq::Worker
+    sidekiq_options queue: 'reviews'
 
     def perform
       InkReview.find_each do |ink_review|

--- a/app/workers/fetch_reviews/recalculate_one.rb
+++ b/app/workers/fetch_reviews/recalculate_one.rb
@@ -1,6 +1,7 @@
 class FetchReviews
   class RecalculateOne
     include Sidekiq::Worker
+    sidekiq_options queue: 'reviews'
 
     def perform(ink_review_id)
       self.ink_review = InkReview.find(ink_review_id)

--- a/app/workers/fetch_reviews/submit_review.rb
+++ b/app/workers/fetch_reviews/submit_review.rb
@@ -1,6 +1,7 @@
 class FetchReviews
   class SubmitReview
     include Sidekiq::Worker
+    sidekiq_options queue: 'reviews'
 
     def perform(url, macro_cluster_id)
       macro_cluster = MacroCluster.find_by(id: macro_cluster_id)

--- a/app/workers/fetch_reviews/youtube_channel.rb
+++ b/app/workers/fetch_reviews/youtube_channel.rb
@@ -1,6 +1,7 @@
 class FetchReviews
   class YoutubeChannel
     include Sidekiq::Worker
+    sidekiq_options queue: 'reviews'
 
     def perform(channel_id)
       self.channel = YouTubeChannel.find_by!(channel_id: channel_id)


### PR DESCRIPTION
The `reviews` queue has only one thread. So, hopefully those won't tax the database as much as they did previously.