### PR TITLE
Less load when loading the admin dashboard

### DIFF
--- a/app/javascript/src/admin/graphs/BotSignUps.jsx
+++ b/app/javascript/src/admin/graphs/BotSignUps.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const BotSignUps = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/bot-signups.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/bot-signups.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/CollectedInks.jsx
+++ b/app/javascript/src/admin/graphs/CollectedInks.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const CollectedInks = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/collected-inks.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", () =>
+      getRequest("/admins/graphs/collected-inks.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/CollectedPens.jsx
+++ b/app/javascript/src/admin/graphs/CollectedPens.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const CollectedPens = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/collected-pens.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/collected-pens.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/CurrentlyInked.jsx
+++ b/app/javascript/src/admin/graphs/CurrentlyInked.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const CurrentlyInked = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/currently-inked.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/currently-inked.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/SignUps.jsx
+++ b/app/javascript/src/admin/graphs/SignUps.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const SignUps = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/signups.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/signups.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/Spam.jsx
+++ b/app/javascript/src/admin/graphs/Spam.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const Spam = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/spam.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/spam.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/UsageRecords.jsx
+++ b/app/javascript/src/admin/graphs/UsageRecords.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const UsageRecords = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/usage-records.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/usage-records.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/graphs/UserAgents.jsx
+++ b/app/javascript/src/admin/graphs/UserAgents.jsx
@@ -8,9 +8,11 @@ import { getRequest } from "../../fetch";
 export const UserAgents = () => {
   const [data, setData] = useState(null);
   useEffect(() => {
-    getRequest("/admins/graphs/user-agents.json")
-      .then((res) => res.json())
-      .then((json) => setData(json));
+    navigator.locks.request("admin-dashboard", async () =>
+      getRequest("/admins/graphs/user-agents.json")
+        .then((res) => res.json())
+        .then((json) => setData(json))
+    );
   }, []);
   if (data) {
     const options = {

--- a/app/javascript/src/admin/stats.jsx
+++ b/app/javascript/src/admin/stats.jsx
@@ -29,15 +29,14 @@ const Stat = ({ id, arg }) => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
-    async function load() {
+    navigator.locks.request("admin-dashboard", async () => {
       let url = `/admins/stats/${id}`;
       if (arg) url += `?arg=${arg}`;
       const response = await getRequest(url);
       const json = await response.json();
       setData(json);
       setLoading(false);
-    }
-    load();
+    });
   });
   if (loading) {
     return (
@@ -55,15 +54,14 @@ const ConditionalStat = ({ id, arg, href, template }) => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   useEffect(() => {
-    async function load() {
+    navigator.locks.request("admin-dashboard", async () => {
       let url = `/admins/stats/${id}`;
       if (arg) url += `?arg=${arg}`;
       const response = await getRequest(url);
       const json = await response.json();
       setData(json);
       setLoading(false);
-    }
-    load();
+    });
   });
   if (loading) {
     return (


### PR DESCRIPTION
To reduce the load on the system when using the admin dashboard page, we're now using a lock to make all requests one by one instead of many at the same time.