### PR TITLE
Fix NoMethodError when YouTube video is unavailable

### DIFF
--- a/app/operations/unfurler/youtube.rb
+++ b/app/operations/unfurler/youtube.rb
@@ -44,6 +44,8 @@ class Unfurler
 
     def video
       @video ||= client.list_videos("snippet", id: video_id).items.first
+      raise Google::Apis::ClientError, "YouTube video not found: #{video_id}" unless @video
+      @video
     end
 
     def client

--- a/spec/operations/ink_review_checker_spec.rb
+++ b/spec/operations/ink_review_checker_spec.rb
@@ -156,6 +156,21 @@ describe InkReviewChecker do
     end
   end
 
+  describe "YouTube video not found (deleted/private)" do
+    before do
+      allow_any_instance_of(Unfurler).to receive(:perform).and_raise(
+        Google::Apis::ClientError.new("YouTube video not found: abc123")
+      )
+    end
+
+    it "records an error check" do
+      described_class.new(review).perform
+      check = InkReviewCheck.last
+      expect(check.result).to eq("error")
+      expect(check.error_message).to include("YouTube video not found")
+    end
+  end
+
   describe "URI::InvalidURIError raised by the unfurler" do
     before do
       allow_any_instance_of(Unfurler).to receive(:perform).and_raise(


### PR DESCRIPTION
## Summary

- When the YouTube API returns no items (video deleted/private/unavailable), `Unfurler::Youtube#video` returned `nil`, causing `video.snippet.title` to raise `NoMethodError`
- This bypassed `InkReviewChecker`'s error handling and caused Sidekiq to retry the job indefinitely (Honeybadger fault 129570908, 135 occurrences)
- Now raises `Google::Apis::ClientError` so the existing rescue in `InkReviewChecker` records a graceful failure