### PR TITLE
Revert "Bump bootstrap from 5.2.3 to 5.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/preset-react": "^7.22.3",
     "@popperjs/core": "^2.11.8",
     "babel-loader": "^9.1.2",
-    "bootstrap": "^5.3.0",
+    "bootstrap": "^5.2.3",
     "color-convert": "^2.0.1",
     "core-js": "^3.30.2",
     "css-loader": "^6.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,10 +2469,10 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bootstrap@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.0.tgz#0718a7cc29040ee8dbf1bd652b896f3436a87c29"
-  integrity sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==
+bootstrap@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
+  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This reverts commit eef07a5747c302f1d023071bdf7bb46bf785bedc.

The upgrade broke Darkmode. @wkillerud, do you remember how you fixed the issue with the table backgrounds last time? The issue seems to be that the table background override (here: https://github.com/ujh/fountainpencompanion/blob/cb45260dc62c97b5a404753b8695ad79ed6692b3/app/javascript/stylesheets/fpc/_global.scss#L31) doesn't work and we end up with a white background.