### PR TITLE
Bring back the signup IP check

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  MAX_SAME_IP_24H = 2
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable,
@@ -32,6 +34,20 @@ class User < ApplicationRecord
 
   def self.bots
     where(bot: true)
+  end
+
+  def sign_up_ip=(value)
+    ip_count =
+      self
+        .class
+        .where("created_at > ?", 24.hours.ago)
+        .where(sign_up_ip: value)
+        .count
+    if ip_count >= MAX_SAME_IP_24H
+      self.bot = true
+      self.bot_reason = "sign_up_ip_24h_timeframe"
+    end
+    super
   end
 
   def after_confirmation

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,32 @@
 require "rails_helper"
 
 describe User do
+  describe "#sign_up_ip=" do
+    it "sets the ip field" do
+      user = build(:user)
+      user.sign_up_ip = "127.0.0.1"
+      expect(user.sign_up_ip).to eq("127.0.0.1")
+    end
+
+    it "does not set the bot field" do
+      user = build(:user)
+      user.sign_up_ip = "127.0.0.1"
+      expect(user.bot).to be false
+    end
+
+    it "marks as bot when too many signups by that IP in the last 24h" do
+      create_list(:user, User::MAX_SAME_IP_24H, sign_up_ip: "123")
+      user = build(:user, sign_up_ip: "123")
+      expect(user.bot).to be true
+    end
+
+    it "correctly sets the bot reason when too many signups in 24h" do
+      create_list(:user, User::MAX_SAME_IP_24H, sign_up_ip: "123")
+      user = build(:user, sign_up_ip: "123")
+      expect(user.bot_reason).to eq("sign_up_ip_24h_timeframe")
+    end
+  end
+
   describe "#active_for_authentication?" do
     it "returns true for confirmed users" do
       user = create(:user)


### PR DESCRIPTION
Now that the site is being picked up by spammers, this might be useful in catching some of their accounts.