### PR TITLE
Quick fix for dark mode

### DIFF
--- a/app/javascript/stylesheets/fpc/_global.scss
+++ b/app/javascript/stylesheets/fpc/_global.scss
@@ -182,9 +182,14 @@
     }
   }
 
+  .card-title,
+  .card-body .table {
+    color: black !important;
+  }
+
   .table {
-    --bs-table-color: var(--fpc-text-color);
-    --bs-table-striped-color: var(--fpc-text-color);
+    --bs-table-color: white !important;
+    --bs-table-striped-color: white !important;
     --bs-table-striped-bg: var(--fpc-bright-background);
 
     // For "manual stripes" for instance like in brand clusters


### PR DESCRIPTION
This is not great (you can tell by the usage of `!important` 😉), but at least the text now shows up again. It might make sense to go back and figure out why the previous version didn't work as expected.

First step towards fixing #1414