### PR TITLE
Separate background jobs for each type of leaderboard refresh

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma
 release: rake db:migrate db:seed
-worker: trap '' SIGTERM; bundle exec sidekiq -c 5 -q default -q mailers & bundle exec sidekiq -c 1 -q reviews & wait -n; kill -SIGTERM -$$; wait
+worker: trap '' SIGTERM; bundle exec sidekiq -c 5 -q default -q mailers & bundle exec sidekiq -c 1 -q reviews -q leaderboards & wait -n; kill -SIGTERM -$$; wait

--- a/app/models/leader_board.rb
+++ b/app/models/leader_board.rb
@@ -1,15 +1,19 @@
 class LeaderBoard
 
-  def self.refresh!
-    inks(force: true)
-    bottles(force: true)
-    samples(force: true)
-    brands(force: true)
-    inks_by_popularity(force: true)
-    currently_inked(force: true)
-    usage_records(force: true)
-    pens_by_popularity(force: true)
-    ink_review_submissions(force: true)
+  TYPES = %w[
+    inks
+    bottles
+    samples
+    brands
+    inks_by_popularity
+    currently_inked
+    usage_records
+    pens_by_popularity
+    ink_review_submissions
+  ]
+
+  def self.refresh!(type)
+    self.send(type, force: true)
   end
 
   def self.pens_by_popularity(force: false)

--- a/app/workers/refresh_leader_board.rb
+++ b/app/workers/refresh_leader_board.rb
@@ -1,0 +1,9 @@
+class RefreshLeaderBoard
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'leaderboards'
+
+  def perform(type)
+    LeaderBoard.refresh!(type)
+  end
+end

--- a/app/workers/refresh_leader_boards.rb
+++ b/app/workers/refresh_leader_boards.rb
@@ -1,7 +1,11 @@
 class RefreshLeaderBoards
   include Sidekiq::Worker
 
+  sidekiq_options queue: 'leaderboards'
+
   def perform
-    LeaderBoard.refresh!
+    LeaderBoard::TYPES.each do |type|
+      RefreshLeaderBoard.perform_async(type)
+    end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     command: bundle exec sidekiq -q default -q mailers -c 1
   sidekiq_reviews:
     <<: *rails
-    command: bundle exec sidekiq -q reviews -c 1
+    command: bundle exec sidekiq -q reviews -q leaderboards -c 1
 
 volumes:
   postgres_14_data:


### PR DESCRIPTION
Some will be fast to compute, some will be slow. Let's not do them all
together as that's a bad idea performance wise.