### PR TITLE
Speed up usage records page and export

### DIFF
--- a/app/controllers/usage_records_controller.rb
+++ b/app/controllers/usage_records_controller.rb
@@ -7,7 +7,10 @@ class UsageRecordsController < ApplicationController
 
   def index
     @usage_records =
-      current_user.usage_records.order("used_on DESC, currently_inked_id")
+      current_user
+        .usage_records
+        .includes(currently_inked: %i[collected_ink collected_pen])
+        .order("used_on DESC, currently_inked_id")
     respond_to do |format|
       format.html { @usage_records = @usage_records.page(params[:page]) }
       format.csv do


### PR DESCRIPTION
Add missing includes to avoid N+1 queries. This was especially problematic for the CSV export.