### PR TITLE
Prepare for adding a production build

### DIFF
--- a/config/docker/dev-entrypoint.sh
+++ b/config/docker/dev-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -ex
+
+cd /app
+
+
+bundle check || bundle install || true
+
+if [[ $@ =~ 'yarn' ]]
+then
+  yarn install --frozen-lockfile
+else
+  # Remove a potentially pre-existing server.pid for Rails.
+  rm -rf /app/tmp/pids/server.pid
+fi
+
+# Since we specified both an ENTRYPOINT and a CMD (which could be overwritten
+# by a "command"), Docker passes the CMD/command to the ENTRYPOINT script as
+# arguments.  So we can run the CMD/command with exec "$@".
+exec "$@"

--- a/config/docker/entrypoint.sh
+++ b/config/docker/entrypoint.sh
@@ -1,19 +1,4 @@
 #!/bin/sh -ex
 
 cd /app
-
-
-bundle check || bundle install || true
-
-if [[ $@ =~ 'yarn' ]]
-then
-  yarn install --frozen-lockfile
-else
-  # Remove a potentially pre-existing server.pid for Rails.
-  rm -rf /app/tmp/pids/server.pid
-fi
-
-# Since we specified both an ENTRYPOINT and a CMD (which could be overwritten
-# by a "command"), Docker passes the CMD/command to the ENTRYPOINT script as
-# arguments.  So we can run the CMD/command with exec "$@".
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ x-rails: &rails
   pull_policy: never
   tty: true
   stdin_open: true
-  build: .
+  build:
+    context: .
+    target: dev
   environment:
     NODE_ENV: development
     PORT: 80


### PR DESCRIPTION
Turn the dev build into a stage and use this in the docker compose file. This can then serve as the base for a leaner production build.