### PR TITLE
Allow deletion of macro clusters with reviews

### DIFF
--- a/app/models/macro_cluster.rb
+++ b/app/models/macro_cluster.rb
@@ -11,6 +11,7 @@ class MacroCluster < ApplicationRecord
   has_many :collected_inks, through: :micro_clusters
   has_many :public_collected_inks, through: :micro_clusters
   has_many :ink_reviews, dependent: :destroy
+  has_many :ink_review_submissions, dependent: :destroy
   belongs_to :brand_cluster, optional: true
 
   paginates_per 100


### PR DESCRIPTION
Ink review submissions reference macro clusters, too. Due to the foreign key constraint, we need the `has_many` association. Otherwise the deletion will fail due to the foreign key constraint.