### PR TITLE
Allow duplicate inks, but add comment

### DIFF
--- a/spec/models/collected_ink_spec.rb
+++ b/spec/models/collected_ink_spec.rb
@@ -31,55 +31,79 @@ describe CollectedInk do
     end
   end
 
-  describe "uniqueness" do
-    let(:existing_ink) { create(:collected_ink, ink_name: "Syrah") }
+  describe "comment" do
+    let(:existing_ink) do
+      create(:collected_ink, kind: "bottle", ink_name: "Syrah")
+    end
 
-    it "is not allowed to create a duplicate collected ink for the same user" do
+    it "adds a comment for the new ink" do
       new_ink =
-        CollectedInk.new(
+        CollectedInk.create!(
           user_id: existing_ink.user_id,
           brand_name: existing_ink.brand_name,
           line_name: existing_ink.line_name,
           ink_name: existing_ink.ink_name,
           kind: existing_ink.kind
         )
-      expect(new_ink).to_not be_valid
+      expect(new_ink.comment).to eq("Bottle no. 2")
     end
 
-    it "is allowed to have the same ink with a different kind" do
-      existing_ink.update!(kind: "bottle")
+    it "does not add a comment for another kind" do
       new_ink =
-        CollectedInk.new(
+        CollectedInk.create!(
           user_id: existing_ink.user_id,
           brand_name: existing_ink.brand_name,
           line_name: existing_ink.line_name,
           ink_name: existing_ink.ink_name,
           kind: "sample"
         )
-      expect(new_ink).to be_valid
+      expect(new_ink.comment).to be_blank
     end
 
-    it "is allowed to create the same ink for another user" do
+    it "does not add a comment for a different user" do
       new_ink =
-        CollectedInk.new(
+        CollectedInk.create!(
           user_id: create(:user).id,
           brand_name: existing_ink.brand_name,
           line_name: existing_ink.line_name,
           ink_name: existing_ink.ink_name
         )
-      expect(new_ink).to be_valid
+      expect(new_ink.comment).to be_blank
     end
 
-    it "is not allowed to create a collected ink that only differs in case" do
+    it "adds a comment if the only difference is in the case" do
       new_ink =
-        CollectedInk.new(
+        CollectedInk.create!(
           user_id: existing_ink.user_id,
           brand_name: existing_ink.brand_name.upcase,
           line_name: existing_ink.line_name,
           ink_name: existing_ink.ink_name,
           kind: existing_ink.kind
         )
-      expect(new_ink).to_not be_valid
+      expect(new_ink.comment).to eq("Bottle no. 2")
+    end
+
+    it "adds a comment if the name gets changed to be a duplicate" do
+      new_ink = create(:collected_ink, user: existing_ink.user, comment: "")
+      new_ink.update!(
+        brand_name: existing_ink.brand_name,
+        line_name: existing_ink.line_name,
+        ink_name: existing_ink.ink_name
+      )
+      expect(new_ink.comment).to eq("Bottle no. 2")
+    end
+
+    it "does not add a comment if there is already a comment" do
+      new_ink =
+        CollectedInk.create!(
+          user_id: existing_ink.user_id,
+          brand_name: existing_ink.brand_name,
+          line_name: existing_ink.line_name,
+          ink_name: existing_ink.ink_name,
+          kind: existing_ink.kind,
+          comment: "existing comment"
+        )
+      expect(new_ink.comment).to eq("existing comment")
     end
   end
 

--- a/spec/requests/collected_inks/add_controller_spec.rb
+++ b/spec/requests/collected_inks/add_controller_spec.rb
@@ -25,12 +25,14 @@ describe CollectedInks::AddController do
         expect(ink.kind).to eq("bottle")
       end
 
-      it "only adds the ink once" do
+      it "adds the second ink with a comment" do
         expect do
           post "/collected_inks/add.json?macro_cluster_id=#{macro_cluster.id}&kind=bottle"
           post "/collected_inks/add.json?macro_cluster_id=#{macro_cluster.id}&kind=bottle"
           expect(response).to have_http_status(:created)
-        end.to change { user.collected_inks.count }.by(1)
+        end.to change { user.collected_inks.count }.by(2)
+        ink = CollectedInk.last
+        expect(ink.comment).to be_present
       end
     end
   end


### PR DESCRIPTION
Many people have asked why they couldn't add an ink. It turned out that they already had it in the system somewhere (possibly the archive). Now you can add as many as you want, but we will generate a comment to distinguish the entries (if there isn't one already).

Fixes #102, #1345