### PR TITLE
Automatically assign pen brand

### DIFF
--- a/Procfile.development
+++ b/Procfile.development
@@ -1,0 +1,3 @@
+web: rails s
+worker: sidekiq
+frontend: yarn dev

--- a/app/models/pens/brand.rb
+++ b/app/models/pens/brand.rb
@@ -9,7 +9,7 @@ class Pens::Brand < ApplicationRecord
   end
 
   def names
-    models.pluck(:brand).uniq.sort
+    ([name] + models.pluck(:brand)).uniq.sort
   end
 
   def update_name!

--- a/app/models/pens/brand.rb
+++ b/app/models/pens/brand.rb
@@ -5,7 +5,11 @@ class Pens::Brand < ApplicationRecord
            dependent: :nullify
 
   def synonyms
-    models.pluck(:brand).uniq.sort - [name]
+    names - [name]
+  end
+
+  def names
+    models.pluck(:brand).uniq.sort
   end
 
   def update_name!

--- a/app/workers/pens/assign_brand.rb
+++ b/app/workers/pens/assign_brand.rb
@@ -1,0 +1,24 @@
+module Pens
+  class AssignBrand
+    include Sidekiq::Worker
+
+    def perform(model_id)
+      self.model = Pens::Model.find_by(id: model_id)
+      return unless model
+
+      assign_brand!
+    end
+
+    private
+
+    attr_accessor :model
+
+    def assign_brand!
+      return if model.pen_brand
+
+      Pens::Brand.find_each do |brand|
+        model.update!(pen_brand: brand) if brand.names.include?(model.brand)
+      end
+    end
+  end
+end

--- a/app/workers/pens/assign_model_micro_cluster.rb
+++ b/app/workers/pens/assign_model_micro_cluster.rb
@@ -9,6 +9,7 @@ module Pens
           cluster_attributes(model_variant)
         )
       model_variant.update!(model_micro_cluster: cluster)
+      Pens::UpdateModelMicroCluster.perform_async(cluster.id)
     rescue ActiveRecord::RecordNotFound
       # do nothing
     end

--- a/app/workers/pens/update_model.rb
+++ b/app/workers/pens/update_model.rb
@@ -7,6 +7,7 @@ module Pens
       return if model.model_variants.empty?
 
       update_attributes!
+      Pens::AssignBrand.perform_async(model_id)
     end
 
     private

--- a/spec/models/pens/brand_spec.rb
+++ b/spec/models/pens/brand_spec.rb
@@ -10,12 +10,19 @@ describe Pens::Brand do
 
   describe "#names" do
     it "returns all the unique names of all assigned models" do
-      brand = create(:pens_brand)
+      brand = create(:pens_brand, name: "Brand 1")
       create(:pens_model, pen_brand: brand, brand: "Brand 1")
       create(:pens_model, pen_brand: brand, brand: "Brand 1")
       create(:pens_model, pen_brand: brand, brand: "Brand 2")
 
       expect(brand.names).to match_array(["Brand 1", "Brand 2"])
+    end
+
+    it "includes the brand name if it is different" do
+      brand = create(:pens_brand, name: "Brand X")
+      create(:pens_model, pen_brand: brand, brand: "Brand 1")
+
+      expect(brand.names).to match_array(["Brand 1", "Brand X"])
     end
   end
 

--- a/spec/models/pens/brand_spec.rb
+++ b/spec/models/pens/brand_spec.rb
@@ -7,4 +7,26 @@ describe Pens::Brand do
 
     expect(brand.models).to eq([model])
   end
+
+  describe "#names" do
+    it "returns all the unique names of all assigned models" do
+      brand = create(:pens_brand)
+      create(:pens_model, pen_brand: brand, brand: "Brand 1")
+      create(:pens_model, pen_brand: brand, brand: "Brand 1")
+      create(:pens_model, pen_brand: brand, brand: "Brand 2")
+
+      expect(brand.names).to match_array(["Brand 1", "Brand 2"])
+    end
+  end
+
+  describe "#synonyms" do
+    it "returns all unique names of all assigned models, apart from the brand's own name" do
+      brand = create(:pens_brand, name: "Brand")
+      create(:pens_model, pen_brand: brand, brand: "Brand")
+      create(:pens_model, pen_brand: brand, brand: "Brand 1")
+      create(:pens_model, pen_brand: brand, brand: "Brand 2")
+
+      expect(brand.synonyms).to match_array(["Brand 1", "Brand 2"])
+    end
+  end
 end

--- a/spec/workers/pens/assign_brand_spec.rb
+++ b/spec/workers/pens/assign_brand_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe Pens::AssignBrand do
+  it "does not fail if pen model does not exist" do
+    expect { subject.perform(-1) }.not_to raise_error
+  end
+
+  it "assigns the pen brand if one can be found" do
+    model = create(:pens_model, brand: "Brand")
+
+    brand = create(:pens_brand, name: "Brand")
+
+    expect do subject.perform(model.id) end.to change {
+      model.reload.pen_brand
+    }.from(nil).to(brand)
+  end
+
+  it "assigns the pen brand if a synonym matches" do
+    model = create(:pens_model, brand: "Brand X")
+
+    brand = create(:pens_brand, name: "Brand")
+    create(:pens_model, pen_brand: brand, brand: "Brand X")
+
+    expect do subject.perform(model.id) end.to change {
+      model.reload.pen_brand
+    }.from(nil).to(brand)
+  end
+
+  it "does not assign if the pen brand is already present" do
+    existing_brand = create(:pens_brand)
+    model = create(:pens_model, brand: "Brand", pen_brand: existing_brand)
+    matching_brand = create(:pens_brand, name: "Brand")
+
+    expect { subject.perform(model.id) }.not_to(
+      change { model.reload.pen_brand }
+    )
+  end
+end

--- a/spec/workers/pens/update_model_spec.rb
+++ b/spec/workers/pens/update_model_spec.rb
@@ -30,4 +30,15 @@ describe Pens::UpdateModel do
     expect(model.brand).to eq("Brand 1")
     expect(model.model).to eq("Model 1")
   end
+
+  it "schedules the brand update job" do
+    model = create(:pens_model)
+    mmc1 = create(:pens_model_micro_cluster, model:)
+    create(:pens_model_variant, model_micro_cluster: mmc1)
+
+    expect do subject.perform(model.id) end.to change(
+      Pens::AssignBrand.jobs,
+      :count
+    ).by(1)
+  end
 end


### PR DESCRIPTION
When the pen model background job updates the data, it also now kicks off the `Pens::AssignBrand` job that assigns a pen brand when none has been set, yet.