### PR TITLE
Spam tracking

### DIFF
--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -17,26 +17,17 @@ class Admins::UsersController < Admins::BaseController
       CollectedInk
         .group(:user_id)
         .select("user_id, count(id)")
-        .reduce({}) do |acc, el|
-          acc[el.user_id] = el.count
-          acc
-        end
+        .each_with_object({}) { |el, acc| acc[el.user_id] = el.count }
     @pen_counts =
       CollectedPen
         .group(:user_id)
         .select("user_id, count(id)")
-        .reduce({}) do |acc, el|
-          acc[el.user_id] = el.count
-          acc
-        end
+        .each_with_object({}) { |el, acc| acc[el.user_id] = el.count }
     @ci_counts =
       CurrentlyInked
         .group(:user_id)
         .select("user_id, max(inked_on) as inked_on, count(id)")
-        .reduce({}) do |acc, el|
-          acc[el.user_id] = el.count
-          acc
-        end
+        .each_with_object({}) { |el, acc| acc[el.user_id] = el.count }
   end
 
   def show
@@ -100,14 +91,18 @@ class Admins::UsersController < Admins::BaseController
 
   def destroy
     user = User.find(params[:id])
-    user.destroy!
-    flash[:notice] = "User deleted"
+    user.update(
+      review_blurb: false,
+      spam: true,
+      spam_reason: "manually-marked-as-spam"
+    )
+    flash[:notice] = "User marked as spam"
     redirect_to to_review_admins_users_path
   end
 
   def approve
     user = User.find(params[:id])
-    user.update(review_blurb: false)
+    user.update(review_blurb: false, spam: false)
     flash[:notice] = "Blurb reviewed"
     redirect_to to_review_admins_users_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = User.where(spam: false).find(params[:id])
 
     add_breadcrumb "#{@user.name}", user_path(@user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@ class User < ApplicationRecord
   end
 
   def self.public
-    where.not(name: [nil, ""])
+    where.not(name: [nil, ""]).where(spam: false)
   end
 
   def self.bots

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ApplicationRecord
     where(bot: true)
   end
 
+  def self.spammer
+    where(spam: true)
+  end
+
   def self.to_review
     where(review_blurb: true)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,10 @@ class User < ApplicationRecord
     where(review_blurb: true)
   end
 
+  def active_for_authentication?
+    super and !spam?
+  end
+
   def sign_up_ip=(value)
     ip_count =
       self

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -17,6 +17,8 @@ table class="table table-striped"
                   |  )
           tr
             td= "(#{@stats.patron_count} Patrons)"
+          tr
+            td= "(#{User.spammer.count} spam accounts)"
     tr
       td Number of ink brands
       td= BrandCluster.count

--- a/app/views/admins/users/to_review.html.slim
+++ b/app/views/admins/users/to_review.html.slim
@@ -26,4 +26,4 @@
     dt class="col-sm-3" Actions
     dd class="col-sm-9"
       = link_to "Approve",  approve_admins_user_path(user), method: :put, class: 'btn btn-success me-2'
-      = link_to "Delete User", admins_user_path(user), method: :delete, class: 'btn btn-secondary', confirm: 'Really delete?'
+      = link_to "Mark as spam", admins_user_path(user), method: :delete, class: 'btn btn-secondary', confirm: 'Really delete?'

--- a/db/migrate/20240916060008_add_spam_fields_to_user.rb
+++ b/db/migrate/20240916060008_add_spam_fields_to_user.rb
@@ -1,0 +1,11 @@
+class AddSpamFieldsToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :spam, :boolean, default: false
+    add_column :users, :spam_reason, :string, default: ""
+
+    safety_assured do
+      add_index :users, :spam
+      add_index :users, :spam_reason
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -879,7 +879,9 @@ CREATE TABLE public.users (
     sign_up_ip character varying,
     bot_reason character varying,
     admin boolean DEFAULT false,
-    review_blurb boolean DEFAULT false
+    review_blurb boolean DEFAULT false,
+    spam boolean DEFAULT false,
+    spam_reason character varying DEFAULT ''::character varying
 );
 
 
@@ -1739,6 +1741,20 @@ CREATE UNIQUE INDEX index_users_on_reset_password_token ON public.users USING bt
 
 
 --
+-- Name: index_users_on_spam; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_spam ON public.users USING btree (spam);
+
+
+--
+-- Name: index_users_on_spam_reason; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_spam_reason ON public.users USING btree (spam_reason);
+
+
+--
 -- Name: index_versions_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1988,6 +2004,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20240916060008'),
 ('20240911151651'),
 ('20240911151335'),
 ('20240911074804'),

--- a/spec/requests/admins/users_controller_spec.rb
+++ b/spec/requests/admins/users_controller_spec.rb
@@ -110,7 +110,7 @@ describe Admins::UsersController do
         pen =
           create(
             :collected_pen,
-            user: user,
+            user:,
             brand: "PenBBS",
             model: "456",
             nib: "F",
@@ -124,7 +124,7 @@ describe Admins::UsersController do
                }
           expect(ImportCollectedPen.jobs.size).to eq(1)
           ImportCollectedPen.drain
-        end.not_to change { user.collected_pens.count }
+        end.not_to(change { user.collected_pens.count })
 
         expect(pen.reload.comment).to eq("comment")
       end
@@ -187,11 +187,12 @@ describe Admins::UsersController do
     context "signed in" do
       before(:each) { sign_in(admin) }
 
-      it "deletes the user" do
-        expect do delete "/admins/users/#{user.id}" end.to change(
-          User,
-          :count
-        ).by(-1)
+      it "marks user as spam" do
+        delete "/admins/users/#{user.id}"
+        user.reload
+        expect(user.review_blurb).to be false
+        expect(user).to be_spam
+        expect(user.spam_reason).to eq("manually-marked-as-spam")
       end
 
       it "redirects to the review page" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -17,6 +17,13 @@ describe UsersController do
       expect(response.body).to_not include("/users/#{user.id}")
     end
 
+    it "does not include users marked as spam" do
+      user = create(:user, name: "a name", spam: true)
+      get "/users"
+      expect(response).to be_successful
+      expect(response.body).to_not include("/users/#{user.id}")
+    end
+
     it "shows the patreon logo next to the correct user" do
       user = create(:user, name: "the name", patron: true)
       get "/users"
@@ -86,6 +93,19 @@ describe UsersController do
       expect(response).to be_successful
       json = JSON.parse(response.body)
       expect(json["data"]["relationships"]["collected_inks"]["data"]).to eq([])
+    end
+
+    it "does not work for users marked as spam" do
+      user = create(:user, name: "the name", spam: true)
+      expect do get "/users/#{user.id}" end.to raise_error(
+        ActiveRecord::RecordNotFound
+      )
+    end
+
+    it "works for users without a user name" do
+      user = create(:user, name: "")
+      get "/users/#{user.id}"
+      expect(response).to be_successful
     end
   end
 end


### PR DESCRIPTION
Instead of deleting the spam accounts, mark them as such and forbid login as well as hide their public pages.