### PR TITLE
Pen detail pages

### DIFF
--- a/app/controllers/api/v1/collected_pens_controller.rb
+++ b/app/controllers/api/v1/collected_pens_controller.rb
@@ -18,7 +18,10 @@ class Api::V1::CollectedPensController < Api::V1::BaseController
             .includes(
               :currently_inkeds,
               :usage_records,
-              newest_currently_inked: :last_usage
+              newest_currently_inked: :last_usage,
+              pens_micro_cluster: {
+                model_variant: :model_micro_cluster
+              }
             )
             .order("brand, model, nib, color, comment")
         relation = filter(relation)

--- a/app/controllers/api/v1/currently_inked_controller.rb
+++ b/app/controllers/api/v1/currently_inked_controller.rb
@@ -17,7 +17,12 @@ class Api::V1::CurrentlyInkedController < Api::V1::BaseController
             :usage_records,
             :collected_pen,
             :last_usage,
-            collected_ink: :micro_cluster
+            collected_ink: :micro_cluster,
+            collected_pen: {
+              pens_micro_cluster: {
+                model_variant: :model_micro_cluster
+              }
+            }
           )
         relation = filter(relation)
         relation.page(params.dig(:page, :number)).per(params.dig(:page, :size))
@@ -86,7 +91,7 @@ class Api::V1::CurrentlyInkedController < Api::V1::BaseController
     if params.dig(:fields, :collected_pen).present?
       params[:fields][:collected_pen].split(",").map(&:strip)
     else
-      %i[brand model nib color]
+      %i[brand model nib color model_id]
     end
   end
 

--- a/app/controllers/pen_brands_controller.rb
+++ b/app/controllers/pen_brands_controller.rb
@@ -1,0 +1,13 @@
+class PenBrandsController < ApplicationController
+  add_breadcrumb "Pens", "/pen_brands"
+
+  def index
+    @brands = Pens::Brand.public.order(:name)
+  end
+
+  def show
+    @brand = Pens::Brand.public.find(params[:id])
+    @models = @brand.public_models.includes(:collected_pens).order(:model)
+    add_breadcrumb @brand.name, pen_brand_path(@brand)
+  end
+end

--- a/app/controllers/pen_models_controller.rb
+++ b/app/controllers/pen_models_controller.rb
@@ -1,0 +1,11 @@
+class PenModelsController < ApplicationController
+  add_breadcrumb "Pens", "/pen_brands"
+
+  def show
+    @model = Pens::Model.find(params[:id])
+    @brand = @model.pen_brand
+    @variants = @model.model_variants.includes(:collected_pens).ordered
+    add_breadcrumb @brand.name, pen_brand_path(@brand)
+    add_breadcrumb @model.model, pen_brand_pen_model_path(@brand, @model)
+  end
+end

--- a/app/controllers/pen_models_controller.rb
+++ b/app/controllers/pen_models_controller.rb
@@ -7,5 +7,9 @@ class PenModelsController < ApplicationController
     @variants = @model.model_variants.includes(:collected_pens).ordered
     add_breadcrumb @brand.name, pen_brand_path(@brand)
     add_breadcrumb @model.model, pen_brand_pen_model_path(@brand, @model)
+
+    unless params[:pen_brand_id]
+      redirect_to pen_brand_pen_model_path(@brand, @model)
+    end
   end
 end

--- a/app/javascript/src/collected_pens/cards/PenCard.jsx
+++ b/app/javascript/src/collected_pens/cards/PenCard.jsx
@@ -30,6 +30,7 @@ export const PenCard = (props) => {
     id,
     brand,
     model,
+    model_id,
     nib,
     color,
     material,
@@ -51,7 +52,17 @@ export const PenCard = (props) => {
   return (
     <Card className="fpc-pen-card">
       <Card.Body>
-        <Card.Title>{fullName}</Card.Title>
+        <Card.Title>
+          {fullName}
+          {model_id && (
+            <>
+              {" "}
+              <a href={`/pen_models/${model_id}`}>
+                <i className="fa fa-external-link"></i>
+              </a>
+            </>
+          )}
+        </Card.Title>
         {isVisible("comment") ? <Card.Text>{comment}</Card.Text> : null}
         {isVisible("color") ? (
           <>

--- a/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
+++ b/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
@@ -26,6 +26,27 @@ export const CollectedPensTable = ({ pens, onLayoutChange }) => {
       {
         Header: "Model",
         accessor: "model",
+        Cell: ({
+          cell: {
+            value,
+            row: {
+              original: { model_id }
+            }
+          }
+        }) => {
+          if (model_id) {
+            return (
+              <span>
+                {value}{" "}
+                <a href={`/pen_models/${model_id}`}>
+                  <i className="fa fa-external-link"></i>
+                </a>
+              </span>
+            );
+          } else {
+            return <span>{value}</span>;
+          }
+        },
         Footer: (info) => {
           return <span>{info.rows.length} pens</span>;
         }

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
@@ -50,7 +50,8 @@ export const CurrentlyInkedCard = (props) => {
     pen_name,
     refillable,
     used_today,
-    collected_ink: { color }
+    collected_ink: { color },
+    collected_pen: { model_id }
   } = props;
 
   const isVisible = (field) => props[field] && !hiddenFields.includes(field);
@@ -67,7 +68,17 @@ export const CurrentlyInkedCard = (props) => {
         {isVisible("pen_name") ? (
           <>
             <div className="small text-secondary">Pen</div>
-            <Card.Text>{pen_name}</Card.Text>
+            <Card.Text>
+              {pen_name}
+              {model_id && (
+                <>
+                  {" "}
+                  <a href={`/pen_models/${model_id}`}>
+                    <i className="fa fa-external-link"></i>
+                  </a>
+                </>
+              )}
+            </Card.Text>
           </>
         ) : null}
         {isVisible("inked_on") ? (

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.spec.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.spec.jsx
@@ -28,7 +28,8 @@ describe("<CurrentlyInkedCards />", () => {
       refillable: true,
       unarchivable: false,
       archived: false,
-      collected_ink: { color: "#ac54b5" }
+      collected_ink: { color: "#ac54b5" },
+      collected_pen: { model_id: 123 }
     }
   ];
 

--- a/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
+++ b/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
@@ -17,6 +17,29 @@ export const CurrentlyInkedTable = ({ currentlyInked, onLayoutChange }) => {
       {
         Header: "Pen",
         accessor: "pen_name",
+        Cell: ({
+          cell: {
+            value,
+            row: {
+              original: {
+                collected_pen: { model_id }
+              }
+            }
+          }
+        }) => {
+          if (model_id) {
+            return (
+              <span>
+                {value}{" "}
+                <a href={`/pen_models/${model_id}`}>
+                  <i className="fa fa-external-link"></i>
+                </a>
+              </span>
+            );
+          } else {
+            return <span>{value}</span>;
+          }
+        },
         Footer: ({ rows }) => {
           return <span>{rows.length} pens</span>;
         }

--- a/app/javascript/src/currently_inked/table/CurrentlyInkedTable.spec.jsx
+++ b/app/javascript/src/currently_inked/table/CurrentlyInkedTable.spec.jsx
@@ -27,7 +27,8 @@ describe("<CurrentlyInkedTable />", () => {
       refillable: true,
       unarchivable: false,
       archived: false,
-      collected_ink: { color: "#ac54b5" }
+      collected_ink: { color: "#ac54b5" },
+      collected_pen: { model_id: 123 }
     },
     {
       inked_on: "2023-01-15",
@@ -41,7 +42,8 @@ describe("<CurrentlyInkedTable />", () => {
       refillable: true,
       unarchivable: false,
       archived: false,
-      collected_ink: { color: "#000" }
+      collected_ink: { color: "#000" },
+      collected_pen: { model_id: null }
     }
   ];
 

--- a/app/models/leader_board.rb
+++ b/app/models/leader_board.rb
@@ -32,7 +32,7 @@ class LeaderBoard
           .includes(:collected_pens)
           .reject { |model| model.collected_pens.size.zero? }
           .map do |model|
-            { name: model.name, count: model.collected_pens.size }
+            { name: model.name, count: model.collected_pens.size, id: model.id }
           end
           .sort do |p1, p2|
             if p1[:count] == p2[:count]

--- a/app/models/pens/brand.rb
+++ b/app/models/pens/brand.rb
@@ -4,6 +4,30 @@ class Pens::Brand < ApplicationRecord
            class_name: "Pens::Model",
            dependent: :nullify
 
+  def self.public
+    hash = pluck(:id).hash
+    ids =
+      Rails
+        .cache
+        .fetch("#{self.class.name}#public-#{hash}", expires_in: 1.hour) do
+          joins(models: :collected_pens).group("pens_brands.id").pluck(:id)
+        end
+    where(id: ids)
+  end
+
+  def self.public_count
+    public.count
+  end
+
+  def public_models
+    ids = models.joins(:collected_pens).group("pens_models.id").pluck(:id)
+    models.where(id: ids)
+  end
+
+  def public_model_count
+    public_models.count
+  end
+
   def synonyms
     names - [name]
   end

--- a/app/models/pens/model.rb
+++ b/app/models/pens/model.rb
@@ -33,4 +33,12 @@ class Pens::Model < ApplicationRecord
   def name
     "#{brand} #{model}"
   end
+
+  def collected_pens_count
+    collected_pens.size
+  end
+
+  def model_variants_count
+    model_variants.size
+  end
 end

--- a/app/models/pens/model_variant.rb
+++ b/app/models/pens/model_variant.rb
@@ -28,4 +28,8 @@ class Pens::ModelVariant < ApplicationRecord
       "pens_model_variants.id"
     )
   end
+
+  def collected_pens_count
+    collected_pens.size
+  end
 end

--- a/app/serializers/collected_pen_serializer.rb
+++ b/app/serializers/collected_pen_serializer.rb
@@ -29,4 +29,7 @@ class CollectedPenSerializer
     object.inked?
   end
   attribute :created_at
+  attribute :model_id do |object|
+    object.pens_micro_cluster&.model_variant&.model_micro_cluster&.pens_model_id
+  end
 end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -12,6 +12,7 @@ nav class="fpc-header navbar navbar-dark navbar-expand-lg" id="header"
           a href="#" class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" Discover
           ul class="dropdown-menu"
             li= link_to "Inks", brands_path, class: "dropdown-item"
+            li= link_to "Pens", pen_brands_path, class: "dropdown-item"
             li= link_to "Missing reviews", missing_reviews_path, class: "dropdown-item"
             li= link_to "Missing descriptions", missing_descriptions_path, class: "dropdown-item"
 

--- a/app/views/pages/leaderboards.html.slim
+++ b/app/views/pages/leaderboards.html.slim
@@ -85,5 +85,7 @@
       p.text-muted Ranked by number of people who own this
       ol
         - LeaderBoard.top_pens_by_popularity.each do |pen|
-          li= "#{pen[:name]} (#{pen[:count]})"
+          li
+            = link_to pen[:name], pen_model_path(pen[:id])
+            = " (#{pen[:count]})"
       p= link_to "Show all", page_path("pens_by_popularity")

--- a/app/views/pages/pens_by_popularity.html.slim
+++ b/app/views/pages/pens_by_popularity.html.slim
@@ -10,4 +10,6 @@
 = cache params[:id], expires_in: 1.hour do
   ol class="fpc-leaderboard"
     - LeaderBoard.pens_by_popularity.each do |pen|
-      li="#{pen[:name]} (#{pen[:count]})"
+      li
+        = link_to pen[:name], pen_model_path(pen[:id])
+        = " (#{pen[:count]})"

--- a/app/views/pen_brands/index.html.slim
+++ b/app/views/pen_brands/index.html.slim
@@ -1,0 +1,8 @@
+- content_for :title, "Pen brands"
+
+h2.mt-5.mb-3 Browse
+p #{Pens::Brand.public_count} brands
+ol class="fpc-brands-list"
+  - @brands.each_with_index do |brand, i|
+    li
+      = link_to brand.name, pen_brand_path(brand)

--- a/app/views/pen_brands/show.html.slim
+++ b/app/views/pen_brands/show.html.slim
@@ -1,0 +1,22 @@
+- content_for :title, @brand.name
+- content_for :head
+  meta property="og:title" content=@brand.name
+  meta property="og:url" content=brand_url(@brand)
+
+div class="fpc-table fpc-table--full-width fpc-inks-table fpc-scroll-shadow"
+  table class="table table-striped"
+    caption
+      = "#{@brand.name} - #{@brand.public_model_count} models"
+    thead
+      tr
+        th Count
+        th Brand
+        th Model
+        th
+    tbody
+      - @models.each do |model|
+        tr
+          td= model.collected_pens_count
+          td= model.brand
+          td= model.model
+          td= link_to "Details", pen_brand_pen_model_path(@brand, model)

--- a/app/views/pen_models/show.html.slim
+++ b/app/views/pen_models/show.html.slim
@@ -1,0 +1,54 @@
+- content_for :title, @model.name
+
+div class="row fpc-ink-details"
+  div class="col-sm-12 col-md-6"
+    h2 class="h4" Details
+    div class="fpc-table fpc-table--full-width fpc-scroll-shadow"
+      table class="table"
+        tbody
+          tr
+            td Brand
+            td= link_to @brand.name, pen_brand_path(@brand)
+          tr
+            td Model
+            td= @model.model
+          tr
+            td Variant count
+            td= @model.model_variants_count
+          tr
+            td Owner count
+            td= @model.collected_pens_count
+
+  div class="col-sm-12 col-md-6"
+    div class="fpc-ink-details__error-reporting"
+      h3 class="h5" Errors
+      p
+        ' If there are any pens variants that don't belong here or if there is anything
+        ' else that is wrong, feel free to report this using the button below.
+        ' We will try to fix it as soon as possible.
+      = link_to "Report an error",
+                "mailto:clustering-error@fountainpencompanion.com?subject=#{@model.name}"
+
+  h2 Model variants
+
+  div class="fpc-table fpc-table--full-width fpc-scroll-shadow"
+    table class="table table-striped"
+      thead
+        tr
+          th Count
+          th Brand
+          th Model
+          th Color
+          th Material
+          th Trim Color
+          th Filling System
+      tbody
+        - @variants.each do |variant|
+          tr
+            td= variant.collected_pens_count
+            td= variant.brand
+            td= variant.model
+            td= variant.color
+            td= variant.material
+            td= variant.trim_color
+            td= variant.filling_system

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
   resources :pen_brands, only: %i[index show] do
     resources :pen_models, only: %i[show]
   end
+  resources :pen_models, only: %i[show]
 
   resources :inks, only: %i[index show] do
     resource :history, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,11 @@ Rails.application.routes.draw do
       resources :ink_review_submissions, only: [:create]
     end
   end
+
+  resources :pen_brands, only: %i[index show] do
+    resources :pen_models, only: %i[show]
+  end
+
   resources :inks, only: %i[index show] do
     resource :history, only: [:show]
   end

--- a/spec/requests/api/v1/currently_inked_spec.rb
+++ b/spec/requests/api/v1/currently_inked_spec.rb
@@ -87,7 +87,8 @@ describe Api::V1::CurrentlyInkedController do
                     brand: anything,
                     model: anything,
                     nib: anything,
-                    color: anything
+                    color: anything,
+                    model_id: anything
                   }
                 )
               ]


### PR DESCRIPTION
Add the first version of the pen details pages. There aren't that many details, yet, but it's good enough to go live. They are linked from the pens and currently inked sections as well as the pens leaderboard. The latter still needs the caches to expire to work correctly.