### PR TITLE
Use brand synonyms in clustering

### DIFF
--- a/app/models/pens/brand.rb
+++ b/app/models/pens/brand.rb
@@ -12,6 +12,10 @@ class Pens::Brand < ApplicationRecord
     ([name] + models.pluck(:brand)).uniq.sort
   end
 
+  def simplified_names
+    names.map { |n| Simplifier.simplify(n) }
+  end
+
   def update_name!
     grouped =
       models

--- a/app/workers/pens/assign_micro_cluster.rb
+++ b/app/workers/pens/assign_micro_cluster.rb
@@ -26,7 +26,19 @@ module Pens
       unless attrs["simplified_model"] == attrs["simplified_brand"]
         attrs["simplified_model"].delete_prefix!(attrs["simplified_brand"])
       end
+      expand_brand_names!(collected_pen, attrs)
       attrs
+    end
+
+    def expand_brand_names!(collected_pen, attrs)
+      brand =
+        Pens::Model
+          .where.not(pen_brand: nil)
+          .find_by(brand: collected_pen.brand)
+          &.pen_brand
+      return unless brand
+
+      attrs["simplified_brand"] = brand.simplified_names
     end
 
     def handle_clear!(attrs)

--- a/spec/workers/pens/assign_micro_cluster_spec.rb
+++ b/spec/workers/pens/assign_micro_cluster_spec.rb
@@ -57,6 +57,26 @@ describe Pens::AssignMicroCluster do
       expect(collected_pen.pens_micro_cluster).to eq(cluster)
     end
 
+    it "finds the cluster even for brand synonym" do
+      collected_pen.update!(
+        brand: "Synonym Brand",
+        model: "Model",
+        color: "Color",
+        material: "Material",
+        trim_color: "Trim Color",
+        filling_system: "Filling System"
+      )
+
+      pen_brand = create(:pens_brand, name: "Brand")
+      pen_model = create(:pens_model, brand: "Synonym Brand", pen_brand:)
+      expect { subject.perform(collected_pen.id) }.not_to change(
+        Pens::MicroCluster,
+        :count
+      )
+      collected_pen.reload
+      expect(collected_pen.pens_micro_cluster).to eq(cluster)
+    end
+
     it "schedules the cluster update job" do
       expect { subject.perform(collected_pen.id) }.to change(
         Pens::UpdateMicroCluster.jobs,


### PR DESCRIPTION
When clustering pens into model variants, make use of the already existing clustering of pen brands.