### PR TITLE
Serve static assets via infrastructure

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -50,6 +50,14 @@ method = "GET"
 timeout = "5s"
 path = "/"
 
+[[statics]]
+guest_path = "/app/public/assets"
+url_prefix = "/assets"
+
+[[statics]]
+guest_path = "/app/public/images"
+url_prefix = "/images"
+
 [[vm]]
 memory = '512mb'
 cpu_kind = 'shared'


### PR DESCRIPTION
That way the Rails processes are not blocked by serving static assets.