### PR TITLE
Only cluster pen micro clusters with more than one pen

### DIFF
--- a/app/controllers/admins/pens/micro_clusters_controller.rb
+++ b/app/controllers/admins/pens/micro_clusters_controller.rb
@@ -9,6 +9,11 @@ class Admins::Pens::MicroClustersController < Admins::BaseController
           Pens::MicroCluster
             .includes(:collected_pens)
             .ordered
+            .joins(
+              "LEFT JOIN collected_pens AS cps ON cps.pens_micro_cluster_id = pens_micro_clusters.id"
+            )
+            .group("pens_micro_clusters.id")
+            .having("count(*) > 1")
             .page(params[:page])
         clusters = clusters.unassigned if params[:unassigned]
         clusters = clusters.without_ignored if params[:without_ignored]

--- a/app/models/admin_stats.rb
+++ b/app/models/admin_stats.rb
@@ -14,12 +14,21 @@ class AdminStats
   end
 
   def pens_micro_clusters_to_assign_count
-    # The JOIN is there to remove clusters without pens
     Pens::MicroCluster
       .unassigned
       .without_ignored
       .joins(:collected_pens)
       .group("pens_micro_clusters.id")
+      .having("count(*) > 1")
+      .count
+      .count
+  end
+
+  def relevant_pens_micro_clusters_count
+    Pens::MicroCluster
+      .joins(:collected_pens)
+      .group("pens_micro_clusters.id")
+      .having("count(*) > 1")
       .count
       .count
   end

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -48,6 +48,11 @@ table class="table table-striped"
             td
               | &nbsp;
               | micro clusters
+          tr
+            td style="text-align:right"= @stats.relevant_pens_micro_clusters_count
+            td
+              | &nbsp;
+              | micro clusters with more than one collected pen
               - if @stats.pens_micro_clusters_to_assign_count.positive?
                 b
                   |   (


### PR DESCRIPTION
Let's exclude all the one off clusters. They are just too many and will not let me move ahead. I might look at those later on, but for now the ones with more than one assigned pen are more important.

It seems like a better idea to improve the automated rules to group more of the pens anyway, that trying to do it all manually, too. Especially, as we're talking about 50-60k micro clusters.