### PR TITLE
Fix frontend error handling

### DIFF
--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
@@ -51,12 +51,13 @@ export const CurrentlyInkedCard = (props) => {
     refillable,
     used_today,
     onUsageRecorded,
-    collected_ink: {
-      color,
-      micro_cluster: { macro_cluster }
-    },
-    collected_pen: { model_variant_id }
+    collected_ink,
+    collected_pen
   } = props;
+
+  const color = collected_ink.color;
+  const macro_cluster = collected_ink.micro_cluster?.macro_cluster;
+  const model_variant_id = collected_pen?.model_variant_id;
 
   const isVisible = (field) => props[field] && !hiddenFields.includes(field);
 

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.spec.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.spec.jsx
@@ -72,4 +72,58 @@ describe("<SwabCard />", () => {
     expect(queryByText("Inked")).not.toBeInTheDocument();
     expect(queryByText("Last used")).not.toBeInTheDocument();
   });
+
+  it("renders without crashing when micro_cluster is null", () => {
+    const { getByText } = setup(
+      <CurrentlyInkedCard
+        id="1"
+        archived={false}
+        ink_name="Black"
+        inked_on="2023-06-19"
+        pen_name="Pilot Metropolitan"
+        refillable={true}
+        used_today={true}
+        collected_ink={{
+          id: "1",
+          color: "#000",
+          micro_cluster: null
+        }}
+        collected_pen={{
+          id: "1"
+        }}
+        hiddenFields={[]}
+      />
+    );
+
+    expect(getByText("Black")).toBeInTheDocument();
+  });
+
+  it("renders ink link when macro_cluster is present", () => {
+    const { container } = setup(
+      <CurrentlyInkedCard
+        id="1"
+        archived={false}
+        ink_name="Black"
+        inked_on="2023-06-19"
+        pen_name="Pilot Metropolitan"
+        refillable={true}
+        used_today={true}
+        collected_ink={{
+          id: "1",
+          color: "#000",
+          micro_cluster: {
+            id: "1",
+            macro_cluster: { id: "42" }
+          }
+        }}
+        collected_pen={{
+          id: "1"
+        }}
+        hiddenFields={[]}
+      />
+    );
+
+    const link = container.querySelector('a[href="/inks/42"]');
+    expect(link).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Redirect to the login page on 401 API responses instead of letting them bubble up as unhandled errors
- Fix crash in the currently inked card view when `micro_cluster` is null (unclustered inks) by using optional chaining, matching the safe pattern already used in the table view