### PR TITLE
Speed up brands leader board calculation

### DIFF
--- a/app/models/leader_board.rb
+++ b/app/models/leader_board.rb
@@ -116,7 +116,7 @@ class LeaderBoard
   def self.brands(force: false)
     Rails.cache.fetch("LeaderBoard#brands", force: force) do
       extract(build(
-        "(select sum(1) OVER () from collected_inks where collected_inks.user_id = users.id group by collected_inks.brand_name limit 1) as counter"
+        "(select count(distinct brand_name) from collected_inks where collected_inks.user_id = users.id) as counter"
       ))
     end
   end


### PR DESCRIPTION
Locally the change from using a window function to just using count
reduced the time from ~120s to ~40s.