### PR TITLE
Do not return micro cluster attributes

### DIFF
--- a/app/controllers/admins/macro_clusters_controller.rb
+++ b/app/controllers/admins/macro_clusters_controller.rb
@@ -59,7 +59,7 @@ class Admins::MacroClustersController < Admins::BaseController
 
   def index_options(rel)
     {
-      include: [:micro_clusters, :"micro_clusters.collected_inks"],
+      include: %i[micro_clusters micro_clusters.collected_inks],
       fields: {
         collected_ink: %i[
           brand_name
@@ -68,7 +68,8 @@ class Admins::MacroClustersController < Admins::BaseController
           maker
           color
           micro_cluster
-        ]
+        ],
+        micro_cluster: %i[collected_inks macro_cluster]
       },
       meta: {
         pagination: pagination(rel)
@@ -78,7 +79,7 @@ class Admins::MacroClustersController < Admins::BaseController
 
   def show_options
     {
-      include: [:micro_clusters, :"micro_clusters.collected_inks"],
+      include: %i[micro_clusters micro_clusters.collected_inks],
       fields: {
         collected_ink: %i[
           brand_name

--- a/spec/requests/admins/macro_clusters_controller_spec.rb
+++ b/spec/requests/admins/macro_clusters_controller_spec.rb
@@ -49,11 +49,6 @@ describe Admins::MacroClustersController do
                     "id" => micro_cluster.id.to_s,
                     "type" => "micro_cluster",
                     "attributes" => {
-                      "simplified_brand_name" =>
-                        micro_cluster.simplified_brand_name,
-                      "simplified_line_name" =>
-                        micro_cluster.simplified_line_name,
-                      "simplified_ink_name" => micro_cluster.simplified_ink_name
                     },
                     "relationships" => {
                       "macro_cluster" => {
@@ -141,11 +136,6 @@ describe Admins::MacroClustersController do
                     "id" => micro_cluster.id.to_s,
                     "type" => "micro_cluster",
                     "attributes" => {
-                      "simplified_brand_name" =>
-                        micro_cluster.simplified_brand_name,
-                      "simplified_line_name" =>
-                        micro_cluster.simplified_line_name,
-                      "simplified_ink_name" => micro_cluster.simplified_ink_name
                     },
                     "relationships" => {
                       "macro_cluster" => {


### PR DESCRIPTION
Do not return the micro cluster attributes on the macro clusters admin index endpoint. They're not being used anyway and might just make the whole thing slower than it needs to be.