### PR TITLE
Fix swabs in Chrome and siblings

### DIFF
--- a/app/javascript/src/collected_inks/cards/swab-card.scss
+++ b/app/javascript/src/collected_inks/cards/swab-card.scss
@@ -18,10 +18,11 @@
     left: 1px;
     right: 1px;
     bottom: 1px;
-
-    mask: url(../../../images/swab.svg);
-    mask-repeat: no-repeat;
     background-color: var(--swab-color);
+    -webkit-mask: url(../../../images/swab.svg);
+    mask: url(../../../images/swab.svg);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
   }
 
   .fpc-swab-card__footer {

--- a/app/javascript/stylesheets/currently_inked.scss
+++ b/app/javascript/stylesheets/currently_inked.scss
@@ -97,7 +97,7 @@
       }
       .actions {
         margin-bottom: 3px;
-        text-align: center;
+        text-align: right;
         .btn {
           margin: 2px;
         }

--- a/app/javascript/stylesheets/currently_inked.scss
+++ b/app/javascript/stylesheets/currently_inked.scss
@@ -76,11 +76,24 @@
       margin-top: 15px;
       margin-bottom: 15px;
       .swab {
-        float: left;
-        height: 220px;
-        width: 50%;
-        mask: url(../images/swab.svg);
-        mask-repeat: no-repeat;
+        margin-inline: auto;
+        height: 180px;
+        width: 180px;
+        position: relative;
+
+        &::before {
+          content: " ";
+          position: absolute;
+          top: 1px;
+          left: 1px;
+          right: 1px;
+          bottom: 1px;
+          background-color: var(--swab-color);
+          -webkit-mask: url(../images/swab.svg);
+          mask: url(../images/swab.svg);
+          -webkit-mask-repeat: no-repeat;
+          mask-repeat: no-repeat;
+        }
       }
       .actions {
         margin-bottom: 3px;

--- a/app/views/currently_inked/_swabs.html.slim
+++ b/app/views/currently_inked/_swabs.html.slim
@@ -15,24 +15,24 @@ div class="row"
         div
           div.swab style="--swab-color:#{ci.ink_color};"
         div
-          b
-            'Pen:
+          div.small.text-secondary
+            'Pen
           = ci.pen_name
         div
-          b
-            'Ink:
+          div.small.text-secondary
+            'Ink
           = ci.ink_short_name
           | &nbsp;
           - if ci.macro_cluster
             = link_to fa_icon("external-link"), ink_path(ci.macro_cluster)
         div
-          b
-            'Date inked:
+          div.small.text-secondary
+            'Date inked
           =l ci.inked_on
         - if ci.last_used_on
           div
-            b
-              'Last used:
+            div.small.text-secondary
+              'Last used
             =l ci.last_used_on
         - if ci.comment.present?
           div= ci.comment

--- a/app/views/currently_inked/_swabs.html.slim
+++ b/app/views/currently_inked/_swabs.html.slim
@@ -13,7 +13,7 @@ div class="row"
     div class="col-sm-12 col-md-6"
       div class="entry"
         div
-          div.swab style="background-color:#{ci.ink_color};"
+          div.swab style="--swab-color:#{ci.ink_color};"
         div
           b
             'Pen:

--- a/app/views/currently_inked_archive/_swabs.html.slim
+++ b/app/views/currently_inked_archive/_swabs.html.slim
@@ -3,7 +3,7 @@ div class="row"
     div class="col-sm-12 col-md-6"
       div class="entry"
         div
-          div.swab style="background-color:#{ci.ink_color};"
+          div.swab style="--swab-color:#{ci.ink_color};"
         div
           b
             'Pen:

--- a/app/views/currently_inked_archive/_swabs.html.slim
+++ b/app/views/currently_inked_archive/_swabs.html.slim
@@ -5,19 +5,19 @@ div class="row"
         div
           div.swab style="--swab-color:#{ci.ink_color};"
         div
-          b
-            'Pen:
+          div.small.text-secondary
+            'Pen
           = ci.pen_name
         div
-          b
-            'Ink:
+          div.small.text-secondary
+            'Ink
           = ci.ink_short_name
           | &nbsp;
           - if ci.macro_cluster
             = link_to fa_icon("external-link"), ink_path(ci.macro_cluster)
         div
-          b
-            'Date inked:
+          div.small.text-secondary
+            'Date inked
           = ci.inked_on
         - if ci.comment.present?
           div= ci.comment


### PR DESCRIPTION
Noticed this while testing a Chromium-based browser
- Fix swabs in Chrome and siblings. Turns out, they need the -webkit-prefixed values.
- Make currently inked cards more similar to collected inks.

![](https://user-images.githubusercontent.com/1223410/235749835-a3b5e076-3195-46c1-83c9-e9914ff03250.png)
