### PR TITLE
Shorter running jobs with blog post publishing

### DIFF
--- a/app/workers/after_blog_post_published.rb
+++ b/app/workers/after_blog_post_published.rb
@@ -3,6 +3,9 @@ class AfterBlogPostPublished
 
   def perform(id)
     blog_post = BlogPost.find(id)
-    User.active.find_each { |user| user.reading_statuses.create!(blog_post: blog_post) }
+
+    User.active.find_each do |user|
+      AfterBlogPostPublishedForUser.perform_async(blog_post.id, user.id)
+    end
   end
 end

--- a/app/workers/after_blog_post_published_for_user.rb
+++ b/app/workers/after_blog_post_published_for_user.rb
@@ -1,0 +1,17 @@
+class AfterBlogPostPublishedForUser
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_throttle concurrency: { limit: 2 }
+  sidekiq_options queue: "low"
+
+  def perform(blog_post_id, user_id)
+    user = User.active.find_by(id: user_id)
+    return unless user
+
+    blog_post = BlogPost.find_by(id: blog_post_id)
+    return unless blog_post
+
+    user.reading_statuses.create!(blog_post: blog_post)
+  end
+end


### PR DESCRIPTION
With so many users, the job needs to be split into smaller jobs to avoid it taking too long (already > 30min with only about 8k users).