### PR TITLE
Separate the leaderboard refresh workers for better stats

### DIFF
--- a/.env
+++ b/.env
@@ -7,4 +7,3 @@ REDIS_PROVIDER=REDIS_URL
 REDIS_CACHE_URL=redis://localhost:6379/11
 # For puma
 PORT=3000
-DATABASE_URL=postgresql://@localhost:5433/fountainpencompanion_development

--- a/app/models/leader_board.rb
+++ b/app/models/leader_board.rb
@@ -12,6 +12,8 @@ class LeaderBoard
     users_by_description_edits
   ]
 
+  WORKERS = TYPES.map { |t| "refresh_leader_board/#{t}".camelize.constantize }
+
   def self.refresh!(type)
     self.send(type, force: true)
   end

--- a/app/workers/refresh_leader_board.rb
+++ b/app/workers/refresh_leader_board.rb
@@ -1,9 +1,0 @@
-class RefreshLeaderBoard
-  include Sidekiq::Worker
-
-  sidekiq_options queue: "leaderboards"
-
-  def perform(type)
-    LeaderBoard.refresh!(type)
-  end
-end

--- a/app/workers/refresh_leader_board/base.rb
+++ b/app/workers/refresh_leader_board/base.rb
@@ -1,0 +1,15 @@
+class RefreshLeaderBoard::Base
+  include Sidekiq::Worker
+
+  sidekiq_options queue: "leaderboards"
+
+  def perform
+    LeaderBoard.refresh!(type)
+  end
+
+  private
+
+  def type
+    self.class.name.demodulize.underscore
+  end
+end

--- a/app/workers/refresh_leader_board/bottles.rb
+++ b/app/workers/refresh_leader_board/bottles.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::Bottles < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/brands.rb
+++ b/app/workers/refresh_leader_board/brands.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::Brands < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/currently_inked.rb
+++ b/app/workers/refresh_leader_board/currently_inked.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::CurrentlyInked < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/ink_review_submissions.rb
+++ b/app/workers/refresh_leader_board/ink_review_submissions.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::InkReviewSubmissions < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/inks.rb
+++ b/app/workers/refresh_leader_board/inks.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::Inks < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/inks_by_popularity.rb
+++ b/app/workers/refresh_leader_board/inks_by_popularity.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::InksByPopularity < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/pens_by_popularity.rb
+++ b/app/workers/refresh_leader_board/pens_by_popularity.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::PensByPopularity < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/samples.rb
+++ b/app/workers/refresh_leader_board/samples.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::Samples < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/usage_records.rb
+++ b/app/workers/refresh_leader_board/usage_records.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::UsageRecords < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_board/users_by_description_edits.rb
+++ b/app/workers/refresh_leader_board/users_by_description_edits.rb
@@ -1,0 +1,2 @@
+class RefreshLeaderBoard::UsersByDescriptionEdits < RefreshLeaderBoard::Base
+end

--- a/app/workers/refresh_leader_boards.rb
+++ b/app/workers/refresh_leader_boards.rb
@@ -4,6 +4,6 @@ class RefreshLeaderBoards
   sidekiq_options queue: "leaderboards"
 
   def perform
-    LeaderBoard::TYPES.each { |type| RefreshLeaderBoard.perform_async(type) }
+    LeaderBoard::WORKERS.each { |worker| worker.perform_async }
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,6 +13,7 @@ development:
 
 test:
   <<: *default
+  url: <%= ENV['DATABASE_URL'] %>
   database: fountainpencompanion_test
 
 production:


### PR DESCRIPTION
Some (one?) of these refresh workers (at least the "brands" one) puts a lot of strain on the database. It's hard to get any stats on which one is problematic when they're all using the same worker. This separates them all so that we get separate run times that are easier to interpret.