### PR TITLE
Simplify the pen embeddings

### DIFF
--- a/app/workers/fetch_embedding.rb
+++ b/app/workers/fetch_embedding.rb
@@ -2,7 +2,7 @@ class FetchEmbedding
   include Sidekiq::Worker
   include Sidekiq::Throttled::Worker
 
-  sidekiq_throttle concurrency: { limit: 1 }
+  sidekiq_throttle concurrency: { limit: 2 }
 
   def perform(class_name, id)
     self.model = class_name.constantize.find_by(id: id)

--- a/app/workers/pens/update_model.rb
+++ b/app/workers/pens/update_model.rb
@@ -28,9 +28,7 @@ module Pens
 
     def update_embedding!
       embedding = model.pen_embedding || model.build_pen_embedding
-      names = ([model.name] + model.model_variants.map(&:name))
-      content = names.uniq.sort.map(&:inspect).join(" OR ")
-      embedding.update!(content: content)
+      embedding.update!(content: model.name)
     end
   end
 end

--- a/app/workers/pens/update_model_variant.rb
+++ b/app/workers/pens/update_model_variant.rb
@@ -36,9 +36,7 @@ module Pens
 
     def update_embedding!
       embedding = model_variant.pen_embedding || model_variant.build_pen_embedding
-      names = ([model_variant.name] + model_variant.all_names.map(&:pen_name))
-      content = names.uniq.sort.map(&:inspect).join(" OR ")
-      embedding.update!(content: content)
+      embedding.update!(content: model_variant.name)
     end
   end
 end

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,12 @@ codecov:
 
 comment:
   after_n_builds: 2
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%
+    patch:
+      default:
+        threshold: 0.2%

--- a/db/migrate/20250331082810_rerun_pen_embeddings.rb
+++ b/db/migrate/20250331082810_rerun_pen_embeddings.rb
@@ -1,0 +1,6 @@
+class RerunPenEmbeddings < ActiveRecord::Migration[8.0]
+  def change
+    Pens::ModelVariant.pluck(:id).each { |mv_id| Pens::UpdateModelVariant.perform_async(mv_id) }
+    Pens::Model.pluck(:id).each { |model_id| Pens::UpdateModel.perform_async(model_id) }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,20 +10,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: public; Type: SCHEMA; Schema: -; Owner: -
---
-
--- *not* creating schema, since initdb creates it
-
-
---
--- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON SCHEMA public IS '';
-
-
---
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -2079,6 +2065,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250331082810'),
 ('20250209193211'),
 ('20250206124945'),
 ('20250206102705'),

--- a/spec/workers/pens/update_model_spec.rb
+++ b/spec/workers/pens/update_model_spec.rb
@@ -51,21 +51,15 @@ describe Pens::UpdateModel do
         color: "red"
       )
     create(
-      :pens_model_variant,
-      model_micro_cluster: mmc1,
-      brand: "brand",
-      model: "model",
-      color: "green"
-    )
-    create(
       :pens_micro_cluster,
       model_variant: mv1,
       collected_pens: [create(:collected_pen, brand: "brand", model: "model")]
     )
 
     expect do subject.perform(model.id) end.to change { PenEmbedding.count }.by(1)
+
     pen_embedding = model.pen_embedding
-    expect(pen_embedding.content).to eq('"brand model" OR "brand model green" OR "brand model red"')
+    expect(pen_embedding.content).to eq("brand model")
   end
 
   it "updates the embedding when present" do
@@ -81,22 +75,13 @@ describe Pens::UpdateModel do
         color: "red"
       )
     create(
-      :pens_model_variant,
-      model_micro_cluster: mmc1,
-      brand: "brand",
-      model: "model",
-      color: "green"
-    )
-    create(
       :pens_micro_cluster,
       model_variant: mv1,
       collected_pens: [create(:collected_pen, brand: "brand", model: "model")]
     )
 
     expect do
-      expect do subject.perform(model.id) end.not_to change { PenEmbedding.count }
-    end.to change { pen_embedding.reload.content }.from("old content").to(
-      '"brand model" OR "brand model green" OR "brand model red"'
-    )
+      expect { subject.perform(model.id) }.not_to(change { PenEmbedding.count })
+    end.to change { pen_embedding.reload.content }.from("old content").to("brand model")
   end
 end

--- a/spec/workers/pens/update_model_variant_spec.rb
+++ b/spec/workers/pens/update_model_variant_spec.rb
@@ -133,7 +133,7 @@ describe Pens::UpdateModelVariant do
     expect do subject.perform(model_variant.id) end.to change { PenEmbedding.count }.by(1)
     pen_embedding = model_variant.pen_embedding
     expect(pen_embedding.content).to eq(
-      '"Brand 1 Model 1 Color 1 Material 1 Trim Color 1 Filling System 1" OR "Brand 1 Model 2 Color 1 Material 1 Trim Color 1 Filling System 1" OR "Brand 1 Model 2 Color 2 Material 1 Trim Color 1 Filling System 1"'
+      "Brand 1 Model 2 Color 1 Material 1 Trim Color 1 Filling System 1"
     )
   end
 
@@ -166,7 +166,7 @@ describe Pens::UpdateModelVariant do
     expect do
       expect { subject.perform(model_variant.id) }.not_to(change { PenEmbedding.count })
     end.to change { pen_embedding.reload.content }.from("old content").to(
-      "\"Brand 1 Model 1 Color 1 Material 1 Trim Color 1 Filling System 1\" OR \"Brand 1 Model 2 Color 1 Material 1 Trim Color 1 Filling System 1\""
+      "Brand 1 Model 1 Color 1 Material 1 Trim Color 1 Filling System 1"
     )
   end
 end


### PR DESCRIPTION
Instead of trying to include all variants in the naming, just use whatever name we're displaying and then be more fancy in the actual search.