### PR TITLE
Adjust some colors in default light mode

### DIFF
--- a/app/assets/stylesheets/sprockets-application.scss
+++ b/app/assets/stylesheets/sprockets-application.scss
@@ -14,7 +14,7 @@
   .select2-results__option[aria-selected="true"]:not(
     .select2-results__option--highlighted
   ) {
-  background-color: var(--fpc-background);
+  background-color: var(--bs-body-bg);
   border-color: var(--bs-border-color);
   color: var(--fpc-text-color);
 }
@@ -23,7 +23,7 @@
   .select2-results__option--highlighted[aria-selected] {
   background-color: var(--bs-primary);
   border-color: var(--bs-primary-border-subtle);
-  color: var(--fpc-text-color);
+  color: #fff;
 }
 
 .select2-container--default
@@ -62,7 +62,7 @@
     .ui-state-highlight {
       background-color: var(--bs-primary);
       border-color: var(--bs-primary-border-subtle);
-      color: var(--fpc-text-color);
+      color: #fff;
     }
   }
 


### PR DESCRIPTION
- Go from black on dark blue, to white on dark blue.
- Restore the correct form widget background color for select2

Dark mode still looks fine with these changes

<details>
<summary>Before and after screenshots</summary>

![date-before](https://github.com/ujh/fountainpencompanion/assets/1223410/d09b3c5f-d8f1-450b-9e1e-fe7abbc26c86)
![date-after](https://github.com/ujh/fountainpencompanion/assets/1223410/e7965fca-f27d-4c47-949f-fc2af6e61f37)

![select-before](https://github.com/ujh/fountainpencompanion/assets/1223410/9604e3d1-884a-4a3c-8b02-7586eba83ca0)
![select-after](https://github.com/ujh/fountainpencompanion/assets/1223410/856ed620-751b-4af1-b2b5-e1afbe7888b8)

</details>