### PR TITLE
Fix inks micro clusters app

### DIFF
--- a/app/javascript/src/admin/micro-clusters/assignCluster.jsx
+++ b/app/javascript/src/admin/micro-clusters/assignCluster.jsx
@@ -15,5 +15,10 @@ export const assignCluster = (microClusterId, macroClusterId) =>
       let microCluster = formatter.deserialize(json);
       microCluster.entries = microCluster.collected_inks;
       delete microCluster.collected_inks;
+      microCluster.macro_cluster.micro_clusters.forEach((mc) => {
+        mc.entries = mc.collected_inks;
+        delete mc.collected_inks;
+      });
+
       return microCluster;
     });

--- a/app/javascript/src/admin/micro-clusters/createMacroClusterAndAssign.jsx
+++ b/app/javascript/src/admin/micro-clusters/createMacroClusterAndAssign.jsx
@@ -24,7 +24,7 @@ export const createMacroClusterAndAssign = (
         assignCluster(microClusterId, json.data.id).then((microCluster) => {
           const macroCluster = microCluster.macro_cluster;
           const grouped_entries = groupedInks(
-            macroCluster.micro_clusters.map((c) => c.collected_inks).flat()
+            macroCluster.micro_clusters.map((c) => c.entries).flat()
           );
           dispatch({
             type: ADD_MACRO_CLUSTER,


### PR DESCRIPTION
When creating a new cluster the data needs to be properly massaged to always use `entries` and not `collected_inks`. That part was generalized for the pens, but somehow missed here.