### PR TITLE
Reject button on ink pages

### DIFF
--- a/app/controllers/admins/reviews_controller.rb
+++ b/app/controllers/admins/reviews_controller.rb
@@ -1,6 +1,8 @@
 class Admins::ReviewsController < Admins::BaseController
   def index
-    @ink_reviews = InkReview.queued.order('created_at asc').page(params[:page])
+    query = InkReview.queued.order('created_at asc')
+    @ink_reviews = query.page(params[:page])
+    @ink_reviews = query.page(0) if @ink_reviews.empty?
   end
 
   def destroy
@@ -18,10 +20,14 @@ class Admins::ReviewsController < Admins::BaseController
   private
 
   def redirect_after_change
-    if InkReview.queued.exists?
-      redirect_to admins_reviews_path
+    if request.referrer.blank? || request.referrer =~ /\/admins/
+      if InkReview.queued.exists?
+        redirect_to admins_reviews_path(page: params[:page])
+      else
+        redirect_to admins_dashboard_path
+      end
     else
-      redirect_to admins_dashboard_path
+      redirect_to request.referrer
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,8 @@ module ApplicationHelper
     # Only for signed in users, roughly every 8 weeks
     user_signed_in? && !current_user.patron? && (Date.current.cweek % 8).zero?
   end
+
+  def admin?
+    current_user&.admin? || admin_signed_in?
+  end
 end

--- a/app/views/admins/reviews/index.html.slim
+++ b/app/views/admins/reviews/index.html.slim
@@ -25,7 +25,7 @@
     tr
       td
       td
-        = link_to "Approve",  admins_review_path(ink_review), method: :put, class: 'btn btn-default'
-        = link_to "Reject", admins_review_path(ink_review), method: :delete, class: 'btn btn-default'
+        = link_to "Approve",  admins_review_path(ink_review, page: params[:page]), method: :put, class: 'btn btn-default'
+        = link_to "Reject", admins_review_path(ink_review, page: params[:page]), method: :delete, class: 'btn btn-default'
 
 = paginate @ink_reviews

--- a/app/views/inks/show.html.slim
+++ b/app/views/inks/show.html.slim
@@ -68,6 +68,8 @@ div class="row details"
                 div class="description"= truncate(ink_review.description, length: 200)
               div class="col-xs-12 col-sm-6"
                 = image_tag ink_review.image
+              - if admin?
+                = link_to "Reject", admins_review_path(ink_review), method: :delete, class: 'btn btn-default', data: { confirm: 'Reject?' }
 
 
 

--- a/spec/requests/admins/reviews_spec.rb
+++ b/spec/requests/admins/reviews_spec.rb
@@ -39,6 +39,12 @@ describe "Admins::Reviews" do
           put "/admins/reviews/#{ink_review.id}"
         end.to change { ink_review.reload.approved? }.from(false).to(true)
       end
+
+      it 'keeps redirects to the reviews index page with the page param if another review exists' do
+        create(:ink_review)
+        put "/admins/reviews/#{ink_review.id}?page=2"
+        expect(response).to redirect_to('/admins/reviews?page=2')
+      end
     end
   end
 


### PR DESCRIPTION
* Add reject button on the ink review page for admins
* Keep page in reviews when approving and rejecting and do not start from page 0 all the time.