### PR TITLE
Don't import all of bootstrap in cards.scss

### DIFF
--- a/app/javascript/src/collected_inks/cards/cards.scss
+++ b/app/javascript/src/collected_inks/cards/cards.scss
@@ -1,8 +1,6 @@
-@use "~bootstrap/scss/bootstrap" as b;
-
 .fpc-ink-cards {
   display: grid;
-  gap: b.$spacer;
+  gap: 1rem;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   grid-template-rows: masonry;
 }

--- a/app/javascript/stylesheets/fpc/_global.scss
+++ b/app/javascript/stylesheets/fpc/_global.scss
@@ -182,14 +182,9 @@
     }
   }
 
-  .card-title,
-  .card-body .table {
-    color: black !important;
-  }
-
   .table {
-    --bs-table-color: white !important;
-    --bs-table-striped-color: white !important;
+    --bs-table-color: var(--fpc-text-color);
+    --bs-table-striped-color: var(--fpc-text-color);
     --bs-table-striped-bg: var(--fpc-bright-background);
 
     // For "manual stripes" for instance like in brand clusters


### PR DESCRIPTION
We end up with Bootstrap imported twice, and the source order messes up dark mode colors in a few places.

Fixes #1414