### PR TITLE
Smaller and faster requests

### DIFF
--- a/app/javascript/src/admin/micro-clusters/macroClusters.js
+++ b/app/javascript/src/admin/micro-clusters/macroClusters.js
@@ -68,7 +68,7 @@ export const updateMacroCluster = (id, dispatch) => {
 
 const loadMacroClusterPage = async (page) => {
   const response = await getRequest(
-    `/admins/macro_clusters.json?per_page=50&page=${page}`
+    `/admins/macro_clusters.json?per_page=25&page=${page}`
   );
   return await response.json();
 };


### PR DESCRIPTION
Some of the requests for ink clusters in the admin area take a really long time to complete. For now, let's just make more and smaller requests.