### PR TITLE
Add periodic ink review link checker

### DIFF
--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -139,7 +139,7 @@ class ReviewApprover
     {
       name: cluster.name,
       synonyms: cluster.synonyms,
-      number_of_reviews: cluster.ink_reviews.approved.size
+      number_of_reviews: cluster.ink_reviews.live.size
     }
   end
 

--- a/app/controllers/admins/graphs_controller.rb
+++ b/app/controllers/admins/graphs_controller.rb
@@ -20,11 +20,19 @@ class Admins::GraphsController < Admins::BaseController
         agents
       when "agent-usage"
         agent_usage
+      when "ink-review-checks"
+        ink_review_checks
       end
     render json: data
   end
 
   private
+
+  def ink_review_checks
+    InkReviewCheck::RESULTS.map do |result|
+      { name: result.titleize, data: build(InkReviewCheck.where(result: result), range: 1.month) }
+    end
+  end
 
   def signups
     [

--- a/app/javascript/src/admin/graphs/InkReviewChecks.jsx
+++ b/app/javascript/src/admin/graphs/InkReviewChecks.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from "react";
+import Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+
+import { Spinner } from "../components/Spinner";
+import { getRequest } from "../../fetch";
+
+export const InkReviewChecks = () => {
+  const [data, setData] = useState(null);
+  useEffect(() => {
+    const fetchData = () => {
+      navigator.locks.request("admin-dashboard", async () =>
+        getRequest("/admins/graphs/ink-review-checks.json")
+          .then((res) => res.json())
+          .then((json) => setData(json))
+      );
+    };
+    fetchData();
+    const interval = setInterval(fetchData, 1000 * 30);
+    return () => clearInterval(interval);
+  }, []);
+  if (data) {
+    const options = {
+      chart: { type: "column" },
+      legend: { enabled: true },
+      series: data,
+      title: { text: "Ink review checks per day" },
+      xAxis: {
+        type: "datetime"
+      },
+      yAxis: { title: { text: "" } },
+      plotOptions: {
+        column: {
+          stacking: "normal"
+        }
+      }
+    };
+    return (
+      <div>
+        <HighchartsReact highcharts={Highcharts} options={options} />
+      </div>
+    );
+  } else {
+    return (
+      <div>
+        <Spinner />
+      </div>
+    );
+  }
+};

--- a/app/javascript/src/admin/graphs/index.jsx
+++ b/app/javascript/src/admin/graphs/index.jsx
@@ -10,6 +10,7 @@ import { UsageRecords } from "./UsageRecords";
 // import { Spam } from "./Spam";
 import { Agents } from "./Agents";
 import { AgentUsage } from "./AgentUsage";
+import { InkReviewChecks } from "./InkReviewChecks";
 import { ErrorBoundary } from "../../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -107,6 +108,18 @@ document.addEventListener("DOMContentLoaded", () => {
     root.render(
       <ErrorBoundary>
         <UsageRecords />
+      </ErrorBoundary>
+    );
+  }
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("ink-review-checks-graph");
+  if (el) {
+    const root = createRoot(el);
+    root.render(
+      <ErrorBoundary>
+        <InkReviewChecks />
       </ErrorBoundary>
     );
   }

--- a/app/models/ink_review.rb
+++ b/app/models/ink_review.rb
@@ -1,7 +1,12 @@
 class InkReview < ApplicationRecord
+  CHECK_INTERVAL = 2.months
+  RETRY_INTERVAL = 24.hours
+  MAX_FAILED_CHECKS = 5
+
   belongs_to :macro_cluster
   belongs_to :you_tube_channel, optional: true
   has_many :ink_review_submissions, dependent: :destroy
+  has_many :ink_review_checks, dependent: :destroy
   has_many :agent_logs, as: :owner, dependent: :destroy
 
   paginates_per 1
@@ -17,13 +22,19 @@ class InkReview < ApplicationRecord
   scope :processed, -> { where.not(approved_at: nil).or(where.not(rejected_at: nil)) }
   scope :manually_processed, -> { processed.where(agent_approved: false) }
   scope :agent_processed, -> { processed.where(agent_approved: true) }
+  scope :live, -> { approved.where(check_count: 0) }
+  scope :due_for_check, -> { approved.where("next_check_at <= ?", Time.zone.now) }
+  scope :link_broken, -> { where("check_count > 0 AND check_count < ?", MAX_FAILED_CHECKS) }
+  scope :link_removed, -> { where("check_count >= ?", MAX_FAILED_CHECKS) }
 
   def reject!
     update!(
       rejected_at: Time.zone.now,
       approved_at: nil,
       agent_approved: false,
-      auto_approved: false
+      auto_approved: false,
+      next_check_at: nil,
+      check_count: 0
     )
   end
 
@@ -32,24 +43,50 @@ class InkReview < ApplicationRecord
       approved_at: Time.zone.now,
       rejected_at: nil,
       agent_approved: false,
-      auto_approved: false
+      auto_approved: false,
+      next_check_at: CHECK_INTERVAL.from_now,
+      check_count: 0
     )
   end
 
   def auto_approve!
-    update(approved_at: Time.zone.now, rejected_at: nil, auto_approved: true)
+    update(
+      approved_at: Time.zone.now,
+      rejected_at: nil,
+      auto_approved: true,
+      next_check_at: CHECK_INTERVAL.from_now,
+      check_count: 0
+    )
   end
 
   def auto_reject!
-    update(rejected_at: Time.zone.now, approved_at: nil, auto_approved: true)
+    update(
+      rejected_at: Time.zone.now,
+      approved_at: nil,
+      auto_approved: true,
+      next_check_at: nil,
+      check_count: 0
+    )
   end
 
   def agent_approve!
-    update(approved_at: Time.zone.now, rejected_at: nil, agent_approved: true)
+    update(
+      approved_at: Time.zone.now,
+      rejected_at: nil,
+      agent_approved: true,
+      next_check_at: CHECK_INTERVAL.from_now,
+      check_count: 0
+    )
   end
 
   def agent_reject!
-    update(rejected_at: Time.zone.now, approved_at: nil, agent_approved: true)
+    update(
+      rejected_at: Time.zone.now,
+      approved_at: nil,
+      agent_approved: true,
+      next_check_at: nil,
+      check_count: 0
+    )
   end
 
   def url=(value)
@@ -77,7 +114,7 @@ class InkReview < ApplicationRecord
     return unless you_tube_short?
     return unless user.admin?
 
-    macro_cluster.ink_reviews.approved.exists?
+    macro_cluster.ink_reviews.live.exists?
   end
 
   private

--- a/app/models/ink_review_check.rb
+++ b/app/models/ink_review_check.rb
@@ -1,0 +1,7 @@
+class InkReviewCheck < ApplicationRecord
+  RESULTS = %w[success error removed].freeze
+
+  belongs_to :ink_review
+
+  validates :result, inclusion: { in: RESULTS }
+end

--- a/app/models/macro_cluster.rb
+++ b/app/models/macro_cluster.rb
@@ -228,7 +228,7 @@ class MacroCluster < ApplicationRecord
   end
 
   def approved_ink_reviews
-    ink_reviews.approved
+    ink_reviews.live
   end
 
   def public_collected_inks_count

--- a/app/operations/ink_review_checker.rb
+++ b/app/operations/ink_review_checker.rb
@@ -1,0 +1,56 @@
+class InkReviewChecker
+  def initialize(ink_review)
+    self.ink_review = ink_review
+  end
+
+  def perform
+    page_data = Unfurler.new(ink_review.url).perform
+    unless image_reachable?(page_data.image)
+      record_failure("Image unreachable")
+      return
+    end
+
+    ink_review.assign_attributes(
+      title: page_data.title,
+      description: page_data.description,
+      image: page_data.image,
+      author: page_data.author
+    )
+    if ink_review.save
+      record_success
+    else
+      error_message = ink_review.errors.full_messages.join(", ")
+      ink_review.reload
+      record_failure(error_message)
+    end
+  rescue URI::InvalidURIError, Faraday::Error, Google::Apis::Error => e
+    record_failure(e.message)
+  end
+
+  private
+
+  attr_accessor :ink_review
+
+  def image_reachable?(url)
+    return false if url.blank?
+    Faraday.new { |c| c.response :follow_redirects }.head(url).success?
+  rescue Faraday::Error
+    false
+  end
+
+  def record_success
+    ink_review.update!(check_count: 0, next_check_at: InkReview::CHECK_INTERVAL.from_now)
+    ink_review.ink_review_checks.create!(result: "success")
+  end
+
+  def record_failure(message)
+    new_count = ink_review.check_count + 1
+    if new_count >= InkReview::MAX_FAILED_CHECKS
+      ink_review.update!(check_count: new_count, next_check_at: nil)
+      ink_review.ink_review_checks.create!(result: "removed", error_message: message)
+    else
+      ink_review.update!(check_count: new_count, next_check_at: InkReview::RETRY_INTERVAL.from_now)
+      ink_review.ink_review_checks.create!(result: "error", error_message: message)
+    end
+  end
+end

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -134,3 +134,5 @@ div#graphs
       div#usage-records-graph
     div.col-sm-12.col-lg-6
       div#signups-graph
+    div.col-sm-12.col-lg-6
+      div#ink-review-checks-graph

--- a/app/workers/check_ink_review.rb
+++ b/app/workers/check_ink_review.rb
@@ -1,0 +1,14 @@
+class CheckInkReview
+  include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
+
+  sidekiq_throttle concurrency: { limit: 3 }
+  sidekiq_options queue: "reviews"
+
+  def perform(id)
+    review = InkReview.find_by(id:)
+    return unless review
+
+    InkReviewChecker.new(review).perform
+  end
+end

--- a/app/workers/enqueue_ink_review_checks.rb
+++ b/app/workers/enqueue_ink_review_checks.rb
@@ -1,0 +1,17 @@
+class EnqueueInkReviewChecks
+  include Sidekiq::Worker
+
+  sidekiq_options queue: "low"
+
+  BATCH_SIZE = 100
+  STAGGER_INTERVAL = 36 # seconds between enqueued jobs (~1 hour for full batch)
+
+  def perform
+    InkReview
+      .due_for_check
+      .order(:next_check_at)
+      .limit(BATCH_SIZE)
+      .pluck(:id)
+      .each_with_index { |id, i| CheckInkReview.perform_in((i * STAGGER_INTERVAL).seconds, id) }
+  end
+end

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -28,3 +28,6 @@ clean_up:
 analyze:
   cron: "0 6 * * *" # Every day at 6am
   class: Analyze
+enqueue_ink_review_checks:
+  cron: "15 * * * *" # Every hour at :15
+  class: EnqueueInkReviewChecks

--- a/db/migrate/20260413083719_add_link_checking_to_ink_reviews.rb
+++ b/db/migrate/20260413083719_add_link_checking_to_ink_reviews.rb
@@ -1,0 +1,26 @@
+class AddLinkCheckingToInkReviews < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :ink_reviews, :next_check_at, :datetime
+    add_column :ink_reviews, :check_count, :integer, default: 0, null: false
+    add_index :ink_reviews, :next_check_at, algorithm: :concurrently
+
+    create_table :ink_review_checks do |t|
+      t.references :ink_review, null: false, foreign_key: true
+      t.string :result, null: false
+      t.text :error_message
+      t.timestamps
+    end
+    add_index :ink_review_checks, %i[result created_at]
+
+    up_only do
+      sql = <<~SQL
+        UPDATE ink_reviews
+        SET next_check_at = NOW() + (RANDOM() * INTERVAL '60 days')
+        WHERE approved_at IS NOT NULL AND rejected_at IS NULL
+      SQL
+      safety_assured { execute(sql) }
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,7 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
@@ -483,6 +484,39 @@ ALTER SEQUENCE public.ink_embeddings_id_seq OWNED BY public.ink_embeddings.id;
 
 
 --
+-- Name: ink_review_checks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ink_review_checks (
+    id bigint NOT NULL,
+    ink_review_id bigint NOT NULL,
+    result character varying NOT NULL,
+    error_message text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: ink_review_checks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.ink_review_checks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ink_review_checks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.ink_review_checks_id_seq OWNED BY public.ink_review_checks.id;
+
+
+--
 -- Name: ink_review_submissions; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -540,7 +574,9 @@ CREATE TABLE public.ink_reviews (
     you_tube_channel_id bigint,
     extra_data jsonb DEFAULT '{}'::jsonb,
     you_tube_short boolean DEFAULT false,
-    agent_approved boolean DEFAULT false
+    agent_approved boolean DEFAULT false,
+    next_check_at timestamp(6) without time zone,
+    check_count integer DEFAULT 0 NOT NULL
 );
 
 
@@ -1225,6 +1261,13 @@ ALTER TABLE ONLY public.ink_embeddings ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: ink_review_checks id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ink_review_checks ALTER COLUMN id SET DEFAULT nextval('public.ink_review_checks_id_seq'::regclass);
+
+
+--
 -- Name: ink_review_submissions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1444,6 +1487,14 @@ ALTER TABLE ONLY public.ink_brands
 
 ALTER TABLE ONLY public.ink_embeddings
     ADD CONSTRAINT ink_embeddings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ink_review_checks ink_review_checks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ink_review_checks
+    ADD CONSTRAINT ink_review_checks_pkey PRIMARY KEY (id);
 
 
 --
@@ -1816,6 +1867,20 @@ CREATE UNIQUE INDEX index_ink_embeddings_on_owner_type_and_owner_id ON public.in
 
 
 --
+-- Name: index_ink_review_checks_on_ink_review_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ink_review_checks_on_ink_review_id ON public.ink_review_checks USING btree (ink_review_id);
+
+
+--
+-- Name: index_ink_review_checks_on_result_and_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ink_review_checks_on_result_and_created_at ON public.ink_review_checks USING btree (result, created_at);
+
+
+--
 -- Name: index_ink_review_submissions_on_ink_review_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1841,6 +1906,13 @@ CREATE INDEX index_ink_review_submissions_on_user_id ON public.ink_review_submis
 --
 
 CREATE INDEX index_ink_reviews_on_macro_cluster_id ON public.ink_reviews USING btree (macro_cluster_id);
+
+
+--
+-- Name: index_ink_reviews_on_next_check_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_ink_reviews_on_next_check_at ON public.ink_reviews USING btree (next_check_at);
 
 
 --
@@ -2135,6 +2207,14 @@ ALTER TABLE ONLY public.reading_statuses
 
 
 --
+-- Name: ink_review_checks fk_rails_1bf38ab51e; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ink_review_checks
+    ADD CONSTRAINT fk_rails_1bf38ab51e FOREIGN KEY (ink_review_id) REFERENCES public.ink_reviews(id);
+
+
+--
 -- Name: macro_clusters fk_rails_4b634dc145; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2309,6 +2389,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260413083719'),
 ('20260325150042'),
 ('20260308164655'),
 ('20260227093006'),

--- a/spec/agents/review_approver_spec.rb
+++ b/spec/agents/review_approver_spec.rb
@@ -628,7 +628,7 @@ RSpec.describe ReviewApprover do
 
         expect(cluster_data[:name]).to eq(macro_cluster.name)
         expect(cluster_data[:synonyms]).to eq(macro_cluster.synonyms)
-        expect(cluster_data[:number_of_reviews]).to eq(macro_cluster.ink_reviews.approved.size)
+        expect(cluster_data[:number_of_reviews]).to eq(macro_cluster.ink_reviews.live.size)
       end
     end
 

--- a/spec/models/ink_review_spec.rb
+++ b/spec/models/ink_review_spec.rb
@@ -37,4 +37,98 @@ describe InkReview do
     subject.url = "https://example.com/some/page"
     expect(subject.host).to eq("example.com")
   end
+
+  describe "approve/reject methods manage check state" do
+    let(:review) do
+      create(:ink_review, check_count: 3, next_check_at: 1.hour.from_now, rejected_at: Time.now)
+    end
+
+    it "approve! schedules a check 2 months out and resets check_count" do
+      review.approve!
+      expect(review.check_count).to eq(0)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::CHECK_INTERVAL.from_now)
+      expect(review.approved_at).not_to be_nil
+      expect(review.rejected_at).to be_nil
+    end
+
+    it "auto_approve! schedules a check 2 months out and resets check_count" do
+      review.auto_approve!
+      expect(review.check_count).to eq(0)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::CHECK_INTERVAL.from_now)
+      expect(review.auto_approved).to eq(true)
+    end
+
+    it "agent_approve! schedules a check 2 months out and resets check_count" do
+      review.agent_approve!
+      expect(review.check_count).to eq(0)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::CHECK_INTERVAL.from_now)
+      expect(review.agent_approved).to eq(true)
+    end
+
+    it "reject! clears next_check_at and resets check_count" do
+      approved = create(:ink_review, check_count: 2, next_check_at: 1.hour.from_now)
+      approved.reject!
+      expect(approved.check_count).to eq(0)
+      expect(approved.next_check_at).to be_nil
+      expect(approved.rejected_at).not_to be_nil
+    end
+
+    it "auto_reject! clears next_check_at and resets check_count" do
+      approved = create(:ink_review, check_count: 2, next_check_at: 1.hour.from_now)
+      approved.auto_reject!
+      expect(approved.check_count).to eq(0)
+      expect(approved.next_check_at).to be_nil
+      expect(approved.auto_approved).to eq(true)
+    end
+
+    it "agent_reject! clears next_check_at and resets check_count" do
+      approved = create(:ink_review, check_count: 2, next_check_at: 1.hour.from_now)
+      approved.agent_reject!
+      expect(approved.check_count).to eq(0)
+      expect(approved.next_check_at).to be_nil
+      expect(approved.agent_approved).to eq(true)
+    end
+  end
+
+  describe "scopes" do
+    let!(:ok_due) do
+      create(:ink_review, approved_at: Time.now, check_count: 0, next_check_at: 1.hour.ago)
+    end
+    let!(:ok_not_due) do
+      create(:ink_review, approved_at: Time.now, check_count: 0, next_check_at: 1.day.from_now)
+    end
+    let!(:broken_due) do
+      create(:ink_review, approved_at: Time.now, check_count: 2, next_check_at: 1.hour.ago)
+    end
+    let!(:removed) do
+      create(:ink_review, approved_at: Time.now, check_count: 5, next_check_at: nil)
+    end
+    let!(:rejected) { create(:ink_review, rejected_at: Time.now, check_count: 0) }
+    let!(:queued) { create(:ink_review) }
+
+    it "live includes only approved reviews with check_count = 0" do
+      expect(InkReview.live).to contain_exactly(ok_due, ok_not_due)
+    end
+
+    it "link_broken matches reviews with 0 < check_count < 5" do
+      expect(InkReview.link_broken).to contain_exactly(broken_due)
+    end
+
+    it "link_removed matches reviews with check_count >= 5" do
+      expect(InkReview.link_removed).to contain_exactly(removed)
+    end
+
+    it "due_for_check matches approved reviews whose next_check_at has passed" do
+      expect(InkReview.due_for_check).to contain_exactly(ok_due, broken_due)
+    end
+
+    it "due_for_check excludes manually rejected reviews even if next_check_at is somehow set" do
+      rejected.update_columns(next_check_at: 1.hour.ago)
+      expect(InkReview.due_for_check).not_to include(rejected)
+    end
+
+    it "due_for_check excludes fully removed reviews (next_check_at IS NULL)" do
+      expect(InkReview.due_for_check).not_to include(removed)
+    end
+  end
 end

--- a/spec/operations/ink_review_checker_spec.rb
+++ b/spec/operations/ink_review_checker_spec.rb
@@ -1,0 +1,242 @@
+require "rails_helper"
+
+describe InkReviewChecker do
+  let(:review) do
+    create(
+      :ink_review,
+      url: "http://example.com/review",
+      title: "old title",
+      description: "old description",
+      image: "http://example.com/old-image.jpg",
+      author: "old author",
+      approved_at: Time.now,
+      next_check_at: 1.hour.ago,
+      check_count: 0
+    )
+  end
+
+  let(:fresh_data) do
+    Unfurler::Result.new(
+      "http://example.com/review",
+      "fresh title",
+      "fresh description",
+      "http://example.com/fresh-image.jpg",
+      "fresh author",
+      nil,
+      false,
+      ""
+    )
+  end
+
+  before { allow_any_instance_of(Unfurler).to receive(:perform).and_return(fresh_data) }
+
+  def stub_image_ok
+    stub_request(:head, fresh_data.image).to_return(status: 200)
+  end
+
+  def stub_image_404
+    stub_request(:head, fresh_data.image).to_return(status: 404)
+  end
+
+  describe "successful check" do
+    before { stub_image_ok }
+
+    it "updates the review with fresh metadata" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.title).to eq("fresh title")
+      expect(review.description).to eq("fresh description")
+      expect(review.image).to eq("http://example.com/fresh-image.jpg")
+      expect(review.author).to eq("fresh author")
+    end
+
+    it "resets check_count and schedules next check 2 months out" do
+      review.update!(check_count: 2)
+      described_class.new(review).perform
+      review.reload
+      expect(review.check_count).to eq(0)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::CHECK_INTERVAL.from_now)
+    end
+
+    it "records a success check" do
+      expect { described_class.new(review).perform }.to change(InkReviewCheck, :count).by(1)
+      expect(InkReviewCheck.last.result).to eq("success")
+    end
+
+    it "leaves approved_at intact" do
+      original = review.approved_at
+      described_class.new(review).perform
+      expect(review.reload.approved_at).to be_within(1.second).of(original)
+    end
+  end
+
+  describe "image unreachable" do
+    before { stub_image_404 }
+
+    it "increments check_count and schedules a 24h retry" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.check_count).to eq(1)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::RETRY_INTERVAL.from_now)
+    end
+
+    it "records an error check with a message" do
+      expect { described_class.new(review).perform }.to change(InkReviewCheck, :count).by(1)
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to eq("Image unreachable")
+    end
+
+    it "leaves the review's metadata untouched (does not save garbage from a broken page)" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.title).to eq("old title")
+      expect(review.description).to eq("old description")
+      expect(review.image).to eq("http://example.com/old-image.jpg")
+      expect(review.author).to eq("old author")
+    end
+  end
+
+  describe "blank image returned by the unfurler" do
+    let(:fresh_data) do
+      Unfurler::Result.new(
+        "http://example.com/review",
+        "fresh title",
+        "fresh description",
+        "",
+        "fresh author",
+        nil,
+        false,
+        ""
+      )
+    end
+
+    it "records an error check" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to eq("Image unreachable")
+    end
+  end
+
+  describe "Faraday error during unfurl" do
+    before do
+      allow_any_instance_of(Unfurler).to receive(:perform).and_raise(
+        Faraday::ConnectionFailed.new("connection refused")
+      )
+    end
+
+    it "records an error check with the exception message" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to include("connection refused")
+    end
+
+    it "increments check_count and schedules a 24h retry" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.check_count).to eq(1)
+      expect(review.next_check_at).to be_within(1.minute).of(InkReview::RETRY_INTERVAL.from_now)
+    end
+  end
+
+  describe "Google API error during youtube unfurl" do
+    before do
+      allow_any_instance_of(Unfurler).to receive(:perform).and_raise(
+        Google::Apis::ClientError.new("notFound: video not found")
+      )
+    end
+
+    it "records an error check rather than letting the worker retry forever" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to include("notFound")
+    end
+  end
+
+  describe "URI::InvalidURIError raised by the unfurler" do
+    before do
+      allow_any_instance_of(Unfurler).to receive(:perform).and_raise(
+        URI::InvalidURIError.new("bad uri")
+      )
+    end
+
+    it "records an error check" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to include("bad uri")
+    end
+  end
+
+  describe "fresh page returns invalid metadata (e.g., nil title)" do
+    let(:fresh_data) do
+      Unfurler::Result.new(
+        "http://example.com/review",
+        nil,
+        "fresh description",
+        "http://example.com/fresh-image.jpg",
+        "fresh author",
+        nil,
+        false,
+        ""
+      )
+    end
+
+    before { stub_image_ok }
+
+    it "records an error check with the validation message" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to include("Title")
+    end
+
+    it "leaves the review's existing metadata in the database" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.title).to eq("old title")
+    end
+  end
+
+  describe "fifth consecutive failure" do
+    before do
+      stub_image_404
+      review.update!(check_count: 4)
+    end
+
+    it "records a removed check" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("removed")
+    end
+
+    it "clears next_check_at so the review is never re-checked" do
+      described_class.new(review).perform
+      review.reload
+      expect(review.next_check_at).to be_nil
+      expect(review.check_count).to eq(5)
+    end
+  end
+
+  describe "recovery after a previous failure" do
+    before do
+      stub_image_ok
+      review.update!(check_count: 3, next_check_at: 1.hour.ago)
+    end
+
+    it "resets check_count to 0" do
+      described_class.new(review).perform
+      expect(review.reload.check_count).to eq(0)
+    end
+
+    it "schedules next check 2 months out" do
+      described_class.new(review).perform
+      expect(review.reload.next_check_at).to be_within(1.minute).of(
+        InkReview::CHECK_INTERVAL.from_now
+      )
+    end
+  end
+end

--- a/spec/requests/admins/graphs_controller_spec.rb
+++ b/spec/requests/admins/graphs_controller_spec.rb
@@ -96,6 +96,30 @@ describe Admins::GraphsController do
         )
       end
 
+      it "returns the ink review checks data" do
+        review = create(:ink_review)
+        InkReviewCheck.create!(ink_review: review, result: "success", created_at: 2.days.ago)
+        InkReviewCheck.create!(ink_review: review, result: "success", created_at: 1.day.ago)
+        InkReviewCheck.create!(ink_review: review, result: "error", created_at: 1.day.ago)
+        InkReviewCheck.create!(ink_review: review, result: "removed", created_at: 1.day.ago)
+        get "/admins/graphs/ink-review-checks"
+        expect(response).to be_successful
+        json = JSON.parse(response.body)
+        expect(json).to eq(
+          [
+            {
+              "name" => "Success",
+              "data" => [
+                [2.days.ago.at_beginning_of_day.to_i * 1000, 1],
+                [1.day.ago.at_beginning_of_day.to_i * 1000, 1]
+              ]
+            },
+            { "name" => "Error", "data" => [[1.day.ago.at_beginning_of_day.to_i * 1000, 1]] },
+            { "name" => "Removed", "data" => [[1.day.ago.at_beginning_of_day.to_i * 1000, 1]] }
+          ]
+        )
+      end
+
       it "returns the bot sign up data" do
         create(:user, created_at: 2.days.ago, bot: true, bot_reason: "reason1")
         create(:user, created_at: 2.days.ago, bot: true, bot_reason: "reason2")

--- a/spec/workers/check_ink_review_spec.rb
+++ b/spec/workers/check_ink_review_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe CheckInkReview do
+  it "delegates to InkReviewChecker for the given review" do
+    review = create(:ink_review)
+    checker = instance_double(InkReviewChecker, perform: nil)
+    expect(InkReviewChecker).to receive(:new).with(review).and_return(checker)
+    expect(checker).to receive(:perform)
+    described_class.new.perform(review.id)
+  end
+
+  it "is a no-op when the review no longer exists" do
+    expect(InkReviewChecker).not_to receive(:new)
+    expect { described_class.new.perform(0) }.not_to raise_error
+  end
+end

--- a/spec/workers/enqueue_ink_review_checks_spec.rb
+++ b/spec/workers/enqueue_ink_review_checks_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe EnqueueInkReviewChecks do
+  it "enqueues a CheckInkReview job for each due review" do
+    due = create(:ink_review, approved_at: Time.now, next_check_at: 1.hour.ago)
+    expect { subject.perform }.to change(CheckInkReview.jobs, :length).by(1)
+    expect(CheckInkReview.jobs.first["args"]).to eq([due.id])
+  end
+
+  it "does not enqueue jobs for reviews not yet due" do
+    create(:ink_review, approved_at: Time.now, next_check_at: 1.day.from_now)
+    expect { subject.perform }.not_to change(CheckInkReview.jobs, :length)
+  end
+
+  it "does not enqueue jobs for unapproved reviews" do
+    create(:ink_review, approved_at: nil, next_check_at: 1.hour.ago)
+    expect { subject.perform }.not_to change(CheckInkReview.jobs, :length)
+  end
+
+  it "respects BATCH_SIZE" do
+    stub_const("EnqueueInkReviewChecks::BATCH_SIZE", 2)
+    create_list(:ink_review, 5, approved_at: Time.now, next_check_at: 1.hour.ago)
+    expect { subject.perform }.to change(CheckInkReview.jobs, :length).by(2)
+  end
+
+  it "stagger-schedules jobs by STAGGER_INTERVAL seconds" do
+    create_list(:ink_review, 3, approved_at: Time.now, next_check_at: 1.hour.ago)
+    subject.perform
+    jobs = CheckInkReview.jobs
+    now = Time.now.to_f
+    expect(jobs[0]["at"]).to be_nil # immediate
+    expect(jobs[1]["at"] - now).to be_within(2).of(EnqueueInkReviewChecks::STAGGER_INTERVAL)
+    expect(jobs[2]["at"] - now).to be_within(2).of(EnqueueInkReviewChecks::STAGGER_INTERVAL * 2)
+  end
+
+  it "processes oldest-due reviews first" do
+    older = create(:ink_review, approved_at: Time.now, next_check_at: 2.days.ago)
+    newer = create(:ink_review, approved_at: Time.now, next_check_at: 1.hour.ago)
+    stub_const("EnqueueInkReviewChecks::BATCH_SIZE", 1)
+    subject.perform
+    expect(CheckInkReview.jobs.first["args"]).to eq([older.id])
+    expect(CheckInkReview.jobs.first["args"]).not_to eq([newer.id])
+  end
+end


### PR DESCRIPTION
## Summary

Re-validates approved `InkReview` records every 2 months by re-running them through `Unfurler`. Reviews whose URL or image breaks are hidden via a new `live` scope (`approved.where(check_count: 0)`) — the records are kept intact so leaderboard counts in `LeaderBoard.ink_review_submissions` stay correct. Failed checks retry every 24h up to 5 times before the review is removed from the rotation permanently.

Each check writes an `InkReviewCheck` row, which powers a new "Ink review checks per day" stacked column chart on the admin dashboard (Success / Error / Removed).

## Throttling

- `EnqueueInkReviewChecks` runs hourly on the `low` queue and only pulls up to 100 due reviews per tick, stagger-enqueueing them 36s apart.
- `CheckInkReview` is on the `reviews` queue with `sidekiq_throttle concurrency: { limit: 3 }` so at most 3 outbound HTTP fetches run concurrently.
- The bootstrap migration spreads existing approved reviews over the next 60 days (`NOW() + RANDOM() * INTERVAL '60 days'`) so the first sweep doesn't dump the whole back catalogue into the queue.

## Notable behaviour

- The checker only persists fresh metadata on full success — if the page returns a generic error page, the review's stored title/description/image stays as it was.
- `URI::InvalidURIError`, `Faraday::Error`, and `Google::Apis::Error` (YouTube API) are caught and recorded as failures rather than triggering Sidekiq's 25-retry cycle.
- `MacroCluster#approved_ink_reviews`, `InkReview#auto_reject?`, and `ReviewApprover` switched from `.approved` to `.live` — wherever the question is "are there visible reviews for this ink?", broken-link reviews shouldn't count.

Closes #3393