### PR TITLE
Remove ability to delete pens and inks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+.vscode

--- a/app/controllers/collected_inks_controller.rb
+++ b/app/controllers/collected_inks_controller.rb
@@ -85,24 +85,6 @@ class CollectedInksController < ApplicationController
     end
   end
 
-  def destroy
-    if ink
-      if ink.deletable?
-        ink.destroy
-        flash[:notice] = "Ink successfully deleted"
-      else
-        flash[
-          :alert
-        ] = "'#{ink.name}' has currently inked entries attached and can't be deleted."
-      end
-    end
-    if archive?
-      redirect_to collected_inks_path(search: { archive: true })
-    else
-      redirect_to collected_inks_path
-    end
-  end
-
   def archive
     flash[:notice] = "Successfully archived '#{ink.name}'" if ink
     ink&.archive!

--- a/app/controllers/collected_pens_archive_controller.rb
+++ b/app/controllers/collected_pens_archive_controller.rb
@@ -31,11 +31,6 @@ class CollectedPensArchiveController < ApplicationController
     redirect_to collected_pens_archive_index_path
   end
 
-  def destroy
-    @collected_pen&.destroy
-    redirect_to collected_pens_archive_index_path
-  end
-
   private
 
   def collected_pen_params

--- a/app/controllers/collected_pens_controller.rb
+++ b/app/controllers/collected_pens_controller.rb
@@ -51,11 +51,6 @@ class CollectedPensController < ApplicationController
     end
   end
 
-  def destroy
-    @collected_pen&.destroy
-    redirect_to collected_pens_path
-  end
-
   def archive
     flash[
       :notice

--- a/app/javascript/src/collected_inks/index.jsx
+++ b/app/javascript/src/collected_inks/index.jsx
@@ -413,7 +413,6 @@ const Actions = ({
 const ActionsCell = ({
   id,
   archived,
-  deletable,
   brand_name,
   line_name,
   ink_name,
@@ -425,12 +424,6 @@ const ActionsCell = ({
     <td className="actions">
       <EditButton name={inkName} id={id} archived={archived} />
       <ArchiveButton name={inkName} id={id} archived={archived} />
-      <DeleteButton
-        name={inkName}
-        id={id}
-        deletable={deletable}
-        archived={archived}
-      />
     </td>
   );
 };
@@ -442,25 +435,6 @@ const EditButton = ({ name, id, archived }) => {
     <span>
       <a className="btn btn-secondary" href={href} title={`Edit ${name}`}>
         <i className="fa fa-pencil" />
-      </a>
-    </span>
-  );
-};
-
-const DeleteButton = ({ name, id, deletable, archived }) => {
-  let href = `/collected_inks/${id}`;
-  if (archived) href += "?search[archive]=true";
-  if (!deletable || !archived) return null;
-  return (
-    <span>
-      <a
-        className="btn btn-danger"
-        data-confirm={`Really delete ${name}?`}
-        title={`Delete ${name}`}
-        data-method="delete"
-        href={href}
-      >
-        <i className="fa fa-trash" />
       </a>
     </span>
   );

--- a/app/models/collected_ink.rb
+++ b/app/models/collected_ink.rb
@@ -173,10 +173,6 @@ class CollectedInk < ApplicationRecord
     super(value.strip)
   end
 
-  def deletable?
-    currently_inked_count == 0
-  end
-
   def simplified_name
     "#{simplified_brand_name}#{simplified_ink_name}"
   end

--- a/app/models/collected_pen.rb
+++ b/app/models/collected_pen.rb
@@ -80,8 +80,4 @@ class CollectedPen < ApplicationRecord
   def color=(value)
     super(value.strip)
   end
-
-  def deletable?
-    currently_inkeds.empty?
-  end
 end

--- a/app/serializable/serializable_collected_ink.rb
+++ b/app/serializable/serializable_collected_ink.rb
@@ -8,9 +8,6 @@ class SerializableCollectedInk < JSONAPI::Serializable::Resource
   attribute :brand_name
   attribute :color
   attribute :comment
-  attribute :deletable do
-    @object.deletable?
-  end
   attribute :ink_id do
     @object.micro_cluster&.macro_cluster_id
   end

--- a/app/serializers/collected_ink_serializer.rb
+++ b/app/serializers/collected_ink_serializer.rb
@@ -23,9 +23,6 @@ class CollectedInkSerializer
   attribute :archived do |object|
     object.archived?
   end
-  attribute :deletable do |object|
-    object.deletable?
-  end
   attribute :ink_id do |object|
     object.micro_cluster&.macro_cluster_id
   end

--- a/app/views/collected_pens_archive/_table.html.slim
+++ b/app/views/collected_pens_archive/_table.html.slim
@@ -26,9 +26,6 @@ div class="pen-collection"
                 = fa_icon("pencil")
               = link_to unarchive_collected_pens_archive_path(cp), class: "btn btn-secondary", method: :post, title: "Unarchive #{cp.name}" do
                 = fa_icon("folder-open")
-              - if cp.deletable?
-                = link_to collected_pens_archive_path(cp), class: "btn btn-danger", method: :delete, data: { confirm: "Really delete #{cp.name}" }, title: "Delete #{cp.name}"
-                  = fa_icon("trash")
       tfoot
         tr
           th

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
   end
 
   resources :reading_statuses, only: [:update]
-  resources :collected_inks, only: %i[index destroy edit update new create] do
+  resources :collected_inks, only: %i[index edit update new create] do
     collection { get "import" }
     member do
       post "archive"
@@ -25,11 +25,11 @@ Rails.application.routes.draw do
     resources :add, only: [:create]
   end
 
-  resources :collected_pens do
+  resources :collected_pens, only: %i[index edit update new create] do
     collection { get "import" }
     member { post "archive" }
   end
-  resources :collected_pens_archive, only: %i[index edit update destroy] do
+  resources :collected_pens_archive, only: %i[index edit update] do
     member { post "unarchive" }
   end
   resources :currently_inked do

--- a/spec/controllers/collected_inks_controller_spec.rb
+++ b/spec/controllers/collected_inks_controller_spec.rb
@@ -147,42 +147,6 @@ describe CollectedInksController do
     end
   end
 
-  describe "#destroy" do
-    it "requires authentication" do
-      delete :destroy, params: { id: 1 }
-      expect(response).to redirect_to(new_user_session_path)
-    end
-
-    context "signed in" do
-      before { sign_in(user) }
-
-      it "deletes the collected ink" do
-        ink = create(:collected_ink, user: user)
-        expect do
-          delete :destroy, params: { id: ink.id }
-          expect(response).to redirect_to(collected_inks_path)
-        end.to change { user.collected_inks.count }.by(-1)
-      end
-
-      it "does not delete inks from other users" do
-        ink = create(:collected_ink)
-        expect do
-          expect do delete :destroy, params: { id: ink.id } end.to raise_error(
-            ActiveRecord::RecordNotFound
-          )
-        end.to_not change { user.collected_inks.count }
-      end
-
-      it "does not delete inks that have currently inkeds" do
-        ink = create(:collected_ink, user: user, currently_inked_count: 1)
-        expect do
-          delete :destroy, params: { id: ink.id }
-          expect(response).to redirect_to(collected_inks_path)
-        end.to_not change { user.collected_inks.count }
-      end
-    end
-  end
-
   describe "#archive" do
     it "requires authentication" do
       post :archive, params: { id: 1 }

--- a/spec/controllers/collected_pens_controller_spec.rb
+++ b/spec/controllers/collected_pens_controller_spec.rb
@@ -171,31 +171,4 @@ describe CollectedPensController do
       end
     end
   end
-
-  describe "#destroy" do
-    it "requires authentication" do
-      expect do
-        delete :destroy, params: { id: wing_sung.id }
-        expect(response).to redirect_to(new_user_session_path)
-      end.to_not change { CollectedPen.count }
-    end
-
-    describe "signed in" do
-      before(:each) { sign_in(user) }
-
-      it "deletes the collected pen" do
-        expect do
-          delete :destroy, params: { id: wing_sung.id }
-          expect(response).to redirect_to(collected_pens_path)
-        end.to change { CollectedPen.count }.by(-1)
-      end
-
-      it "does not delete other users pens" do
-        expect do
-          delete :destroy, params: { id: platinum.id }
-          expect(response).to redirect_to(collected_pens_path)
-        end.to_not change { CollectedPen.count }
-      end
-    end
-  end
 end

--- a/spec/requests/accounts_controller_spec.rb
+++ b/spec/requests/accounts_controller_spec.rb
@@ -60,7 +60,6 @@ describe AccountsController do
                 "color" => ink.color,
                 "comment" => ink.comment,
                 "daily_usage" => 0,
-                "deletable" => true,
                 "ink_id" => nil,
                 "ink_name" => ink.ink_name,
                 "kind" => ink.kind,

--- a/spec/requests/collected_pens_archive_controller_spec.rb
+++ b/spec/requests/collected_pens_archive_controller_spec.rb
@@ -129,35 +129,4 @@ describe CollectedPensArchiveController do
       end
     end
   end
-
-  describe "#destroy" do
-    let!(:collected_pen) do
-      create(:collected_pen, user: user, archived_on: Date.today)
-    end
-
-    it "requires authentication" do
-      delete "/collected_pens_archive/#{collected_pen.id}"
-      expect(response).to redirect_to(new_user_session_path)
-    end
-
-    context "signed in" do
-      before(:each) { sign_in(user) }
-
-      it "correctly deletes the pen" do
-        expect do
-          delete "/collected_pens_archive/#{collected_pen.id}"
-        end.to change { user.collected_pens.count }.by(-1)
-        expect(response).to redirect_to(collected_pens_archive_index_path)
-      end
-
-      it "does not delete pens from other users" do
-        pen = create(:collected_pen, archived_on: Date.today)
-        expect do
-          expect do
-            delete "/collected_pens_archive/#{pen.id}"
-          end.to raise_error(ActiveRecord::RecordNotFound)
-        end.to_not change { CollectedPen.count }
-      end
-    end
-  end
 end


### PR DESCRIPTION
The distinction between archiving and deleting an ink is super confusing to anyone who isn't a programmer, it seems. Mainly, because the deletion only works when the pen or ink hasn't been used for a currently inked entry. Now, you can only archive pens and inks and be content with that. ;)

Fixes #1381