### PR TITLE
Use the new leaderboard row data for the brands leaderboard

### DIFF
--- a/app/models/leader_board.rb
+++ b/app/models/leader_board.rb
@@ -3,7 +3,6 @@ class LeaderBoard
     inks
     bottles
     samples
-    brands
     inks_by_popularity
     currently_inked
     usage_records
@@ -172,25 +171,17 @@ class LeaderBoard
   end
 
   def self.brands(force: false)
-    # LeaderBoardRow::Brands.includes(:user)
-    #   .order(value: :desc)
-    #   .where('value > 0')
-    #   .map do |row|
-    #     {
-    #       id: row.user.id,
-    #       public_name: row.user.public_name,
-    #       counter: row.value,
-    #       patron: row.user.patron?
-    #     }
-    #   end
-    Rails
-      .cache
-      .fetch("LeaderBoard#brands", force: force) do
-        extract(
-          build(
-            "(select count(distinct brand_name) from collected_inks where collected_inks.user_id = users.id) as counter"
-          )
-        )
+    LeaderBoardRow::Brands
+      .includes(:user)
+      .order(value: :desc)
+      .where("value > 0")
+      .map do |row|
+        {
+          id: row.user.id,
+          public_name: row.user.public_name,
+          counter: row.value,
+          patron: row.user.patron?
+        }
       end
   end
 

--- a/app/workers/refresh_leader_board/brands.rb
+++ b/app/workers/refresh_leader_board/brands.rb
@@ -1,2 +1,0 @@
-class RefreshLeaderBoard::Brands < RefreshLeaderBoard::Base
-end

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -34,3 +34,4 @@ exceptions:
     - ActiveRecord::RecordNotUnique
     - ActionController::BadRequest
     - Redis::ConnectionError
+    - Rack::Timeout::RequestTimeoutException

--- a/spec/models/leader_board_spec.rb
+++ b/spec/models/leader_board_spec.rb
@@ -277,6 +277,8 @@ describe LeaderBoard do
       create(:collected_ink, user: user2, brand_name: "brand 1")
       create(:collected_ink, user: user2, brand_name: "brand 2")
 
+      Sidekiq::Testing.inline! { RefreshLeaderBoardRows.perform_async }
+
       expect(described_class.brands.map { |e| [e[:id], e[:counter]] }).to eq(
         [[user1.id, 3], [user2.id, 2]]
       )


### PR DESCRIPTION
With the data in place, we can also forego the caching of the data as it's super cheap to calculate on the fly. More importantly though, we can get rid off the calculation of the data in one go.