### PR TITLE
Remove default sorting of tables

### DIFF
--- a/app/javascript/src/collected_inks/table/CollectedInksTable.jsx
+++ b/app/javascript/src/collected_inks/table/CollectedInksTable.jsx
@@ -206,8 +206,7 @@ export const CollectedInksTable = ({ data, archive, onLayoutChange }) => {
       columns,
       data,
       initialState: {
-        hiddenColumns: hiddenFields,
-        sortBy: [{ id: "brand_name" }, { id: "line_name" }, { id: "ink_name" }]
+        hiddenColumns: hiddenFields
       },
       filterTypes: {
         fuzzyText: fuzzyMatch

--- a/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
+++ b/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
@@ -100,13 +100,7 @@ export const CollectedPensTable = ({ pens, onLayoutChange }) => {
       columns,
       data: pens,
       initialState: {
-        hiddenColumns: hiddenFields,
-        sortBy: [
-          { id: "brand" },
-          { id: "model" },
-          { id: "nib" },
-          { id: "color" }
-        ]
+        hiddenColumns: hiddenFields
       },
       filterTypes: {
         fuzzyText: fuzzyMatch

--- a/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
+++ b/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
@@ -123,8 +123,7 @@ export const CurrentlyInkedTable = ({ currentlyInked, onLayoutChange }) => {
       columns,
       data: currentlyInked,
       initialState: {
-        hiddenColumns: hiddenFields,
-        sortBy: [{ id: "pen_name" }]
+        hiddenColumns: hiddenFields
       },
       filterTypes: {
         fuzzyText: fuzzyMatch


### PR DESCRIPTION
It interacts weirdly with the search and doesn't let it override and have the most important rows come first.

Fixes #1649