### PR TITLE
When having more than pen pen model name to choose from use the longest

### DIFF
--- a/app/workers/pens/update_model.rb
+++ b/app/workers/pens/update_model.rb
@@ -23,7 +23,15 @@ module Pens
     def best_attr_value(attr)
       attr_values = model.collected_pens.map { |cp| cp.send(attr) }.find_all { |v| v.present? }
       return "" if attr_values.empty?
-      attr_values.tally.max_by { |_k, v| v }.first || ""
+      # From all values with the most members, pick the one with the longest,
+      # i.e most specific, name.
+      attr_values
+        .tally
+        .group_by(&:last)
+        .max_by { |k, v| k }
+        .last
+        .max_by { |k, v| k.length }
+        .first || ""
     end
 
     def update_embedding!


### PR DESCRIPTION
This should reduce the number of clashes