### PR TITLE
Let users configure visible fields in the inks table

### DIFF
--- a/app/javascript/src/collected_inks/CollectedInks.jsx
+++ b/app/javascript/src/collected_inks/CollectedInks.jsx
@@ -1,0 +1,75 @@
+import React, { useCallback, useState, useEffect, useMemo } from "react";
+import Jsona from "jsona";
+import { getRequest } from "../fetch";
+import { useScreen } from "../useScreen";
+import * as storage from "../localStorage";
+import { CollectedInksCards, CollectedInksCardsPlaceholder } from "./cards";
+import { CollectedInksTable, CollectedInksTablePlaceholder } from "./table";
+
+const formatter = new Jsona();
+
+export const storageKeyLayout = "fpc-collected-inks-layout";
+
+/**
+ * @param {{ archive: boolean }} props
+ */
+export const CollectedInks = ({ archive }) => {
+  const [inks, setInks] = useState();
+
+  useEffect(() => {
+    async function getCollectedInks() {
+      const response = await getRequest("/collected_inks.json");
+      const json = await response.json();
+      const inks = formatter.deserialize(json);
+      // let mountainOfInks = [];
+      // while (mountainOfInks.length < 5000) {
+      //   mountainOfInks = mountainOfInks.concat(inks);
+      // }
+      setInks(inks);
+    }
+    getCollectedInks();
+  }, []);
+
+  const visibleInks = useMemo(
+    () => (inks ? inks.filter((i) => i.archived == archive) : []),
+    [inks, archive]
+  );
+
+  const screen = useScreen();
+
+  const [layout, setLayout] = useState(storage.getItem(storageKeyLayout));
+  const onLayoutChange = useCallback(
+    (e) => {
+      const nextLayout = e.target.value;
+      setLayout(nextLayout);
+      storage.setItem(storageKeyLayout, nextLayout);
+    },
+    [setLayout]
+  );
+
+  if (layout ? layout === "card" : screen.isSmall) {
+    if (inks) {
+      return (
+        <CollectedInksCards
+          data={visibleInks}
+          archive={archive}
+          onLayoutChange={onLayoutChange}
+        />
+      );
+    } else {
+      return <CollectedInksCardsPlaceholder />;
+    }
+  } else {
+    if (inks) {
+      return (
+        <CollectedInksTable
+          data={visibleInks}
+          archive={archive}
+          onLayoutChange={onLayoutChange}
+        />
+      );
+    } else {
+      return <CollectedInksTablePlaceholder />;
+    }
+  }
+};

--- a/app/javascript/src/collected_inks/CollectedInks.spec.jsx
+++ b/app/javascript/src/collected_inks/CollectedInks.spec.jsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CollectedInks, storageKeyLayout } from "./CollectedInks";
+
+const setup = (jsx, options) => {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx, options)
+  };
+};
+
+describe("<CollectedInks />", () => {
+  const server = setupServer(
+    rest.get("/collected_inks.json", (req, res, ctx) =>
+      res(
+        ctx.json({
+          data: [
+            {
+              id: "4",
+              type: "collected_ink",
+              attributes: {
+                brand_name: "Sailor",
+                line_name: "Shikiori",
+                ink_name: "Yozakura",
+                maker: "Sailor",
+                color: "#ac54b5",
+                archived_on: null,
+                comment:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                kind: "bottle",
+                private: false,
+                private_comment:
+                  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                simplified_brand_name: "sailor",
+                simplified_ink_name: "yozakura",
+                simplified_line_name: "shikiori",
+                swabbed: true,
+                used: true,
+                archived: false,
+                ink_id: 3,
+                usage: 2,
+                daily_usage: 1
+              },
+              relationships: {
+                micro_cluster: { data: { id: "3", type: "micro_cluster" } },
+                tags: {
+                  data: [
+                    { id: "1", type: "tag" },
+                    { id: "2", type: "tag" }
+                  ]
+                },
+                currently_inkeds: {
+                  data: [
+                    { id: "1", type: "currently_inked" },
+                    { id: "3", type: "currently_inked" }
+                  ]
+                }
+              }
+            },
+            {
+              id: "11",
+              type: "collected_ink",
+              attributes: {
+                brand_name: "DeAtramentis",
+                line_name: "Document",
+                ink_name: "Black",
+                maker: "",
+                color: "#120e0e",
+                archived_on: "2023-02-18",
+                comment: "",
+                kind: "",
+                private: false,
+                private_comment: "",
+                simplified_brand_name: "deatramentis",
+                simplified_ink_name: "black",
+                simplified_line_name: "document",
+                swabbed: false,
+                used: false,
+                archived: true,
+                ink_id: 49,
+                usage: 0,
+                daily_usage: 0
+              },
+              relationships: {
+                micro_cluster: { data: { id: "8", type: "micro_cluster" } },
+                tags: { data: [] },
+                currently_inkeds: { data: [] }
+              }
+            }
+          ],
+          included: [
+            { id: "1", type: "tag", attributes: { name: "maximum" } },
+            { id: "2", type: "tag", attributes: { name: "taggage" } }
+          ]
+        })
+      )
+    )
+  );
+
+  beforeAll(() => {
+    localStorage.clear();
+    server.listen();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    server.resetHandlers();
+  });
+
+  afterAll(() => server.close());
+
+  it("renders the app", async () => {
+    const { findByText, queryByText } = setup(
+      <CollectedInks archive={false} />
+    );
+
+    const result = await findByText("Yozakura");
+
+    expect(result).toBeTruthy();
+    // Does not show archived when archive=false
+    expect(queryByText("DeAtramentis")).not.toBeInTheDocument();
+  });
+
+  it("swaps to card layout when clicked", async () => {
+    const { findByText, getByTitle, queryByText, user } = setup(
+      <CollectedInks archive={false} />
+    );
+
+    await findByText("Yozakura");
+    const cardLayoutButton = getByTitle("Card layout");
+    await user.click(cardLayoutButton);
+
+    // Mock response data from Yozakura, formated as in a card
+    expect(queryByText("2 inked (1 daily usages)")).toBeInTheDocument();
+  });
+
+  it("remembers layout from localStorage", async () => {
+    localStorage.setItem(storageKeyLayout, "card");
+
+    const { findByText, queryByText } = setup(
+      <CollectedInks archive={false} />
+    );
+
+    await findByText("Sailor Shikiori Yozakura");
+
+    // Mock response data from Yozakura, formated as in a card
+    expect(queryByText("2 inked (1 daily usages)")).toBeInTheDocument();
+  });
+
+  it("renders the archive", async () => {
+    const { findByText, queryByText } = setup(<CollectedInks archive={true} />);
+
+    const result = await findByText("DeAtramentis");
+
+    expect(result).toBeTruthy();
+    // Does not show unarchived when archive=true
+    expect(queryByText("Yozakura")).not.toBeInTheDocument();
+  });
+});

--- a/app/javascript/src/collected_inks/cards/Cards.jsx
+++ b/app/javascript/src/collected_inks/cards/Cards.jsx
@@ -2,11 +2,11 @@ import React from "react";
 import { SwabCard } from "./SwabCard";
 import "./cards.scss";
 
-export const Cards = ({ data }) => {
+export const Cards = ({ data, hiddenFields }) => {
   return (
     <div className="fpc-ink-cards">
       {data.map((row, i) => (
-        <SwabCard key={row.id + "i" + i} {...row} />
+        <SwabCard key={row.id + "i" + i} hiddenFields={hiddenFields} {...row} />
       ))}
     </div>
   );

--- a/app/javascript/src/collected_inks/cards/CollectedInksCards.jsx
+++ b/app/javascript/src/collected_inks/cards/CollectedInksCards.jsx
@@ -1,11 +1,44 @@
-import React, { useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
+import * as storage from "../../localStorage";
 import { Actions } from "../components";
 import { Cards } from "./Cards";
 import { fuzzyMatch } from "./match";
 
+export const storageKeyHiddenFields = "fpc-collected-inks-cards-hidden-fields";
+
 export const CollectedInksCards = ({ data, archive, onLayoutChange }) => {
   const [matchOn, setMatchOn] = useState("");
   const visible = fuzzyMatch(data, matchOn);
+
+  const [hiddenFields, setHiddenFields] = useState([]);
+
+  useEffect(() => {
+    const fromLocalStorage = JSON.parse(
+      storage.getItem(storageKeyHiddenFields)
+    );
+    if (fromLocalStorage) {
+      setHiddenFields(fromLocalStorage);
+      return;
+    }
+
+    setHiddenFields([]);
+  }, [setHiddenFields]);
+
+  const onHiddenFieldsChange = useCallback(
+    (nextHiddenFields) => {
+      if (nextHiddenFields === null) {
+        storage.removeItem(storageKeyHiddenFields);
+
+        setHiddenFields([]);
+
+        return;
+      }
+
+      setHiddenFields(nextHiddenFields);
+      storage.setItem(storageKeyHiddenFields, JSON.stringify(nextHiddenFields));
+    },
+    [setHiddenFields]
+  );
 
   return (
     <div>
@@ -15,8 +48,10 @@ export const CollectedInksCards = ({ data, archive, onLayoutChange }) => {
         numberOfInks={data.length}
         onFilterChange={setMatchOn}
         onLayoutChange={onLayoutChange}
+        hiddenFields={hiddenFields}
+        onHiddenFieldsChange={onHiddenFieldsChange}
       />
-      <Cards data={visible} />
+      <Cards data={visible} hiddenFields={hiddenFields} />
     </div>
   );
 };

--- a/app/javascript/src/collected_inks/cards/CollectedInksCards.spec.jsx
+++ b/app/javascript/src/collected_inks/cards/CollectedInksCards.spec.jsx
@@ -1,0 +1,128 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  CollectedInksCards,
+  storageKeyHiddenFields
+} from "./CollectedInksCards";
+
+const setup = (jsx, options) => {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx, options)
+  };
+};
+
+describe("<CollectedInksCards />", () => {
+  const data = [
+    {
+      id: "4",
+      brand_name: "Sailor",
+      line_name: "Shikiori",
+      ink_name: "Yozakura",
+      maker: "Sailor",
+      color: "#ac54b5",
+      archived_on: null,
+      comment:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+      kind: "bottle",
+      private: false,
+      private_comment:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+      simplified_brand_name: "sailor",
+      simplified_ink_name: "yozakura",
+      simplified_line_name: "shikiori",
+      swabbed: true,
+      used: true,
+      archived: false,
+      ink_id: 3,
+      usage: 2,
+      daily_usage: 1,
+      tags: [
+        { id: "1", type: "tag", name: "maximum" },
+        { id: "2", type: "tag", name: "taggage" }
+      ]
+    }
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders", async () => {
+    const { findByText } = setup(
+      <CollectedInksCards
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    const result = await findByText("Sailor Shikiori Yozakura");
+
+    expect(result).toBeInTheDocument();
+  });
+
+  it("updates hidden fields when clicked", async () => {
+    const { getByTitle, getByLabelText, queryByText, user } = setup(
+      <CollectedInksCards
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    expect(queryByText("2 inked (1 daily usages)")).toBeInTheDocument();
+
+    await user.click(getByTitle("Configure visible fields"));
+    await user.click(getByLabelText("Show usage"));
+    await user.click(getByLabelText("Show daily usage"));
+
+    expect(queryByText("2 inked (1 daily usages)")).not.toBeInTheDocument();
+  });
+
+  it("resets hidden fields when restore defaults is clicked", async () => {
+    const { getByText, getByTitle, getByLabelText, queryByText, user } = setup(
+      <CollectedInksCards
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    await user.click(getByTitle("Configure visible fields"));
+    await user.click(getByLabelText("Show usage"));
+    await user.click(getByLabelText("Show daily usage"));
+
+    expect(queryByText("2 inked (1 daily usages)")).not.toBeInTheDocument();
+
+    await user.click(getByText("Restore defaults"));
+
+    expect(queryByText("2 inked (1 daily usages)")).toBeInTheDocument();
+  });
+
+  it("renders with hidden fields restored from localStorage", () => {
+    localStorage.setItem(
+      storageKeyHiddenFields,
+      JSON.stringify(["usage", "daily_usage"])
+    );
+
+    const { queryByText } = setup(
+      <CollectedInksCards
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    expect(queryByText("2 inked (1 daily usages)")).not.toBeInTheDocument();
+  });
+});

--- a/app/javascript/src/collected_inks/cards/CollectedInksCardsPlaceholder.spec.jsx
+++ b/app/javascript/src/collected_inks/cards/CollectedInksCardsPlaceholder.spec.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { CollectedInksCardsPlaceholder } from "./CollectedInksCardsPlaceholder";
+
+describe("<CollectedInksCardsPlaceholder />", () => {
+  it("renders", async () => {
+    render(<CollectedInksCardsPlaceholder />);
+  });
+});

--- a/app/javascript/src/collected_inks/cards/SwabCard.jsx
+++ b/app/javascript/src/collected_inks/cards/SwabCard.jsx
@@ -5,6 +5,7 @@ import "./swab-card.scss";
 
 /**
  * @param {{
+ *    hiddenFields: string[];
  *    archived: boolean;
  *    id: string;
  *    ink_id?: string;
@@ -33,20 +34,20 @@ export const SwabCard = (props) => {
     maker,
     kind,
     color,
-    swabbed = false,
-    used = false,
     usage = 0,
     daily_usage = 0,
     comment,
     private_comment,
-    tags
+    tags,
+    hiddenFields
   } = props;
 
   const fullName = ["brand_name", "line_name", "ink_name"]
     .map((a) => props[a])
     .join(" ");
 
-  const hasUsage = usage || daily_usage;
+  const isVisible = (field) => props[field] && !hiddenFields.includes(field);
+  const hasUsage = isVisible("usage") || isVisible("daily_usage");
 
   return (
     <Card className="fpc-swab-card">
@@ -68,14 +69,14 @@ export const SwabCard = (props) => {
             </>
           ) : null}
         </Card.Title>
-        {comment ? <Card.Text>{comment}</Card.Text> : null}
-        {private_comment ? (
+        {isVisible("comment") ? <Card.Text>{comment}</Card.Text> : null}
+        {isVisible("private_comment") ? (
           <>
             <div className="small text-secondary">Private comment</div>
             <Card.Text>{private_comment}</Card.Text>
           </>
         ) : null}
-        {maker ? (
+        {isVisible("maker") ? (
           <>
             <div className="small text-secondary">Maker</div>
             <Card.Text>{maker}</Card.Text>
@@ -94,14 +95,16 @@ export const SwabCard = (props) => {
             {isPrivate ? (
               <span className="badge text-bg-info">Private</span>
             ) : null}
-            {swabbed ? (
+            {isVisible("swabbed") ? (
               <span className="badge text-bg-success">Swabbed</span>
             ) : null}
-            {used ? <span className="badge text-bg-success">Used</span> : null}
-            {kind ? (
+            {isVisible("used") ? (
+              <span className="badge text-bg-success">Used</span>
+            ) : null}
+            {isVisible("kind") ? (
               <span className="badge text-bg-secondary">{kind}</span>
             ) : null}
-            {Array.isArray(tags)
+            {isVisible("tags") && Array.isArray(tags)
               ? tags.map(({ id, name }) => (
                   <span
                     key={`ink-tag-${id}`}

--- a/app/javascript/src/collected_inks/cards/SwabCard.spec.jsx
+++ b/app/javascript/src/collected_inks/cards/SwabCard.spec.jsx
@@ -20,6 +20,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         ink_name="Blue"
         private={true}
+        hiddenFields={[]}
       />
     );
 
@@ -28,7 +29,13 @@ describe("<SwabCard />", () => {
 
   it("renders no Private-badge if public", () => {
     const { queryByText } = setup(
-      <SwabCard id="1" archived={false} brand_name="Pilot" ink_name="Black" />
+      <SwabCard
+        id="1"
+        archived={false}
+        brand_name="Pilot"
+        ink_name="Black"
+        hiddenFields={[]}
+      />
     );
 
     expect(queryByText("Private")).not.toBeInTheDocument();
@@ -42,6 +49,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         ink_name="Blue"
         swabbed={true}
+        hiddenFields={[]}
       />
     );
 
@@ -50,7 +58,13 @@ describe("<SwabCard />", () => {
 
   it("renders no Swabbed-badge if not swabbed", () => {
     const { queryByText } = setup(
-      <SwabCard id="1" archived={false} brand_name="Pilot" ink_name="Black" />
+      <SwabCard
+        id="1"
+        archived={false}
+        brand_name="Pilot"
+        ink_name="Black"
+        hiddenFields={[]}
+      />
     );
 
     expect(queryByText("Swabbed")).not.toBeInTheDocument();
@@ -64,6 +78,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         ink_name="Blue"
         used={true}
+        hiddenFields={[]}
       />
     );
 
@@ -72,7 +87,13 @@ describe("<SwabCard />", () => {
 
   it("renders no Used-badge if unused", () => {
     const { queryByText } = setup(
-      <SwabCard id="1" archived={false} brand_name="Pilot" ink_name="Black" />
+      <SwabCard
+        id="1"
+        archived={false}
+        brand_name="Pilot"
+        ink_name="Black"
+        hiddenFields={[]}
+      />
     );
 
     expect(queryByText("Used")).not.toBeInTheDocument();
@@ -87,6 +108,7 @@ describe("<SwabCard />", () => {
         ink_name="Blue"
         kind="bottle"
         used={true}
+        hiddenFields={[]}
       />
     );
 
@@ -95,7 +117,13 @@ describe("<SwabCard />", () => {
 
   it("doesn't render the kind-badge if not set", () => {
     const { queryByText } = setup(
-      <SwabCard id="1" archived={false} brand_name="Pilot" ink_name="Black" />
+      <SwabCard
+        id="1"
+        archived={false}
+        brand_name="Pilot"
+        ink_name="Black"
+        hiddenFields={[]}
+      />
     );
 
     expect(queryByText("bottle")).not.toBeInTheDocument();
@@ -116,6 +144,7 @@ describe("<SwabCard />", () => {
           { id: "2", name: "bespoke" },
           { id: "3", name: "personal" }
         ]}
+        hiddenFields={[]}
       />
     );
 
@@ -133,6 +162,7 @@ describe("<SwabCard />", () => {
         archived={false}
         brand_name="Pilot"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -151,6 +181,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         maker="Pilot"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -166,6 +197,7 @@ describe("<SwabCard />", () => {
         archived={false}
         brand_name="Pilot"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -182,6 +214,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         comment="This is a comment"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -199,6 +232,7 @@ describe("<SwabCard />", () => {
         daily_usage={10}
         usage={1}
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -215,6 +249,7 @@ describe("<SwabCard />", () => {
         archived={false}
         brand_name="Pilot"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -231,6 +266,7 @@ describe("<SwabCard />", () => {
         brand_name="Pilot"
         private_comment="Secret"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
@@ -247,9 +283,55 @@ describe("<SwabCard />", () => {
         archived={false}
         brand_name="Pilot"
         ink_name="Black"
+        hiddenFields={[]}
       />
     );
 
     expect(queryByText("Maker")).not.toBeInTheDocument();
+  });
+
+  it("hides as expected if given hidden fields", () => {
+    const { queryByText } = setup(
+      <SwabCard
+        id="1"
+        ink_id="1"
+        color="#000"
+        archived={false}
+        brand_name="Pilot"
+        ink_name="Black"
+        kind="bottle"
+        maker="Maker"
+        comment="Public"
+        private_comment="Secret"
+        tags={[
+          { id: "1", name: "custom" },
+          { id: "2", name: "bespoke" },
+          { id: "3", name: "personal" }
+        ]}
+        used={true}
+        swabbed={true}
+        hiddenFields={[
+          "maker",
+          "kind",
+          "usage",
+          "used",
+          "swabbed",
+          "comment",
+          "private_comment",
+          "tags"
+        ]}
+      />
+    );
+
+    expect(queryByText("Maker")).not.toBeInTheDocument();
+    expect(queryByText("Secret")).not.toBeInTheDocument();
+    expect(queryByText("Maker")).not.toBeInTheDocument();
+    expect(queryByText("Public")).not.toBeInTheDocument();
+    expect(queryByText("custom")).not.toBeInTheDocument();
+    expect(queryByText("bespoke")).not.toBeInTheDocument();
+    expect(queryByText("personal")).not.toBeInTheDocument();
+    expect(queryByText("bottle")).not.toBeInTheDocument();
+    expect(queryByText("Used")).not.toBeInTheDocument();
+    expect(queryByText("Swabbed")).not.toBeInTheDocument();
   });
 });

--- a/app/javascript/src/collected_inks/components/Actions.jsx
+++ b/app/javascript/src/collected_inks/components/Actions.jsx
@@ -2,14 +2,17 @@ import _ from "lodash";
 import React, { useCallback, useState } from "react";
 import { LayoutToggle } from "../../components";
 import "./actions.scss";
+import { Switch } from "./Switch";
 
 /**
- * @param {{ archive: boolean; activeLayout: "card" | "table"; numberOfInks: number; onFilterChange: (val: string | undefined) => void; onLayoutChange: (e: import('react').ChangeEvent) => void; }} props
+ * @param {{ archive: boolean; activeLayout: "card" | "table"; numberOfInks: number; hiddenFields: string[]; onHiddenFieldsChange: (newValues: string[]) => void; onFilterChange: (val: string | undefined) => void; onLayoutChange: (e: import('react').ChangeEvent) => void; }} props
  */
 export const Actions = ({
   archive,
   activeLayout,
   numberOfInks,
+  hiddenFields,
+  onHiddenFieldsChange,
   onFilterChange,
   onLayoutChange
 }) => {
@@ -25,10 +28,115 @@ export const Actions = ({
     [onFilterChange, numberOfInks]
   );
 
+  const isSwitchedOn = useCallback(
+    (field) => !hiddenFields.includes(field),
+    [hiddenFields]
+  );
+
+  const onSwitchChange = useCallback(
+    (checked, field) => {
+      if (checked) {
+        const newHiddenFields = hiddenFields.filter((f) => f !== field);
+        onHiddenFieldsChange(newHiddenFields);
+      } else {
+        const newHiddenFields = [...hiddenFields, field];
+        onHiddenFieldsChange(newHiddenFields);
+      }
+    },
+    [hiddenFields, onHiddenFieldsChange]
+  );
+
   return (
     <div>
       <div className="fpc-inks-actions">
         <LayoutToggle activeLayout={activeLayout} onChange={onLayoutChange} />
+        <div className="dropdown">
+          <button
+            type="button"
+            title="Configure visible fields"
+            className="btn btn-sm btn-outline-secondary dropdown-toggle"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+            data-bs-auto-close="outside"
+          >
+            <i className="fa fa-cog"></i>
+          </button>
+          <form className="dropdown-menu p-4">
+            <div className="mb-2">
+              <Switch
+                checked={isSwitchedOn("private")}
+                onChange={(e) => onSwitchChange(e.target.checked, "private")}
+              >
+                Show&nbsp;private
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("maker")}
+                onChange={(e) => onSwitchChange(e.target.checked, "maker")}
+              >
+                Show&nbsp;maker
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("kind")}
+                onChange={(e) => onSwitchChange(e.target.checked, "kind")}
+              >
+                Show&nbsp;type
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("swabbed")}
+                onChange={(e) => onSwitchChange(e.target.checked, "swabbed")}
+              >
+                Show&nbsp;swabbed
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("used")}
+                onChange={(e) => onSwitchChange(e.target.checked, "used")}
+              >
+                Show&nbsp;used
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("usage")}
+                onChange={(e) => onSwitchChange(e.target.checked, "usage")}
+              >
+                Show&nbsp;usage
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("daily_usage")}
+                onChange={(e) =>
+                  onSwitchChange(e.target.checked, "daily_usage")
+                }
+              >
+                Show&nbsp;daily&nbsp;usage
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("comment")}
+                onChange={(e) => onSwitchChange(e.target.checked, "comment")}
+              >
+                Show&nbsp;comment
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("private_comment")}
+                onChange={(e) =>
+                  onSwitchChange(e.target.checked, "private_comment")
+                }
+              >
+                Show&nbsp;private&nbsp;comment
+              </Switch>
+              <Switch
+                checked={isSwitchedOn("tags")}
+                onChange={(e) => onSwitchChange(e.target.checked, "tags")}
+              >
+                Show&nbsp;tags
+              </Switch>
+            </div>
+            <button
+              type="button"
+              className="btn btn-sm btn-link p-0 mt-2"
+              onClick={() => onHiddenFieldsChange(null)}
+            >
+              Restore defaults
+            </button>
+          </form>
+        </div>
       </div>
       <div className="d-flex flex-wrap justify-content-end align-items-center mb-3">
         {!archive && (

--- a/app/javascript/src/collected_inks/components/Actions.spec.jsx
+++ b/app/javascript/src/collected_inks/components/Actions.spec.jsx
@@ -18,6 +18,10 @@ describe("<Actions />", () => {
         archive={false}
         activeLayout="table"
         numberOfInks={0}
+        hiddenFields={[]}
+        onHiddenFieldsChange={() => {
+          return;
+        }}
         onFilterChange={() => {
           return;
         }}
@@ -43,6 +47,10 @@ describe("<Actions />", () => {
         archive={true}
         activeLayout="card"
         numberOfInks={0}
+        hiddenFields={[]}
+        onHiddenFieldsChange={() => {
+          return;
+        }}
         onFilterChange={() => {
           return;
         }}
@@ -64,6 +72,10 @@ describe("<Actions />", () => {
         archive={true}
         activeLayout="table"
         numberOfInks={0}
+        hiddenFields={[]}
+        onHiddenFieldsChange={() => {
+          return;
+        }}
         onFilterChange={onFilterChange}
         onLayoutChange={() => {
           return;
@@ -75,5 +87,108 @@ describe("<Actions />", () => {
     await user.type(input, "p");
 
     expect(onFilterChange).toHaveBeenCalledWith("p");
+  });
+
+  it("calls onFilterChange with undefined when emptied", async () => {
+    const onFilterChange = jest.fn();
+    const { user, getByRole } = setup(
+      <Actions
+        archive={true}
+        activeLayout="table"
+        numberOfInks={0}
+        hiddenFields={[]}
+        onHiddenFieldsChange={() => {
+          return;
+        }}
+        onFilterChange={onFilterChange}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    const input = getByRole("textbox");
+    await user.type(input, "p");
+
+    expect(onFilterChange).toHaveBeenCalledWith("p");
+
+    await user.type(input, "{backspace}");
+
+    expect(onFilterChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("calls onHiddenFieldsChange with expected result when turning switch on", async () => {
+    const onHiddenFieldsChange = jest.fn();
+    const { user, getByTitle, getByLabelText } = setup(
+      <Actions
+        archive={true}
+        activeLayout="table"
+        numberOfInks={0}
+        hiddenFields={[]}
+        onHiddenFieldsChange={onHiddenFieldsChange}
+        onFilterChange={() => {
+          return;
+        }}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    await user.click(getByTitle("Configure visible fields"));
+
+    await user.click(getByLabelText("Show private"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["private"]);
+
+    await user.click(getByLabelText("Show maker"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["maker"]);
+
+    await user.click(getByLabelText("Show type"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["kind"]);
+
+    await user.click(getByLabelText("Show swabbed"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["swabbed"]);
+
+    await user.click(getByLabelText("Show used"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["used"]);
+
+    await user.click(getByLabelText("Show usage"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["usage"]);
+
+    await user.click(getByLabelText("Show daily usage"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["daily_usage"]);
+
+    await user.click(getByLabelText("Show comment"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["comment"]);
+
+    await user.click(getByLabelText("Show private comment"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["private_comment"]);
+
+    await user.click(getByLabelText("Show tags"));
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith(["tags"]);
+  });
+
+  it("calls onHiddenFieldsChange with expected result when turning switch off", async () => {
+    const onHiddenFieldsChange = jest.fn();
+    const { user, getByTitle, getByLabelText } = setup(
+      <Actions
+        archive={true}
+        activeLayout="table"
+        numberOfInks={0}
+        hiddenFields={["private"]}
+        onHiddenFieldsChange={onHiddenFieldsChange}
+        onFilterChange={() => {
+          return;
+        }}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    await user.click(getByTitle("Configure visible fields"));
+    await user.click(getByLabelText("Show private"));
+
+    expect(onHiddenFieldsChange).toHaveBeenCalledWith([]);
   });
 });

--- a/app/javascript/src/collected_inks/components/Switch.jsx
+++ b/app/javascript/src/collected_inks/components/Switch.jsx
@@ -1,0 +1,25 @@
+import React, { useId } from "react";
+
+/**
+ * @see https://getbootstrap.com/docs/5.3/forms/checks-radios/#switches
+ * @param {{ checked: boolean; children: import("react").ReactNode; onChange: import("react").ChangeEventHandler<HTMLInputElement>; }} props
+ */
+export const Switch = ({ checked, children, onChange }) => {
+  const id = useId();
+
+  return (
+    <div className="form-check form-switch">
+      <input
+        type="checkbox"
+        role="switch"
+        className="form-check-input"
+        id={id}
+        checked={checked}
+        onChange={onChange}
+      />
+      <label className="form-check-label" htmlFor={id}>
+        {children}
+      </label>
+    </div>
+  );
+};

--- a/app/javascript/src/collected_inks/components/Switch.spec.jsx
+++ b/app/javascript/src/collected_inks/components/Switch.spec.jsx
@@ -1,0 +1,44 @@
+// @ts-check
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Switch } from "./Switch";
+
+const setup = (jsx, options) => {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx, options)
+  };
+};
+
+describe("<Switch />", () => {
+  it("calls onChange when clicked", async () => {
+    let checked = false;
+
+    const { user, getByRole } = setup(
+      <Switch checked={false} onChange={(e) => (checked = e.target.checked)}>
+        Comments
+      </Switch>
+    );
+
+    const input = getByRole("switch");
+    await user.click(input);
+
+    expect(checked).toBe(true);
+  });
+
+  it("returns expected value when starting checked", async () => {
+    let checked = true;
+
+    const { user, getByRole } = setup(
+      <Switch checked={true} onChange={(e) => (checked = e.target.checked)}>
+        Comments
+      </Switch>
+    );
+
+    const input = getByRole("switch");
+    await user.click(input);
+
+    expect(checked).toBe(false);
+  });
+});

--- a/app/javascript/src/collected_inks/components/actions.scss
+++ b/app/javascript/src/collected_inks/components/actions.scss
@@ -1,5 +1,7 @@
 .fpc-inks-actions {
   float: left;
+  display: flex;
+  gap: 4px;
 
   // This is when the search field starts being on the same line as the actions,
   // increasing height. Set margin-top to offset.

--- a/app/javascript/src/collected_inks/components/index.js
+++ b/app/javascript/src/collected_inks/components/index.js
@@ -1,3 +1,4 @@
 export * from "./Actions";
 export * from "./ArchiveButton";
 export * from "./EditButton";
+export * from "./Switch";

--- a/app/javascript/src/collected_inks/index.jsx
+++ b/app/javascript/src/collected_inks/index.jsx
@@ -1,11 +1,7 @@
-import React, { useCallback, useState, useEffect, useMemo } from "react";
+/* istanbul ignore file */
+import React from "react";
 import { createRoot } from "react-dom/client";
-import Jsona from "jsona";
-import { getRequest } from "../fetch";
-import { useScreen } from "../useScreen";
-import * as storage from "../localStorage";
-import { CollectedInksCards, CollectedInksCardsPlaceholder } from "./cards";
-import { CollectedInksTable, CollectedInksTablePlaceholder } from "./table";
+import { CollectedInks } from "./CollectedInks";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll("#collected-inks .app");
@@ -16,70 +12,3 @@ document.addEventListener("DOMContentLoaded", () => {
     );
   });
 });
-
-const formatter = new Jsona();
-
-/**
- * @param {{ archive: boolean }} props
- */
-const CollectedInks = ({ archive }) => {
-  const [inks, setInks] = useState();
-
-  useEffect(() => {
-    async function getCollectedInks() {
-      const response = await getRequest("/collected_inks.json");
-      const json = await response.json();
-      const inks = formatter.deserialize(json);
-      // let mountainOfInks = [];
-      // while (mountainOfInks.length < 5000) {
-      //   mountainOfInks = mountainOfInks.concat(inks);
-      // }
-      setInks(inks);
-    }
-    getCollectedInks();
-  }, []);
-
-  const visibleInks = useMemo(
-    () => (inks ? inks.filter((i) => i.archived == archive) : []),
-    [inks, archive]
-  );
-
-  const screen = useScreen();
-
-  const storageKey = "fpc-collected-inks-layout";
-  const [layout, setLayout] = useState(storage.getItem(storageKey));
-  const onLayoutChange = useCallback(
-    (e) => {
-      const nextLayout = e.target.value;
-      setLayout(nextLayout);
-      storage.setItem(storageKey, nextLayout);
-    },
-    [setLayout]
-  );
-
-  if (layout ? layout === "card" : screen.isSmall) {
-    if (inks) {
-      return (
-        <CollectedInksCards
-          data={visibleInks}
-          archive={archive}
-          onLayoutChange={onLayoutChange}
-        />
-      );
-    } else {
-      return <CollectedInksCardsPlaceholder />;
-    }
-  } else {
-    if (inks) {
-      return (
-        <CollectedInksTable
-          data={visibleInks}
-          archive={archive}
-          onLayoutChange={onLayoutChange}
-        />
-      );
-    } else {
-      return <CollectedInksTablePlaceholder />;
-    }
-  }
-};

--- a/app/javascript/src/collected_inks/table/CollectedInksTable.spec.jsx
+++ b/app/javascript/src/collected_inks/table/CollectedInksTable.spec.jsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  CollectedInksTable,
+  storageKeyHiddenFields
+} from "./CollectedInksTable";
+
+const setup = (jsx, options) => {
+  return {
+    user: userEvent.setup(),
+    ...render(jsx, options)
+  };
+};
+
+describe("<CollectedInksTable />", () => {
+  const data = [
+    {
+      id: "4",
+      brand_name: "Sailor",
+      line_name: "Shikiori",
+      ink_name: "Yozakura",
+      maker: "Sailor",
+      color: "#ac54b5",
+      archived_on: null,
+      comment:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+      kind: "bottle",
+      private: true,
+      private_comment:
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+      simplified_brand_name: "sailor",
+      simplified_ink_name: "yozakura",
+      simplified_line_name: "shikiori",
+      swabbed: true,
+      used: true,
+      archived: false,
+      ink_id: 3,
+      usage: 2,
+      daily_usage: 1,
+      tags: [
+        { id: "1", type: "tag", name: "maximum" },
+        { id: "2", type: "tag", name: "taggage" }
+      ]
+    },
+    {
+      id: "3",
+      brand_name: "Sailor",
+      line_name: "Shikiori",
+      ink_name: "Miruai",
+      maker: "Sailor",
+      color: null,
+      archived_on: null,
+      comment: null,
+      kind: "bottle",
+      private: false,
+      private_comment: null,
+      simplified_brand_name: "sailor",
+      simplified_ink_name: "yozakura",
+      simplified_line_name: "miruai",
+      swabbed: true,
+      used: true,
+      archived: false,
+      ink_id: 2,
+      usage: 1,
+      daily_usage: 1,
+      tags: []
+    }
+  ];
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders", async () => {
+    const { findByText } = setup(
+      <CollectedInksTable
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    const result = await findByText("Yozakura");
+
+    expect(result).toBeInTheDocument();
+  });
+
+  it("updates hidden fields when clicked", async () => {
+    const { getByTitle, getByLabelText, queryByText, user } = setup(
+      <CollectedInksTable
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    expect(queryByText("Usage")).toBeInTheDocument();
+
+    await user.click(getByTitle("Configure visible fields"));
+    await user.click(getByLabelText("Show usage"));
+
+    expect(queryByText("Usage")).not.toBeInTheDocument();
+  });
+
+  it("resets hidden fields when restore defaults is clicked", async () => {
+    const { getByText, getByTitle, getByLabelText, queryByText, user } = setup(
+      <CollectedInksTable
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    await user.click(getByTitle("Configure visible fields"));
+    await user.click(getByLabelText("Show usage"));
+
+    expect(queryByText("Usage")).not.toBeInTheDocument();
+
+    await user.click(getByText("Restore defaults"));
+
+    expect(queryByText("Usage")).toBeInTheDocument();
+  });
+
+  it("renders with hidden fields restored from localStorage", () => {
+    localStorage.setItem(storageKeyHiddenFields, JSON.stringify(["usage"]));
+
+    const { queryByText } = setup(
+      <CollectedInksTable
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    expect(queryByText("Usage")).not.toBeInTheDocument();
+  });
+
+  it("can be sorted", async () => {
+    const { getAllByRole, user } = setup(
+      <CollectedInksTable
+        archive={false}
+        data={data}
+        onLayoutChange={() => {
+          return;
+        }}
+      />
+    );
+
+    await user.click(getAllByRole("columnheader")[0]);
+
+    let firstNonHeaderRow = getAllByRole("row")[1];
+    expect(firstNonHeaderRow).toHaveTextContent(/yozakura/i);
+
+    await user.click(getAllByRole("columnheader")[0]);
+
+    firstNonHeaderRow = getAllByRole("row")[1];
+    expect(firstNonHeaderRow).toHaveTextContent(/miruai/i);
+  });
+});

--- a/app/javascript/src/collected_inks/table/Table.jsx
+++ b/app/javascript/src/collected_inks/table/Table.jsx
@@ -34,7 +34,7 @@ export const Table = ({
                 </span>
               </th>
             ))}
-            <th>Actions</th>
+            <th style={{ textAlign: "right" }}>Actions</th>
           </tr>
         ))}
       </thead>

--- a/app/javascript/src/collected_inks/table/sort.spec.js
+++ b/app/javascript/src/collected_inks/table/sort.spec.js
@@ -25,11 +25,15 @@ describe("booleanSort", () => {
   it("sorts the given bool column in order of false to true", () => {
     const input = [
       { values: { swabbed: true } },
-      { values: { swabbed: false } }
+      { values: { swabbed: false } },
+      { values: { swabbed: true } },
+      { values: { swabbed: true } }
     ];
 
     const expected = [
       { values: { swabbed: false } },
+      { values: { swabbed: true } },
+      { values: { swabbed: true } },
       { values: { swabbed: true } }
     ];
 

--- a/app/javascript/src/components/Card.jsx
+++ b/app/javascript/src/components/Card.jsx
@@ -1,26 +1,26 @@
 import React from "react";
 import "./card.scss";
 
-export const Card = ({ className, ...rest }) => (
+export const Card = ({ className = "", ...rest }) => (
   <div className={`card fpc-card ${className}`} {...rest} />
 );
 
-Card.Image = ({ className, ...rest }) => (
+Card.Image = ({ className = "", ...rest }) => (
   <div className={`card-img-top ${className}`} {...rest} />
 );
 Card.Image.displayName = "Card.Image";
 
-Card.Body = ({ className, ...rest }) => (
+Card.Body = ({ className = "", ...rest }) => (
   <div className={`card-body ${className}`} {...rest} />
 );
 Card.Body.displayName = "Card.Body";
 
-Card.Title = ({ className, ...rest }) => (
+Card.Title = ({ className = "", ...rest }) => (
   <p className={`h5 card-title ${className}`} {...rest} />
 );
 Card.Title.displayName = "Card.Title";
 
-Card.Text = ({ className, ...rest }) => (
+Card.Text = ({ className = "", ...rest }) => (
   <p className={`card-text ${className}`} {...rest} />
 );
 Card.Text.displayName = "Card.Text";

--- a/app/javascript/src/localStorage.js
+++ b/app/javascript/src/localStorage.js
@@ -24,3 +24,15 @@ export function setItem(key, value) {
     // Err on the side of caution.
   }
 }
+
+/**
+ * @param {string} key
+ */
+export function removeItem(key) {
+  try {
+    return localStorage.removeItem(key);
+  } catch (e) {
+    // In private browsing interacting with localStorage may raise an error in certain browsers.
+    // Err on the side of caution.
+  }
+}

--- a/app/javascript/stylesheets/collected_inks.scss
+++ b/app/javascript/stylesheets/collected_inks.scss
@@ -87,11 +87,11 @@ form.new_collected_ink {
 ul.tags {
   list-style: none;
   padding: 0px;
+  display: inline-flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 4px;
   li.tag {
-    display: inline-flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 4px;
     text-transform: capitalize;
   }
 }


### PR DESCRIPTION
Use localStorage to remember between visits. Separate config for table and card views, in case users want different things for the different views.

Fixes #1365