### PR TITLE
Redirect to login page on 401 responses

### DIFF
--- a/app/javascript/src/fetch.js
+++ b/app/javascript/src/fetch.js
@@ -40,6 +40,10 @@ async function req(path, method, body, retries = 5) {
     }
     throw error;
   }
+  if (response.status === 401) {
+    window.location.href = "/users/sign_in";
+    return;
+  }
   const failure = !response.ok;
   if (method === "GET" && failure && retries > 0) {
     console.log("Retrying", path, method, body, retries);


### PR DESCRIPTION
## Summary

- When the backend returns a 401 Unauthorized (e.g. expired session), the frontend now redirects to `/users/sign_in` instead of silently failing
- The check is added in the centralized fetch wrapper (`app/javascript/src/fetch.js`) so all React components are covered
- 401 responses are intercepted before retry logic, so they are never retried