### PR TITLE
Properly set up eager loading between collected pens and clusters

### DIFF
--- a/app/controllers/admins/pens/micro_clusters_controller.rb
+++ b/app/controllers/admins/pens/micro_clusters_controller.rb
@@ -5,7 +5,11 @@ class Admins::Pens::MicroClustersController < Admins::BaseController
         # FIXME: Adding an includes here breaks the serialization and does not include
         #        the collected pens anymore. This is due to the way the association is
         #        set up and not being really bi-directional.
-        clusters = Pens::MicroCluster.ordered.page(params[:page])
+        clusters =
+          Pens::MicroCluster
+            .includes(:collected_pens)
+            .ordered
+            .page(params[:page])
         clusters = clusters.unassigned if params[:unassigned]
         clusters = clusters.without_ignored if params[:without_ignored]
         render json:

--- a/app/models/pens/micro_cluster.rb
+++ b/app/models/pens/micro_cluster.rb
@@ -1,6 +1,6 @@
 class Pens::MicroCluster < ApplicationRecord
   has_many :collected_pens,
-           foreign_key: :pens_micro_cluster,
+           foreign_key: :pens_micro_cluster_id,
            inverse_of: :pens_micro_cluster
   belongs_to :model_variant,
              optional: true,

--- a/spec/models/pens/micro_cluster_spec.rb
+++ b/spec/models/pens/micro_cluster_spec.rb
@@ -37,4 +37,15 @@ describe Pens::MicroCluster do
       expect(described_class.without_ignored).not_to include(cluster)
     end
   end
+
+  it "eager loading of collected_pens is properly configured" do
+    cluster = create(:pens_micro_cluster)
+    collected_pen = create(:collected_pen, pens_micro_cluster: cluster)
+
+    expect(cluster.reload.collected_pens).to eq([collected_pen])
+    # Requires stuff to be properly set up for eager loading to work
+    expect(
+      described_class.includes(:collected_pens).first.collected_pens
+    ).to eq([collected_pen])
+  end
 end


### PR DESCRIPTION
This is required for the clustering admin app to avoid N+1 queries