### PR TITLE
Only require brand model and color for micro clusters

### DIFF
--- a/app/workers/pens/assign_micro_cluster.rb
+++ b/app/workers/pens/assign_micro_cluster.rb
@@ -44,9 +44,7 @@ module Pens
     end
 
     def default_attributes(collected_pen)
-      %i[brand model color material trim_color filling_system].each_with_object(
-        {}
-      ) do |attribute, hash|
+      %i[brand model color].each_with_object({}) do |attribute, hash|
         search_key = "simplified_#{attribute}"
         search_value = Simplifier.simplify(collected_pen.send(attribute) || "")
         hash[search_key] = search_value

--- a/db/migrate/20240911074804_relax_pen_micro_cluster_rules.rb
+++ b/db/migrate/20240911074804_relax_pen_micro_cluster_rules.rb
@@ -1,0 +1,7 @@
+class RelaxPenMicroClusterRules < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null(:pens_micro_clusters, :simplified_material, true)
+    change_column_null(:pens_micro_clusters, :simplified_trim_color, true)
+    change_column_null(:pens_micro_clusters, :simplified_filling_system, true)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -643,9 +643,9 @@ CREATE TABLE public.pens_micro_clusters (
     simplified_brand text NOT NULL,
     simplified_model text NOT NULL,
     simplified_color text NOT NULL,
-    simplified_material text NOT NULL,
-    simplified_trim_color text NOT NULL,
-    simplified_filling_system text NOT NULL,
+    simplified_material text,
+    simplified_trim_color text,
+    simplified_filling_system text,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL,
     ignored boolean DEFAULT false,
@@ -1991,6 +1991,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240911074804'),
 ('20240821105438'),
 ('20240811095146'),
 ('20240612132332'),


### PR DESCRIPTION
Having all these extra field to pick a micro cluster means that there is a lot more manual work to do than what is actually necessary in practice.