### PR TITLE
Use same ink color cell as collected inks

### DIFF
--- a/app/views/brands/show.html.slim
+++ b/app/views/brands/show.html.slim
@@ -23,7 +23,8 @@ div class="fpc-table fpc-table--full-width fpc-inks-table fpc-scroll-shadow"
           td= ink.collected_inks_count
           td= ink.brand_name
           td= ink.line_name
-          td style="background-color:#{ink.color};width: 37px;"
+          td
+            div style="background-color:#{ink.color};width:45px;height:45px;"
           td= ink.ink_name
           td= link_to "Details", brand_ink_url(@brand, ink)
           - if user_signed_in?

--- a/app/views/inks/index.html.slim
+++ b/app/views/inks/index.html.slim
@@ -2,7 +2,7 @@
 
 = render partial: 'inks/search'
 
-div class="fpc-table fpc-table--full-width fpc-scroll-shadow"
+div class="fpc-table fpc-table--full-width fpc-inks-table fpc-scroll-shadow"
   table class="table table-striped"
     thead
       tr

--- a/app/views/inks/index.html.slim
+++ b/app/views/inks/index.html.slim
@@ -17,7 +17,8 @@ div class="fpc-table fpc-table--full-width fpc-scroll-shadow"
         tr
           td= ink.brand_name
           td= ink.line_name
-          td style="background-color:#{ink.color};width: 37px;"
+          td
+            div style="background-color:#{ink.color};width:45px;height:45px;"
           td= ink.ink_name
           td
             - if ink.brand_cluster.present?


### PR DESCRIPTION
Bootstrap apparently uses box shadow to fill in the colors of the striped
tables. This meant any background-color set on the table is overlaid with
the box-shadow color. This was a bit unexpected. The collected inks table
was unaffected by this since it set the background color on a div inside
the cell, rather than the cell itself. Let's do the same in these tables
as well. Bonus: with the same ink color size as collected inks, there's
no longer a layout shift when the Add to collection buttons load.

Fixes #1425