### PR TITLE
Add test for the patreon logo

### DIFF
--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -16,6 +16,13 @@ describe UsersController do
       expect(response).to be_successful
       expect(response.body).to_not include("/users/#{user.id}")
     end
+
+    it 'shows the patreon logo next to the correct user' do
+      user = create(:user, name: 'the name', patron: true)
+      get '/users'
+      expect(response).to be_successful
+      expect(response.body).to include('fpc-patron-tiny')
+    end
   end
 
   describe '#show' do


### PR DESCRIPTION
The main benefit here is that it will fail, if the image is missing as then the `image_path` method will raise an exception.