### PR TITLE
Separate capsule for the leaderboard

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,3 +8,11 @@ Sidekiq.configure_server do |config|
     SidekiqScheduler::Scheduler.instance.reload_schedule!
   end
 end
+
+# Separate capsule for the leaderboard queue as it's super slow
+Sidekiq.configure_server do |config|
+  config.capsule('slow') do |cap|
+    cap.concurrency = 1
+    cap.queues = ['leaderboards']
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,4 +4,3 @@
   - mailers
   - default
   - reviews
-  - leaderboards


### PR DESCRIPTION
The leaderboard calculations are sometimes slow so it's best for them to run in their own capsule with just one thread. Then they won't overload the database either.