### PR TITLE
Adjusted pen search

### DIFF
--- a/app/controllers/pen_models_controller.rb
+++ b/app/controllers/pen_models_controller.rb
@@ -2,7 +2,7 @@ class PenModelsController < ApplicationController
   add_breadcrumb "Pens", "/pen_brands"
 
   def index
-    @embeddings = Pens::Model.embedding_search(params[:q])
+    @model_data = Pens::Model.embedding_search(params[:q])
   end
 
   def show

--- a/app/models/collected_pen.rb
+++ b/app/models/collected_pen.rb
@@ -124,4 +124,8 @@ class CollectedPen < ApplicationRecord
   def pen_variant
     pens_micro_cluster&.model_variant
   end
+
+  def pen_model
+    pen_variant&.pen_model
+  end
 end

--- a/app/views/pen_models/index.html.slim
+++ b/app/views/pen_models/index.html.slim
@@ -10,9 +10,18 @@ div class="fpc-table fpc-table--full-width fpc-inks-table fpc-scroll-shadow"
         th Model
         th
     tbody
-      - @embeddings.each do |embedding|
-        - model = embedding.owner
+      - @model_data.each do |data|
+        - model = data.owner.pen_model
         tr
           td= model.brand
           td= model.model
           td= link_to "Details", pen_model_path(model)
+
+          - if data.model_variants.present?
+            tr
+              td colspan=3
+                table class="table table-striped"
+                  - data.model_variants.each do |model_variant|
+                    tr
+                      td= model_variant.name
+                      td= link_to "Details", pen_variant_path(model_variant)


### PR DESCRIPTION
Now that the embeddings do not contain all possible names anymore we need to includes searches in models, model variants, and collected pens. It's a bit of a mess and probably requires some extra work to remove the N+1 queries, but it is probably already better than before.