### PR TITLE
Fix add to collection button when many results

### DIFF
--- a/app/javascript/src/add-ink-button/app.jsx
+++ b/app/javascript/src/add-ink-button/app.jsx
@@ -1,18 +1,32 @@
 import React from "react";
 import { useState, useEffect } from "react";
+import TrackVisibility from "react-on-screen";
 import { getRequest, postRequest } from "../fetch";
 
-export const App = ({ macro_cluster_id, details }) => {
+export const App = ({ renderWhenInvisible, ...rest }) => {
+  if (renderWhenInvisible) {
+    return <InternalApp {...rest} isVisible={true} />;
+  }
+
+  return (
+    <TrackVisibility once partialVisibility>
+      {({ isVisible }) => <InternalApp {...rest} isVisible={isVisible} />}
+    </TrackVisibility>
+  );
+};
+
+const InternalApp = ({ macro_cluster_id, details, isVisible }) => {
   const [loading, setLoading] = useState(true);
   const [inCollection, setInCollection] = useState(false);
   useEffect(() => {
+    if (!isVisible) return;
     getRequest(`/collected_inks.json?filter[macro_cluster_id]=${macro_cluster_id}`)
       .then((response) => response.json())
       .then((json) => {
         setInCollection(json.data.length > 0);
         setLoading(false);
       });
-  }, [macro_cluster_id]);
+  }, [macro_cluster_id, isVisible]);
   if (loading) {
     return <Loader />;
   } else {

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -15,7 +15,7 @@ Rack::Attack.throttle("Mastodon", limit: 1, period: 1) do |request|
   "mastodon" if request.user_agent =~ /mastodon/i
 end
 
-Rack::Attack.throttle("general", limit: 100, period: 1.minute) do |request|
+Rack::Attack.throttle("general", limit: 180, period: 1.minute) do |request|
   request.ip unless request.path.starts_with?("/admins")
 end
 

--- a/spec/javascript/src/add-ink-button/add.spec.jsx
+++ b/spec/javascript/src/add-ink-button/add.spec.jsx
@@ -25,17 +25,17 @@ describe("App", () => {
 
   describe("ink already in collection", () => {
     it("shows the add button", async () => {
-      render(<App macro_cluster_id="in_collection" />);
+      render(<App macro_cluster_id="in_collection" renderWhenInvisible={true} />);
       await screen.findByText("Add again?");
     });
 
     it("has a different text for the detail view", async () => {
-      render(<App macro_cluster_id="in_collection" details={true} />);
+      render(<App macro_cluster_id="in_collection" details={true} renderWhenInvisible={true} />);
       await screen.findByText("Add additional entries to collection?");
     });
 
     it("clicking shows the type selector", async () => {
-      render(<App macro_cluster_id="in_collection" />);
+      render(<App macro_cluster_id="in_collection" renderWhenInvisible={true} />);
       await screen.findByText("Add again?");
       const user = userEvent.setup();
       await user.click(screen.getByText("Add again?"));
@@ -49,17 +49,17 @@ describe("App", () => {
 
   describe("ink not in collection", () => {
     it("shows the add button", async () => {
-      render(<App macro_cluster_id="missing" />);
+      render(<App macro_cluster_id="missing" renderWhenInvisible={true} />);
       await screen.findByText("Add to collection");
     });
 
     it("has the same text for detail view", async () => {
-      render(<App macro_cluster_id="missing" details={true} />);
+      render(<App macro_cluster_id="missing" details={true} renderWhenInvisible={true} />);
       await screen.findByText("Add to collection");
     });
 
     it("clicking shows the type selector", async () => {
-      render(<App macro_cluster_id="missing" />);
+      render(<App macro_cluster_id="missing" renderWhenInvisible={true} />);
       await screen.findByText("Add to collection");
       const user = userEvent.setup();
       await user.click(screen.getByText("Add to collection"));


### PR DESCRIPTION
When there are many results to a search, we would make a request to the backend for each of them. That could mean, that we are running into the rate limiting and then some of them would randomly not work.

So instead, let's just make requests for those that are on screen and also increase the rate limit somewhat.