### PR TITLE
Sort currently inked entries by pen name by default

### DIFF
--- a/app/javascript/src/currently_inked/CurrentlyInked.jsx
+++ b/app/javascript/src/currently_inked/CurrentlyInked.jsx
@@ -7,6 +7,7 @@ import { CardsPlaceholder } from "../components/CardsPlaceholder";
 import { TablePlaceholder } from "../components/TablePlaceholder";
 import { CurrentlyInkedCards } from "./cards/CurrentlyInkedCards";
 import { CurrentlyInkedTable } from "./table/CurrentlyInkedTable";
+import _ from "lodash";
 
 const formatter = new Jsona();
 
@@ -17,7 +18,10 @@ export const CurrentlyInked = () => {
 
   useEffect(() => {
     async function getData() {
-      setCurrentlyInked(await getCurrentlyInked());
+      // Hack to keep the default sort order of the table and the card view the same.
+      // Will eventually (ha!) be replaced by a sorting capability for the card view.
+      const data = await getCurrentlyInked();
+      setCurrentlyInked(_.sortBy(data, "pen_name"));
     }
     getData();
   }, []);


### PR DESCRIPTION
We do this sorting in the table, but not in the card view so when switching from the desktop to a mobile phone "stuff changes".

At some point I imagine we will replace this by a way to sort entries in the card view, but until then let's just make it the same as the default in the table view.

Fixes #1625