### PR TITLE
Background jobs to update values of Pens::ModelVariant

### DIFF
--- a/app/models/pens/model_variant.rb
+++ b/app/models/pens/model_variant.rb
@@ -2,9 +2,10 @@ class Pens::ModelVariant < ApplicationRecord
   has_many :micro_clusters,
            foreign_key: :pens_model_variant_id,
            class_name: "Pens::MicroCluster"
+  has_many :collected_pens, through: :micro_clusters
 
   scope :ordered,
-        -> do
+        lambda {
           order(:brand, :model, :color, :material, :trim_color, :filling_system)
-        end
+        }
 end

--- a/app/workers/pens/assign_micro_cluster.rb
+++ b/app/workers/pens/assign_micro_cluster.rb
@@ -7,6 +7,7 @@ module Pens
       cluster =
         Pens::MicroCluster.find_or_create_by!(cluster_attributes(collected_pen))
       collected_pen.update!(pens_micro_cluster: cluster)
+      Pens::UpdateMicroCluster.perform_async(cluster.id)
     rescue ActiveRecord::RecordNotFound
       # do nothing
     end

--- a/app/workers/pens/update_micro_cluster.rb
+++ b/app/workers/pens/update_micro_cluster.rb
@@ -1,0 +1,12 @@
+module Pens
+  class UpdateMicroCluster
+    include Sidekiq::Worker
+
+    def perform(pens_micro_cluster_id)
+      cluster = Pens::MicroCluster.find(pens_micro_cluster_id)
+      return unless cluster.pens_model_variant_id
+
+      Pens::UpdateModelVariant.perform_async(cluster.pens_model_variant_id)
+    end
+  end
+end

--- a/app/workers/pens/update_model_variant.rb
+++ b/app/workers/pens/update_model_variant.rb
@@ -1,0 +1,28 @@
+module Pens
+  class UpdateModelVariant
+    include Sidekiq::Worker
+
+    def perform(model_variant_id)
+      self.model_variant = Pens::ModelVariant.find(model_variant_id)
+      return if model_variant.collected_pens.empty?
+
+      update_attributes!
+    end
+
+    private
+
+    attr_accessor :model_variant
+
+    def update_attributes!
+      %i[brand model color material trim_color filling_system].each do |attr|
+        model_variant.send("#{attr}=", best_attr_value(attr))
+      end
+      model_variant.save
+    end
+
+    def best_attr_value(attr)
+      attr_values = model_variant.collected_pens.map { |cp| cp.send(attr) }
+      attr_values.tally.max_by { |_k, v| v }.first || ""
+    end
+  end
+end

--- a/spec/factories/pens/micro_clusters.rb
+++ b/spec/factories/pens/micro_clusters.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :pens_micro_cluster, class: "Pens::MicroCluster" do
     simplified_brand { "brand" }
-    simplified_model { "model" }
+    sequence(:simplified_model) { |n| "model#{n}" }
     simplified_color { "color" }
     simplified_material { "material" }
     simplified_trim_color { "trim" }

--- a/spec/requests/admins/pens/micro_clusters_controller_spec.rb
+++ b/spec/requests/admins/pens/micro_clusters_controller_spec.rb
@@ -24,12 +24,13 @@ describe Admins::Pens::MicroClustersController do
             "id" => pens_cluster.id.to_s,
             "type" => "pens_micro_cluster",
             "attributes" => {
-              "simplified_brand" => "brand",
-              "simplified_model" => "model",
-              "simplified_color" => "color",
-              "simplified_material" => "material",
-              "simplified_trim_color" => "trim",
-              "simplified_filling_system" => "fillingsystem"
+              "simplified_brand" => pens_cluster.simplified_brand,
+              "simplified_model" => pens_cluster.simplified_model,
+              "simplified_color" => pens_cluster.simplified_color,
+              "simplified_material" => pens_cluster.simplified_material,
+              "simplified_trim_color" => pens_cluster.simplified_trim_color,
+              "simplified_filling_system" =>
+                pens_cluster.simplified_filling_system
             },
             "relationships" => {
               "collected_pens" => {

--- a/spec/workers/pens/assign_micro_cluster_spec.rb
+++ b/spec/workers/pens/assign_micro_cluster_spec.rb
@@ -17,6 +17,13 @@ describe Pens::AssignMicroCluster do
       collected_pen.reload
       expect(collected_pen.pens_micro_cluster).to eq(cluster)
     end
+
+    it "schedules the cluster update job" do
+      expect { subject.perform(collected_pen.id) }.to change(
+        Pens::UpdateMicroCluster.jobs,
+        :length
+      ).by(1)
+    end
   end
 
   context "existing pen" do
@@ -48,6 +55,13 @@ describe Pens::AssignMicroCluster do
       )
       collected_pen.reload
       expect(collected_pen.pens_micro_cluster).to eq(cluster)
+    end
+
+    it "schedules the cluster update job" do
+      expect { subject.perform(collected_pen.id) }.to change(
+        Pens::UpdateMicroCluster.jobs,
+        :length
+      ).by(1)
     end
   end
 end

--- a/spec/workers/pens/update_micro_cluster_spec.rb
+++ b/spec/workers/pens/update_micro_cluster_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe Pens::UpdateMicroCluster do
+  it "does nothing if no model variant was assigned" do
+    micro_cluster = create(:pens_micro_cluster)
+
+    expect { subject.perform(micro_cluster.id) }.not_to change(
+      Pens::UpdateModelVariant.jobs,
+      :length
+    )
+  end
+
+  it "schedules the model variant update job if model variant assigned" do
+    micro_cluster =
+      create(:pens_micro_cluster, model_variant: create(:pens_model_variant))
+
+    expect { subject.perform(micro_cluster.id) }.to change(
+      Pens::UpdateModelVariant.jobs,
+      :length
+    ).by(1)
+  end
+end

--- a/spec/workers/pens/update_model_variant_spec.rb
+++ b/spec/workers/pens/update_model_variant_spec.rb
@@ -1,0 +1,74 @@
+require "rails_helper"
+
+describe Pens::UpdateModelVariant do
+  it "sets the attributes to the most common value from the collected pens" do
+    model_variant = create(:pens_model_variant)
+    mc1 = create(:pens_micro_cluster, model_variant:)
+    mc2 = create(:pens_micro_cluster, model_variant:)
+    create(
+      :collected_pen,
+      pens_micro_cluster: mc1,
+      brand: "Brand 1",
+      model: "Model 1",
+      color: "Color 1",
+      material: "Material 1",
+      trim_color: "Trim Color 1",
+      filling_system: "Filling System 1"
+    )
+    create(
+      :collected_pen,
+      pens_micro_cluster: mc1,
+      brand: "Brand 2",
+      model: "Model 1",
+      color: "Color 2",
+      material: "Material 2",
+      trim_color: "Trim Color 2",
+      filling_system: "Filling System 2"
+    )
+    create(
+      :collected_pen,
+      pens_micro_cluster: mc2,
+      brand: "Brand 1",
+      model: "Model 2",
+      color: "Color 1",
+      material: "Material 1",
+      trim_color: "Trim Color 1",
+      filling_system: "Filling System 1"
+    )
+
+    subject.perform(model_variant.id)
+
+    model_variant.reload
+    expect(model_variant.brand).to eq("Brand 1")
+    expect(model_variant.model).to eq("Model 1")
+    expect(model_variant.color).to eq("Color 1")
+    expect(model_variant.material).to eq("Material 1")
+    expect(model_variant.trim_color).to eq("Trim Color 1")
+    expect(model_variant.filling_system).to eq("Filling System 1")
+  end
+
+  it "works with empty values, too" do
+    model_variant = create(:pens_model_variant)
+    mc = create(:pens_micro_cluster, model_variant:)
+    create(
+      :collected_pen,
+      pens_micro_cluster: mc,
+      brand: "Brand",
+      model: "Model",
+      color: "",
+      material: nil,
+      trim_color: nil,
+      filling_system: nil
+    )
+
+    subject.perform(model_variant.id)
+
+    model_variant.reload
+    expect(model_variant.brand).to eq("Brand")
+    expect(model_variant.model).to eq("Model")
+    expect(model_variant.color).to eq("")
+    expect(model_variant.material).to eq("")
+    expect(model_variant.trim_color).to eq("")
+    expect(model_variant.filling_system).to eq("")
+  end
+end


### PR DESCRIPTION
Follows the logic of the pens, and picks the most common value for and attribute as the one to use.