### PR TITLE
Fix link in pen brand pie chart

### DIFF
--- a/app/javascript/src/dashboard/pens_grouped_by_brand_widget.jsx
+++ b/app/javascript/src/dashboard/pens_grouped_by_brand_widget.jsx
@@ -6,7 +6,7 @@ import { generateColors, dataWithOtherEntry } from "./charting";
 
 export const PensGroupedByBrandWidget = () => (
   <Widget
-    header={<a href="/collected_inks">Pens</a>}
+    header={<a href="/collected_pens">Pens</a>}
     path="/dashboard/widgets/pens_grouped_by_brand.json"
   >
     <PensGroupedByBrandWidgetContent />


### PR DESCRIPTION
I noticed a while ago that the title of the "Your pens grouped by brand" pie chart on the dashboard links to inks instead of pens which seems wrong.

Note. I haven't actually run this code at all. I just used the github.dev online editor.