### PR TITLE
Do not use a default scope

### DIFF
--- a/app/models/leader_board_row.rb
+++ b/app/models/leader_board_row.rb
@@ -1,10 +1,9 @@
 class LeaderBoardRow < ApplicationRecord
   belongs_to :user
 
-  default_scope { includes(:user).order(value: :desc).where("value > 0") }
-
   def self.to_leader_board
-    all.map do |row|
+    rows = includes(:user).order(value: :desc).where("value > 0")
+    rows.map do |row|
       {
         id: row.user.id,
         public_name: row.user.public_name,


### PR DESCRIPTION
With the default scope in place we cannot delete users with leader board rows with a value of zero.