### PR TITLE
Add newlines to json output to make it easier to read

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,4 +17,8 @@ module ApplicationHelper
   def admin?
     current_user&.admin?
   end
+
+  def jsonify(object)
+    JSON.pretty_generate(object).gsub('\r\n', " ").gsub('\n', "\n")
+  end
 end

--- a/app/views/admins/agent_logs/index.html.slim
+++ b/app/views/admins/agent_logs/index.html.slim
@@ -19,7 +19,7 @@
 
     dt class="col-sm-3" Extra Data
     dd class="col-sm-9"
-      pre= JSON.pretty_generate(agent_log.extra_data)
+      pre= jsonify(agent_log.extra_data)
 
     - if  agent_log.owner
       dt class="col-sm-3" Owner
@@ -29,7 +29,7 @@
     dt class="col-sm-3" Transcript
     dd class="col-sm-9"
       - agent_log.transcript.each do |transcript|
-        pre= JSON.pretty_generate(transcript)
+        pre= jsonify(transcript)
 
 
 = paginate @agent_logs

--- a/app/views/admins/agents/ink_clusterer/index.html.slim
+++ b/app/views/admins/agents/ink_clusterer/index.html.slim
@@ -56,7 +56,7 @@ table class="table"
           b= action
       dt class="col-sm-3" Extra Data
       dd class="col-sm-9"
-        pre= JSON.pretty_generate(agent_log.extra_data)
+        pre= jsonify(agent_log.extra_data)
 
     - unless agent_log.processing?
       dt class="col-sm-3" Owner
@@ -81,6 +81,6 @@ table class="table"
     dt class="col-sm-3" Transcript
     dd class="col-sm-9"
       - agent_log.transcript.each do |transcript|
-        pre= JSON.pretty_generate(transcript)
+        pre= jsonify(transcript)
 
 = paginate @agent_logs


### PR DESCRIPTION
Probably the better solution would be to show each pair of key/value on its own line, but this is a quick improvement for now.