### PR TITLE
Fix problems with dark mode after upgrading bootstrap

### DIFF
--- a/app/assets/stylesheets/sprockets-application.scss
+++ b/app/assets/stylesheets/sprockets-application.scss
@@ -7,3 +7,68 @@
 @import "jquery-ui/datepicker";
 
 @import "select2";
+
+.select2-dropdown,
+.select2-container--default .select2-selection--single,
+.select2-container--default
+  .select2-results__option[aria-selected="true"]:not(
+    .select2-results__option--highlighted
+  ) {
+  background-color: var(--fpc-background);
+  border-color: var(--bs-border-color);
+  color: var(--fpc-text-color);
+}
+
+.select2-container--default
+  .select2-results__option--highlighted[aria-selected] {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary-border-subtle);
+  color: var(--fpc-text-color);
+}
+
+.select2-container--default
+  .select2-selection--single
+  .select2-selection__rendered {
+  color: var(--fpc-text-color);
+}
+
+.ui-autocomplete {
+  max-height: 200px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  color: var(--fpc-text-color);
+  background-color: var(--fpc-bright-background);
+}
+
+.ui-widget {
+  &.ui-widget-content,
+  &-content {
+    background-color: var(--fpc-background);
+    border: 1px solid var(--bs-border-color);
+    color: var(--fpc-text-color);
+
+    .ui-state-default {
+      background-color: var(--fpc-bright-background);
+      border-color: var(--bs-border-color);
+      color: var(--fpc-text-color);
+    }
+
+    .ui-state-hover {
+      background-color: var(--bs-primary-bg-subtle);
+      border-color: var(--bs-primary-border-subtle);
+      color: var(--fpc-text-color);
+    }
+
+    .ui-state-highlight {
+      background-color: var(--bs-primary);
+      border-color: var(--bs-primary-border-subtle);
+      color: var(--fpc-text-color);
+    }
+  }
+
+  &-header {
+    border: 1px solid var(--bs-border-color);
+    background-color: var(--fpc-bright-background);
+    color: var(--fpc-text-color);
+  }
+}

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -4,6 +4,7 @@ import "regenerator-runtime/runtime";
 import { Tooltip, Dropdown } from "bootstrap";
 import "@popperjs/core";
 
+import "./color-mode";
 import "./src/admin/micro-clusters";
 import "./src/admin/graphs";
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,6 +4,7 @@ import "regenerator-runtime/runtime";
 import { Tooltip, Dropdown } from "bootstrap";
 import "@popperjs/core";
 
+import "./color-mode";
 import "./src/color-picker";
 import "./src/collected_inks";
 import "./src/collected_pens";

--- a/app/javascript/color-mode.js
+++ b/app/javascript/color-mode.js
@@ -1,0 +1,26 @@
+/*!
+ * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
+ * Copyright 2011-2023 The Bootstrap Authors
+ * Licensed under the Creative Commons Attribution 3.0 Unported License.
+ */
+(() => {
+  "use strict";
+
+  const getPreferredTheme = () => {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  };
+
+  const setTheme = (theme) => {
+    document.documentElement.setAttribute("data-bs-theme", theme);
+  };
+
+  setTheme(getPreferredTheme());
+
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      setTheme(getPreferredTheme());
+    });
+})();

--- a/app/javascript/stylesheets/collected_inks.scss
+++ b/app/javascript/stylesheets/collected_inks.scss
@@ -71,12 +71,12 @@ form.new_collected_ink {
     font-size: smaller;
     line-height: 15px;
   }
-}
 
-.ui-autocomplete {
-  max-height: 200px;
-  overflow-y: auto;
-  overflow-x: hidden;
+  .chrome-picker {
+    input {
+      background-color: #fff; // fixes a bug in dark mode where text is invisible
+    }
+  }
 }
 
 .pick-kind {

--- a/app/javascript/stylesheets/fpc/_global.scss
+++ b/app/javascript/stylesheets/fpc/_global.scss
@@ -5,13 +5,29 @@
   $primary: rgb(13, 110, 253)
 );
 
-.fpc {
+html {
+  // See also: https://getbootstrap.com/docs/5.3/customize/color/#colors
   --fpc-text-color: #{b.$gray-900};
+  --bs-body-color: var(--fpc-text-color);
   --fpc-muted-text-color: #{b.$gray-700};
   --fpc-background: #{b.$gray-100};
   --fpc-bright-background: #{b.$white};
   --fpc-shadow-color: #{b.$black};
+  --fpc-active-color: #{b.$blue-300};
+}
 
+html[data-bs-theme="dark"] {
+  --fpc-text-color: #{b.$gray-100};
+  --bs-body-color: var(--fpc-text-color);
+  --fpc-muted-text-color: #{b.$gray-300};
+  --fpc-background: #{b.$gray-900};
+  --fpc-bright-background: #{b.$black};
+  --fpc-shadow-color: #{b.$white};
+  --fpc-active-text-color: #{b.$black};
+  --fpc-active-background: #{b.$blue-800};
+}
+
+.fpc {
   background: var(--fpc-background);
   color: var(--fpc-text-color);
 
@@ -22,16 +38,6 @@
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-
-  @media (prefers-color-scheme: dark) {
-    & {
-      --fpc-text-color: #{b.$gray-100};
-      --fpc-muted-text-color: #{b.$gray-300};
-      --fpc-background: #{b.$gray-900};
-      --fpc-bright-background: #{b.$black};
-      --fpc-shadow-color: #{b.$white};
-    }
-  }
 }
 
 .fpc-skip-link {
@@ -161,7 +167,7 @@
   @include b.visually-hidden;
 }
 
-@media (prefers-color-scheme: dark) {
+[data-bs-theme="dark"] {
   $_table-dark-border-color: rgba(255, 255, 255, 0.1);
   $_table-dark-border: solid 1px $_table-dark-border-color;
 
@@ -170,6 +176,20 @@
 
     .-pagination .-btn {
       color: var(--fpc-text-color);
+    }
+
+    .-pagination input,
+    .-pagination select,
+    .rt-thead.-filters input,
+    .rt-thead.-filters select {
+      color: var(--fpc-text-color);
+      background-color: var(--fpc-body);
+      border-color: var(--bs-border-color);
+
+      &:hover,
+      &:focus {
+        border-color: var(--bs-primary-border-subtle);
+      }
     }
 
     .rt-thead,
@@ -188,6 +208,8 @@
 
   .table {
     --bs-table-color: var(--fpc-text-color);
+    --bs-table-bg: transparent;
+    --bs-table-accent-bg: transparent;
     --bs-table-striped-color: var(--fpc-text-color);
     --bs-table-striped-bg: var(--fpc-bright-background);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@babel/preset-react": "^7.22.3",
     "@popperjs/core": "^2.11.8",
     "babel-loader": "^9.1.2",
-    "bootstrap": "^5.2.3",
+    "bootstrap": "^5.3.0",
     "color-convert": "^2.0.1",
     "core-js": "^3.30.2",
     "css-loader": "^6.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2469,10 +2469,10 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bootstrap@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.2.3.tgz#54739f4414de121b9785c5da3c87b37ff008322b"
-  integrity sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==
+bootstrap@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.0.tgz#0718a7cc29040ee8dbf1bd652b896f3436a87c29"
+  integrity sha512-UnBV3E3v4STVNQdms6jSGO2CvOkjUMdDAVR2V5N4uCMdaIkaQjbcEAMqRimDHIs4uqBYzDAKCQwCB+97tJgHQw==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
Did not meet my goal of _removing_ CSS, but I couldn't resist theming the few remaining widgets (apart from the color picker).

- Adapt the [theme picker script from Bootstrap](https://getbootstrap.com/docs/5.3/customize/color-modes/#javascript) to simply keep the `data-` attribute in sync with the system theme. Can be extended for manual control, if need be.
- Override the (in my opinion) too subtle body text in the default dark theme from Bootstrap (keep our current one).
- Use the `data-` attribute instead of a media query in the selectors, to get higher specificity than Bootstrap, where we change variables.
- Fix a few legibility problems with non-Bootstrap inputs in dark mode.

Fixes #1599 