### PR TITLE
Clean up after Redis move to DigitalOcean

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.log_tags = [ :request_id ]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL', ENV['REDISCLOUD_URL']) }
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_CACHE_URL') }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,12 +8,3 @@ Sidekiq.configure_server do |config|
     SidekiqScheduler::Scheduler.instance.reload_schedule!
   end
 end
-
-# Heroku uses self signed certificates for their premium Redis
-Sidekiq.configure_server do |config|
-  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = { ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
-end


### PR DESCRIPTION
* No need for redis could env url
* No need to bypass SSL security