### PR TITLE
Load admin stats asynchronously

### DIFF
--- a/app/controllers/admins/stats_controller.rb
+++ b/app/controllers/admins/stats_controller.rb
@@ -1,0 +1,11 @@
+class Admins::StatsController < Admins::BaseController
+  def show
+    render json: statistic
+  end
+
+  private
+
+  def statistic
+    AdminStats.new.send(params[:id])
+  end
+end

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -9,6 +9,7 @@ import "./src/admin/micro-clusters";
 import "./src/admin/pens-micro-clusters";
 import "./src/admin/pens-model-micro-clusters";
 import "./src/admin/graphs";
+import "./src/admin/stats";
 
 [...document.querySelectorAll('[data-bs-toggle="tooltip"]')].map(
   (triggerEl) => new Tooltip(triggerEl)

--- a/app/javascript/src/admin/stats.jsx
+++ b/app/javascript/src/admin/stats.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const elements = document.querySelectorAll(".stats");
+  Array.from(elements).forEach((el) => {
+    const root = createRoot(el);
+    root.render(<Stat id={el.dataset.id} />);
+  });
+});
+
+const Stat = ({ id }) => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    async function load() {
+      const response = await fetch(`/admins/stats/${id}`);
+      const json = await response.json();
+      setData(json);
+      setLoading(false);
+    }
+    load();
+  });
+  if (loading) {
+    return (
+      <>
+        <i className="fa fa-spin fa-refresh" />
+        &nbsp;
+      </>
+    );
+  } else {
+    return <>{data} </>;
+  }
+};

--- a/app/models/admin_stats.rb
+++ b/app/models/admin_stats.rb
@@ -90,6 +90,50 @@ class AdminStats
     User.where(patron: true).count
   end
 
+  def spammer_count
+    User.spammer.count
+  end
+
+  def brand_cluster_count
+    BrandCluster.count
+  end
+
+  def collected_pens_count
+    CollectedPen.count
+  end
+
+  def pens_micro_clusters_count
+    Pens::MicroCluster.count
+  end
+
+  def pens_model_variants_count
+    Pens::ModelVariant.count
+  end
+
+  def pens_model_micro_clusters_count
+    Pens::ModelMicroCluster.count
+  end
+
+  def pens_models_count
+    Pens::Model.count
+  end
+
+  def pens_brands_count
+    Pens::Brand.count
+  end
+
+  def currently_inked_count
+    CurrentlyInked.count
+  end
+
+  def usage_records_count
+    UsageRecord.count
+  end
+
+  def ink_review_count
+    InkReview.count
+  end
+
   def users_using_collected_pens_count
     @users_using_collected_pens_count ||=
       User.joins(:collected_pens).group("users.id").count.count

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -9,23 +9,31 @@ table class="table table-striped"
         table
           tr
             td
-              = "#{@stats.user_count} confirmed users"
+              span(class="stats" data-id="user_count")
+              | confirmed users
               - if User.to_review.count.positive?
                 b
                   |   (
                   = link_to " #{User.to_review.count} users to review", to_review_admins_users_path
                   |  )
           tr
-            td= "(#{@stats.patron_count} Patrons)"
+            td
+              | (
+              span(class="stats" data-id="patron_count")
+              | Patrons)
           tr
-            td= "(#{User.spammer.count} spam accounts)"
+            td
+              | (
+              span(class="stats" data-id="spammer_count")
+              | spam accounts)
     tr
       td Number of ink brands
-      td= BrandCluster.count
+      td
+        span(class="stats" data-id="brand_cluster_count")
     tr
       td Number of macro clusters
       td
-        = @stats.macro_cluster_count
+        span(class="stats" data-id="macro_cluster_count")
         - if @stats.unassigned_macro_cluster_count.positive?
           b
             |   (
@@ -34,7 +42,7 @@ table class="table table-striped"
     tr
       td Number of micro clusters
       td
-        = @stats.micro_cluster_count
+        span(class="stats" data-id="micro_cluster_count")
         - if @stats.micro_clusters_to_assign_count.positive?
           b
             |   (
@@ -42,17 +50,20 @@ table class="table table-striped"
             |  )
     tr
       td Number of collected inks
-      td= @stats.collected_inks_count
+      td
+        span(class="stats" data-id="collected_inks_count")
 
     tr
       td Number of collected pens
       td
         table
           tr
-            td style="text-align:right"= CollectedPen.count
+            td style="text-align:right"
+              span(class="stats" data-id="collected_pens_count")
             td
           tr
-            td style="text-align:right"= Pens::MicroCluster.count
+            td style="text-align:right"
+              span(class="stats" data-id="pens_micro_clusters_count")
             td
               | &nbsp;
               | micro clusters
@@ -63,7 +74,8 @@ table class="table table-striped"
                   = link_to "#{@stats.pens_micro_clusters_to_assign_count} to assign", admins_pens_micro_clusters_path
                   |  )
           tr
-            td style="text-align:right"= @stats.relevant_pens_micro_clusters_count
+            td style="text-align:right"
+              span(class="stats" data-id="relevant_pens_micro_clusters_count")
             td
               | &nbsp;
               | micro clusters with more than one collected pen
@@ -85,12 +97,14 @@ table class="table table-striped"
                   = link_to "#{@stats.pens_micro_clusters_prio_to_assign_count(2)} to assign", admins_pens_micro_clusters_path(count: 2)
                   |  )
           tr
-            td style="text-align:right"= Pens::ModelVariant.count
+            td style="text-align:right"
+              span(class="stats" data-id="pens_model_variants_count")
             td
               | &nbsp;
               | model variants
           tr
-            td style="text-align:right"= Pens::ModelMicroCluster.count
+            td style="text-align:right"
+              span(class="stats" data-id="pens_model_micro_clusters_count")
             td
               | &nbsp;
               | model micro clusters
@@ -101,7 +115,8 @@ table class="table table-striped"
                   = link_to "#{@stats.pens_model_micro_clusters_to_assign_count} to assign", admins_pens_model_micro_clusters_path
                   |  )
           tr
-            td style="text-align:right"= Pens::Model.count
+            td style="text-align:right"
+              span(class="stats" data-id="pens_models_count")
             td
               | &nbsp;
               | models
@@ -112,7 +127,8 @@ table class="table table-striped"
                   = link_to "#{@stats.pens_models_to_assign_count} to assign", new_admins_pens_brand_cluster_path
                   |  )
           tr
-            td style="text-align:right"= Pens::Brand.count
+            td style="text-align:right"
+              span(class="stats" data-id="pens_brands_count")
             td
               | &nbsp;
               | brands
@@ -120,14 +136,16 @@ table class="table table-striped"
 
     tr
       td Number of "Currently Inked"
-      td= CurrentlyInked.count
+      td
+        span(class="stats" data-id="currently_inked_count")
     tr
       td Number of usage records
-      td= UsageRecord.count
+      td
+        span(class="stats" data-id="usage_records_count")
     tr
       td Number of ink reviews
       td
-        = InkReview.count
+        span(class="stats" data-id="ink_review_count")
         - if InkReview.queued.count.positive?
           b
             |  (

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
 
   namespace :admins do
     resource :dashboard, only: [:show]
+    resources :stats, only: [:show]
     resources :users, only: %i[index show update destroy] do
       collection { get "to_review" }
       member do


### PR DESCRIPTION
The admin dashboard needs to do a lot of SQL queries to gather all the data. Under higher load this makes the page super slow and sometimes it even runs into the 30s Heroku limit.

Now, we're loading all the data afterwards via JS.