### PR TITLE
Fix background color on ink cards in dark mode

### DIFF
--- a/app/javascript/src/collected_inks/cards/swab-card.scss
+++ b/app/javascript/src/collected_inks/cards/swab-card.scss
@@ -2,6 +2,7 @@
   margin-block: 15px;
   display: flex;
   flex-direction: column;
+  background: var(--fpc-bright-background);
 
   .fpc-swab-card__swab {
     margin-inline: auto;


### PR DESCRIPTION
Forgot to use the background-color CSS variable for dark mode support.

Didn't find anything else in my testing of the public and admin pages.

Fixes #1414 (for real this time 😄 )