### PR TITLE
Use automatic JSX runtime

### DIFF
--- a/app/javascript/src/ErrorBoundary.jsx
+++ b/app/javascript/src/ErrorBoundary.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { HoneybadgerErrorBoundary } from "@honeybadger-io/react";
 import honeybadger from "./honeybadger";
 

--- a/app/javascript/src/add-ink-button/app.jsx
+++ b/app/javascript/src/add-ink-button/app.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import TrackVisibility from "react-on-screen";
 import { getRequest, postRequest } from "../fetch";
 

--- a/app/javascript/src/add-ink-button/index.jsx
+++ b/app/javascript/src/add-ink-button/index.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { App } from "./app";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll(".fpc-add-ink-button");

--- a/app/javascript/src/admin/components/Spinner.jsx
+++ b/app/javascript/src/admin/components/Spinner.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const Spinner = ({ text }) => (
   <div className="loader">
     <i className="fa fa-spin fa-refresh" />

--- a/app/javascript/src/admin/components/Spinner.spec.jsx
+++ b/app/javascript/src/admin/components/Spinner.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { Spinner } from "./Spinner";
 

--- a/app/javascript/src/admin/components/clustering/App.jsx
+++ b/app/javascript/src/admin/components/clustering/App.jsx
@@ -2,10 +2,10 @@ import React, { useEffect, useReducer } from "react";
 
 import { Spinner } from "../Spinner";
 import { BrandSelector } from "./BrandSelector";
+import { DisplayMicroClusters } from "./DisplayMicroClusters";
 import { LoadingOverlay } from "./LoadingOverlay";
 import { Summary } from "./Summary";
 import { initalState, reducer } from "./reducer";
-import { DisplayMicroClusters } from "./DisplayMicroClusters";
 
 export const StateContext = React.createContext();
 export const DispatchContext = React.createContext();

--- a/app/javascript/src/admin/components/clustering/BrandSelector.jsx
+++ b/app/javascript/src/admin/components/clustering/BrandSelector.jsx
@@ -1,6 +1,6 @@
-import React, { useContext } from "react";
-import Select from "react-select";
 import _ from "lodash";
+import { useContext } from "react";
+import Select from "react-select";
 
 import { DispatchContext, StateContext } from "./App";
 import { UPDATE_SELECTED_BRANDS } from "./actions";

--- a/app/javascript/src/admin/components/clustering/BrandSelector.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/BrandSelector.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { DispatchContext, StateContext } from "./App";
 import { BrandSelector } from "./BrandSelector";
-import { StateContext, DispatchContext } from "./App";
 import { UPDATE_SELECTED_BRANDS } from "./actions";
 
 // Mock the keyDownListener module

--- a/app/javascript/src/admin/components/clustering/CreateRow.jsx
+++ b/app/javascript/src/admin/components/clustering/CreateRow.jsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useContext, useEffect } from "react";
 import _ from "lodash";
+import { useCallback, useContext, useEffect } from "react";
 
-import { StateContext, DispatchContext } from "./App";
+import { DispatchContext, StateContext } from "./App";
 import { REMOVE_MICRO_CLUSTER } from "./actions";
 import { keyDownListener } from "./keyDownListener";
 

--- a/app/javascript/src/admin/components/clustering/CreateRow.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/CreateRow.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { DispatchContext, StateContext } from "./App";
 import { CreateRow } from "./CreateRow";
-import { StateContext, DispatchContext } from "./App";
 import { REMOVE_MICRO_CLUSTER } from "./actions";
 
 // Mock the keyDownListener module

--- a/app/javascript/src/admin/components/clustering/DisplayMacroClusters.jsx
+++ b/app/javascript/src/admin/components/clustering/DisplayMacroClusters.jsx
@@ -1,9 +1,9 @@
-import React, { useContext, useEffect } from "react";
+import { useContext, useEffect } from "react";
 
+import { DispatchContext } from "./App";
 import { MacroClusterRows } from "./MacroClusterRows";
 import { NEXT_MACRO_CLUSTER, PREVIOUS_MACRO_CLUSTER } from "./actions";
 import { keyDownListener } from "./keyDownListener";
-import { DispatchContext } from "./App";
 
 export const DisplayMacroClusters = ({
   afterAssign,

--- a/app/javascript/src/admin/components/clustering/DisplayMicroCluster.jsx
+++ b/app/javascript/src/admin/components/clustering/DisplayMicroCluster.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { StateContext } from "./App";
 import { CreateRow } from "./CreateRow";

--- a/app/javascript/src/admin/components/clustering/DisplayMicroCluster.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/DisplayMicroCluster.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
-import { DisplayMicroCluster } from "./DisplayMicroCluster";
 import { StateContext } from "./App";
+import { DisplayMicroCluster } from "./DisplayMicroCluster";
 
 // Mock the child components
 jest.mock("./CreateRow", () => ({

--- a/app/javascript/src/admin/components/clustering/DisplayMicroClusters.jsx
+++ b/app/javascript/src/admin/components/clustering/DisplayMicroClusters.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useCallback } from "react";
+import { useCallback, useContext, useEffect } from "react";
 
 import { DispatchContext, StateContext } from "./App";
 import { DisplayMicroCluster } from "./DisplayMicroCluster";

--- a/app/javascript/src/admin/components/clustering/EntriesList.jsx
+++ b/app/javascript/src/admin/components/clustering/EntriesList.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import _ from "lodash";
 import { SearchLink } from "./SearchLink";
 

--- a/app/javascript/src/admin/components/clustering/EntriesList.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/EntriesList.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { EntriesList } from "./EntriesList";
 

--- a/app/javascript/src/admin/components/clustering/LoadingOverlay.jsx
+++ b/app/javascript/src/admin/components/clustering/LoadingOverlay.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { StateContext } from "./App";
 

--- a/app/javascript/src/admin/components/clustering/LoadingOverlay.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/LoadingOverlay.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { render } from "@testing-library/react";
-import { LoadingOverlay } from "./LoadingOverlay";
 import { StateContext } from "./App";
+import { LoadingOverlay } from "./LoadingOverlay";
 
 const renderWithContext = (contextValue) => {
   return render(

--- a/app/javascript/src/admin/components/clustering/MacroClusterRow.jsx
+++ b/app/javascript/src/admin/components/clustering/MacroClusterRow.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useEffect, useState } from "react";
 import ScrollIntoViewIfNeeded from "react-scroll-into-view-if-needed";
 
 import { DispatchContext, StateContext } from "./App";

--- a/app/javascript/src/admin/components/clustering/MacroClusterRow.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/MacroClusterRow.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { DispatchContext, StateContext } from "./App";
 import { MacroClusterRow } from "./MacroClusterRow";
-import { StateContext, DispatchContext } from "./App";
 import { ASSIGN_TO_MACRO_CLUSTER, UPDATING } from "./actions";
 
 // Mock the dependencies

--- a/app/javascript/src/admin/components/clustering/MacroClusterRows.jsx
+++ b/app/javascript/src/admin/components/clustering/MacroClusterRows.jsx
@@ -1,9 +1,9 @@
 import _ from "lodash";
 import { matchSorter } from "match-sorter";
-import React, { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
+import { StateContext } from "./App";
 import { MacroClusterRow } from "./MacroClusterRow";
 import { setInBrandSelector } from "./keyDownListener";
-import { StateContext } from "./App";
 
 export const MacroClusterRows = ({
   afterAssign,

--- a/app/javascript/src/admin/components/clustering/SearchLink.jsx
+++ b/app/javascript/src/admin/components/clustering/SearchLink.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 export const SearchLink = ({ e, fields }) => {
   const fullName = fields.map((a) => e[a]).join(" ");
   return (

--- a/app/javascript/src/admin/components/clustering/SearchLink.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/SearchLink.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { SearchLink } from "./SearchLink";
 

--- a/app/javascript/src/admin/components/clustering/Summary.jsx
+++ b/app/javascript/src/admin/components/clustering/Summary.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 
 import { StateContext } from "./App";
 

--- a/app/javascript/src/admin/components/clustering/Summary.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/Summary.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
-import { Summary } from "./Summary";
 import { StateContext } from "./App";
+import { Summary } from "./Summary";
 
 const renderWithContext = (contextValue) => {
   return render(

--- a/app/javascript/src/admin/graphs/AgentUsage.jsx
+++ b/app/javascript/src/admin/graphs/AgentUsage.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const AgentUsage = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/Agents.jsx
+++ b/app/javascript/src/admin/graphs/Agents.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const Agents = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/BotSignUps.jsx
+++ b/app/javascript/src/admin/graphs/BotSignUps.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const BotSignUps = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/CollectedInks.jsx
+++ b/app/javascript/src/admin/graphs/CollectedInks.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const CollectedInks = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/CollectedPens.jsx
+++ b/app/javascript/src/admin/graphs/CollectedPens.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const CollectedPens = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/CurrentlyInked.jsx
+++ b/app/javascript/src/admin/graphs/CurrentlyInked.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const CurrentlyInked = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/InkReviewChecks.jsx
+++ b/app/javascript/src/admin/graphs/InkReviewChecks.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const InkReviewChecks = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/SignUps.jsx
+++ b/app/javascript/src/admin/graphs/SignUps.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const SignUps = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/Spam.jsx
+++ b/app/javascript/src/admin/graphs/Spam.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const Spam = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/UsageRecords.jsx
+++ b/app/javascript/src/admin/graphs/UsageRecords.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import { useEffect, useState } from "react";
 
-import { Spinner } from "../components/Spinner";
 import { getRequest } from "../../fetch";
+import { Spinner } from "../components/Spinner";
 
 export const UsageRecords = () => {
   const [data, setData] = useState(null);

--- a/app/javascript/src/admin/graphs/__tests__/AgentUsage.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/AgentUsage.test.jsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { AgentUsage } from "../AgentUsage";
 import * as fetchModule from "../../../fetch";
+import { AgentUsage } from "../AgentUsage";
 
 // Mock Highcharts to avoid running real code
 jest.mock("highcharts", () => ({}));

--- a/app/javascript/src/admin/graphs/__tests__/Agents.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/Agents.test.jsx
@@ -1,10 +1,9 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { Agents } from "../Agents";
-import * as fetchModule from "../../../fetch";
 import HighchartsReact from "highcharts-react-official";
+import * as fetchModule from "../../../fetch";
+import { Agents } from "../Agents";
 
 // Mock Highcharts to prevent real code execution
 jest.mock("highcharts", () => ({}));

--- a/app/javascript/src/admin/graphs/__tests__/BotSignUps.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/BotSignUps.test.jsx
@@ -1,10 +1,9 @@
 /* eslint-env jest */
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { BotSignUps } from "../BotSignUps";
 import * as fetchModule from "../../../fetch";
+import { BotSignUps } from "../BotSignUps";
 
 // Mock Highcharts to prevent real code execution
 jest.mock("highcharts", () => ({}));

--- a/app/javascript/src/admin/graphs/__tests__/CollectedInks.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CollectedInks.test.jsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { CollectedInks } from "../CollectedInks";
 import * as fetchModule from "../../../fetch";
+import { CollectedInks } from "../CollectedInks";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/__tests__/CollectedPens.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CollectedPens.test.jsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { CollectedPens } from "../CollectedPens";
 import * as fetchModule from "../../../fetch";
+import { CollectedPens } from "../CollectedPens";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/__tests__/CurrentlyInked.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CurrentlyInked.test.jsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { CurrentlyInked } from "../CurrentlyInked";
 import * as fetchModule from "../../../fetch";
+import { CurrentlyInked } from "../CurrentlyInked";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/__tests__/SignUps.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/SignUps.test.jsx
@@ -1,10 +1,9 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 /* eslint-env jest */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { SignUps } from "../SignUps";
 import * as fetchModule from "../../../fetch";
+import { SignUps } from "../SignUps";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/__tests__/Spam.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/Spam.test.jsx
@@ -2,10 +2,9 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 /* eslint-env jest */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { Spam } from "../Spam";
 import * as fetchModule from "../../../fetch";
+import { Spam } from "../Spam";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/__tests__/UsageRecords.test.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/UsageRecords.test.jsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 /* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
-import { UsageRecords } from "../UsageRecords";
 import * as fetchModule from "../../../fetch";
+import { UsageRecords } from "../UsageRecords";
 
 jest.mock("highcharts", () => ({}));
 

--- a/app/javascript/src/admin/graphs/index.jsx
+++ b/app/javascript/src/admin/graphs/index.jsx
@@ -1,17 +1,16 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 
-import { SignUps } from "./SignUps";
 import { CollectedInks } from "./CollectedInks";
 import { CollectedPens } from "./CollectedPens";
 import { CurrentlyInked } from "./CurrentlyInked";
+import { SignUps } from "./SignUps";
 import { UsageRecords } from "./UsageRecords";
 // // import { BotSignUps } from "./BotSignUps";
 // import { Spam } from "./Spam";
+import { ErrorBoundary } from "../../ErrorBoundary";
 import { Agents } from "./Agents";
 import { AgentUsage } from "./AgentUsage";
 import { InkReviewChecks } from "./InkReviewChecks";
-import { ErrorBoundary } from "../../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("signups-graph");

--- a/app/javascript/src/admin/micro-clusters/extraColumn.jsx
+++ b/app/javascript/src/admin/micro-clusters/extraColumn.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const extraColumn = (ci) => (
   <div
     style={{

--- a/app/javascript/src/admin/micro-clusters/index.jsx
+++ b/app/javascript/src/admin/micro-clusters/index.jsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 
+import { ErrorBoundary } from "../../ErrorBoundary";
 import { App } from "../components/clustering/App";
 import { assignCluster } from "./assignCluster";
 import { createMacroClusterAndAssign } from "./createMacroClusterAndAssign";
@@ -9,7 +9,6 @@ import { ignoreCluster } from "./ignoreCluster";
 import { getMacroClusters, updateMacroCluster } from "./macroClusters";
 import { getMicroClusters } from "./microClusters";
 import { withDistance } from "./withDistance";
-import { ErrorBoundary } from "../../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("micro-clusters-app");

--- a/app/javascript/src/admin/pens-micro-clusters/index.jsx
+++ b/app/javascript/src/admin/pens-micro-clusters/index.jsx
@@ -1,12 +1,11 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 
+import { ErrorBoundary } from "../../ErrorBoundary";
 import { App } from "../components/clustering/App";
 import { fields } from "./fields";
 import { createMacroClusterAndAssign, getMacroClusters, updateMacroCluster } from "./macroClusters";
 import { assignCluster, getMicroClusters, ignoreCluster } from "./microClusters";
 import { withDistance } from "./withDistance";
-import { ErrorBoundary } from "../../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("pens-micro-clusters-app");

--- a/app/javascript/src/admin/pens-model-micro-clusters/index.jsx
+++ b/app/javascript/src/admin/pens-model-micro-clusters/index.jsx
@@ -1,12 +1,11 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 
+import { ErrorBoundary } from "../../ErrorBoundary";
 import { App } from "../components/clustering/App";
 import { fields } from "./fields";
 import { createMacroClusterAndAssign, getMacroClusters, updateMacroCluster } from "./macroClusters";
 import { assignCluster, getMicroClusters, ignoreCluster } from "./microClusters";
 import { withDistance } from "./withDistance";
-import { ErrorBoundary } from "../../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("pens-model-micro-clusters-app");

--- a/app/javascript/src/admin/stats.jsx
+++ b/app/javascript/src/admin/stats.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { getRequest } from "../fetch";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { getRequest } from "../fetch";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll(".stats");

--- a/app/javascript/src/collected-inks-autocomplete/index.jsx
+++ b/app/javascript/src/collected-inks-autocomplete/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 import { Autocomplete } from "../components/Autocomplete";
 import { ErrorBoundary } from "../ErrorBoundary";

--- a/app/javascript/src/collected-pens-autocomplete/index.jsx
+++ b/app/javascript/src/collected-pens-autocomplete/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
 import { Autocomplete } from "../components/Autocomplete";
 import { ErrorBoundary } from "../ErrorBoundary";

--- a/app/javascript/src/collected_inks/CollectedInks.jsx
+++ b/app/javascript/src/collected_inks/CollectedInks.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useMemo } from "react";
 import Jsona from "jsona";
+import { useEffect, useMemo, useState } from "react";
+import { CardsPlaceholder } from "../components/CardsPlaceholder";
+import { TablePlaceholder } from "../components/TablePlaceholder";
 import { getRequest } from "../fetch";
 import { useLayout } from "../useLayout";
 import { useScreen } from "../useScreen";
-import { CardsPlaceholder } from "../components/CardsPlaceholder";
-import { TablePlaceholder } from "../components/TablePlaceholder";
 import { CollectedInksCards } from "./cards";
 import { CollectedInksTable } from "./table";
 

--- a/app/javascript/src/collected_inks/CollectedInks.spec.jsx
+++ b/app/javascript/src/collected_inks/CollectedInks.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { CollectedInks, storageKeyLayout } from "./CollectedInks";
 
 const setup = (jsx, options) => {

--- a/app/javascript/src/collected_inks/cards/Cards.jsx
+++ b/app/javascript/src/collected_inks/cards/Cards.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { SwabCard } from "./SwabCard";
 import "./cards.scss";
 

--- a/app/javascript/src/collected_inks/cards/CollectedInksCards.jsx
+++ b/app/javascript/src/collected_inks/cards/CollectedInksCards.jsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHiddenFields } from "../../useHiddenFields";
 import { Actions } from "../components";
-import { Cards } from "./Cards";
 import { fuzzyMatch } from "../match";
+import { Cards } from "./Cards";
 
 export const storageKeyHiddenFields = "fpc-collected-inks-cards-hidden-fields";
 

--- a/app/javascript/src/collected_inks/cards/CollectedInksCards.spec.jsx
+++ b/app/javascript/src/collected_inks/cards/CollectedInksCards.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CollectedInksCards, storageKeyHiddenFields } from "./CollectedInksCards";

--- a/app/javascript/src/collected_inks/cards/SwabCard.jsx
+++ b/app/javascript/src/collected_inks/cards/SwabCard.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import _ from "lodash";
-import { RelativeDate } from "../../components/RelativeDate";
 import { Card } from "../../components";
-import { ArchiveButton, EditButton, DeleteButton } from "../components";
+import { RelativeDate } from "../../components/RelativeDate";
+import { ArchiveButton, DeleteButton, EditButton } from "../components";
 import "./swab-card.scss";
 
 function fixedEncodeURIComponent(str) {

--- a/app/javascript/src/collected_inks/cards/SwabCard.spec.jsx
+++ b/app/javascript/src/collected_inks/cards/SwabCard.spec.jsx
@@ -1,9 +1,8 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { SwabCard } from "./SwabCard";
 import { formatISO9075 } from "date-fns";
+import { SwabCard } from "./SwabCard";
 
 const setup = (jsx, options) => {
   return {

--- a/app/javascript/src/collected_inks/components/Actions.jsx
+++ b/app/javascript/src/collected_inks/components/Actions.jsx
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import React, { useMemo, useState } from "react";
-import { useFieldSwitcher } from "../../useFieldSwitcher";
+import { useMemo, useState } from "react";
 import { LayoutToggle } from "../../components/LayoutToggle";
 import { Switch } from "../../components/Switch";
+import { useFieldSwitcher } from "../../useFieldSwitcher";
 import "./actions.scss";
 
 /**

--- a/app/javascript/src/collected_inks/components/Actions.spec.jsx
+++ b/app/javascript/src/collected_inks/components/Actions.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Actions } from "./Actions";

--- a/app/javascript/src/collected_inks/components/ArchiveButton.jsx
+++ b/app/javascript/src/collected_inks/components/ArchiveButton.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @param {{ name: string; id: string; archived: boolean }} props
  */

--- a/app/javascript/src/collected_inks/components/ArchiveButton.spec.jsx
+++ b/app/javascript/src/collected_inks/components/ArchiveButton.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import { ArchiveButton } from "./ArchiveButton";
 

--- a/app/javascript/src/collected_inks/components/DeleteButton.jsx
+++ b/app/javascript/src/collected_inks/components/DeleteButton.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @param {{ name: string; id: string; archived: boolean }} props
  */

--- a/app/javascript/src/collected_inks/components/DeleteButton.spec.jsx
+++ b/app/javascript/src/collected_inks/components/DeleteButton.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { DeleteButton } from "./DeleteButton";
 

--- a/app/javascript/src/collected_inks/components/EditButton.jsx
+++ b/app/javascript/src/collected_inks/components/EditButton.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @param {{ name: string; id: string; archived: boolean }} props
  */

--- a/app/javascript/src/collected_inks/components/EditButton.spec.jsx
+++ b/app/javascript/src/collected_inks/components/EditButton.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import { EditButton } from "./EditButton";
 

--- a/app/javascript/src/collected_inks/index.jsx
+++ b/app/javascript/src/collected_inks/index.jsx
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { CollectedInks } from "./CollectedInks";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { CollectedInks } from "./CollectedInks";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll("#collected-inks .app");

--- a/app/javascript/src/collected_inks/table/ActionsCell.jsx
+++ b/app/javascript/src/collected_inks/table/ActionsCell.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { ArchiveButton, EditButton, DeleteButton } from "../components";
+import { ArchiveButton, DeleteButton, EditButton } from "../components";
 
 /**
  * @typedef {"bottle" | "sample" | "cartridge" | "swab"} InkType

--- a/app/javascript/src/collected_inks/table/ActionsCell.spec.jsx
+++ b/app/javascript/src/collected_inks/table/ActionsCell.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import { ActionsCell } from "./ActionsCell";
 

--- a/app/javascript/src/collected_inks/table/CollectedInksTable.jsx
+++ b/app/javascript/src/collected_inks/table/CollectedInksTable.jsx
@@ -1,20 +1,20 @@
-import React, { useEffect, useMemo, useState } from "react";
 import {
-  useReactTable,
+  flexRender,
   getCoreRowModel,
   getSortedRowModel,
-  flexRender
+  useReactTable
 } from "@tanstack/react-table";
 import _ from "lodash";
+import { useEffect, useMemo, useState } from "react";
 import { RelativeDate } from "../../components/RelativeDate";
+import { Table } from "../../components/Table";
 import { useHiddenFields } from "../../useHiddenFields";
 import { Actions } from "../components";
 import { fuzzyMatch } from "../match";
+import { ActionsCell } from "./ActionsCell";
 import { Counter } from "./Counter";
 import { InkWithLink } from "./InkWithLink";
-import { Table } from "../../components/Table";
 import { booleanSort, colorSort, dateSort } from "./sort";
-import { ActionsCell } from "./ActionsCell";
 
 export const storageKeyHiddenFields = "fpc-collected-inks-table-hidden-fields";
 

--- a/app/javascript/src/collected_inks/table/CollectedInksTable.spec.jsx
+++ b/app/javascript/src/collected_inks/table/CollectedInksTable.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, act, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CollectedInksTable, storageKeyHiddenFields } from "./CollectedInksTable";
 

--- a/app/javascript/src/collected_inks/table/Counter.jsx
+++ b/app/javascript/src/collected_inks/table/Counter.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @typedef {"bottle" | "sample" | "cartridge" | "swab"} InkType
  * @param {{ data: Record<InkType, number>; field: InkType }} props

--- a/app/javascript/src/collected_inks/table/Counter.spec.jsx
+++ b/app/javascript/src/collected_inks/table/Counter.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import { Counter } from "./Counter";
 

--- a/app/javascript/src/collected_inks/table/InkWithLink.jsx
+++ b/app/javascript/src/collected_inks/table/InkWithLink.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @param {{ value?: string; row: { original: { ink_id?: string } } }} props
  */

--- a/app/javascript/src/collected_inks/table/InkWithLink.spec.jsx
+++ b/app/javascript/src/collected_inks/table/InkWithLink.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import { InkWithLink } from "./InkWithLink";
 

--- a/app/javascript/src/collected_pens/CollectedPens.jsx
+++ b/app/javascript/src/collected_pens/CollectedPens.jsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect } from "react";
 import Jsona from "jsona";
+import { useEffect, useState } from "react";
+import { CardsPlaceholder } from "../components/CardsPlaceholder";
+import { TablePlaceholder } from "../components/TablePlaceholder";
 import { getRequest } from "../fetch";
 import { useLayout } from "../useLayout";
 import { useScreen } from "../useScreen";
-import { CardsPlaceholder } from "../components/CardsPlaceholder";
-import { TablePlaceholder } from "../components/TablePlaceholder";
 import { CollectedPensCards } from "./cards/CollectedPensCards";
 import { CollectedPensTable } from "./table/CollectedPensTable";
 

--- a/app/javascript/src/collected_pens/CollectedPens.spec.jsx
+++ b/app/javascript/src/collected_pens/CollectedPens.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { CollectedPens, storageKeyLayout } from "./CollectedPens";
 
 const setup = (jsx, options) => {

--- a/app/javascript/src/collected_pens/cards/Cards.jsx
+++ b/app/javascript/src/collected_pens/cards/Cards.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { PenCard } from "./PenCard";
 import "./cards.scss";
 

--- a/app/javascript/src/collected_pens/cards/CollectedPensCards.jsx
+++ b/app/javascript/src/collected_pens/cards/CollectedPensCards.jsx
@@ -1,8 +1,8 @@
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { useHiddenFields } from "../../useHiddenFields";
 import { Actions } from "../components/Actions";
-import { Cards } from "./Cards";
 import { fuzzyMatch } from "../match";
+import { Cards } from "./Cards";
 
 export const storageKeyHiddenFields = "fpc-collected-pens-cards-hidden-fields";
 

--- a/app/javascript/src/collected_pens/cards/CollectedPensCards.spec.jsx
+++ b/app/javascript/src/collected_pens/cards/CollectedPensCards.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CollectedPensCards, storageKeyHiddenFields } from "./CollectedPensCards";

--- a/app/javascript/src/collected_pens/cards/PenCard.jsx
+++ b/app/javascript/src/collected_pens/cards/PenCard.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { Card } from "../../components/Card";
-import "./pen-card.scss";
 import { RelativeDate } from "../../components/RelativeDate";
+import "./pen-card.scss";
 
 /**
  * @param {{

--- a/app/javascript/src/collected_pens/cards/PenCard.spec.jsx
+++ b/app/javascript/src/collected_pens/cards/PenCard.spec.jsx
@@ -1,9 +1,8 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { PenCard } from "./PenCard";
 import { formatISO9075 } from "date-fns";
+import { PenCard } from "./PenCard";
 
 const setup = (jsx, options) => {
   return {

--- a/app/javascript/src/collected_pens/components/Actions.jsx
+++ b/app/javascript/src/collected_pens/components/Actions.jsx
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import React, { useMemo, useState } from "react";
-import { useFieldSwitcher } from "../../useFieldSwitcher";
+import { useMemo, useState } from "react";
 import { LayoutToggle } from "../../components/LayoutToggle";
 import { Switch } from "../../components/Switch";
+import { useFieldSwitcher } from "../../useFieldSwitcher";
 import "./actions.scss";
 
 /**

--- a/app/javascript/src/collected_pens/components/Actions.spec.jsx
+++ b/app/javascript/src/collected_pens/components/Actions.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Actions } from "./Actions";

--- a/app/javascript/src/collected_pens/index.jsx
+++ b/app/javascript/src/collected_pens/index.jsx
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { CollectedPens } from "./CollectedPens";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { CollectedPens } from "./CollectedPens";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll("#collected-pens .app");

--- a/app/javascript/src/collected_pens/table/ActionsCell.jsx
+++ b/app/javascript/src/collected_pens/table/ActionsCell.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export const ActionsCell = ({ id }) => {
   return (
     <div className="actions">

--- a/app/javascript/src/collected_pens/table/ActionsCell.spec.jsx
+++ b/app/javascript/src/collected_pens/table/ActionsCell.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ActionsCell } from "./ActionsCell";
 

--- a/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
+++ b/app/javascript/src/collected_pens/table/CollectedPensTable.jsx
@@ -1,17 +1,17 @@
-import React, { useMemo, useState, useCallback, useEffect } from "react";
 import {
-  useReactTable,
+  flexRender,
   getCoreRowModel,
   getSortedRowModel,
-  flexRender
+  useReactTable
 } from "@tanstack/react-table";
 import _ from "lodash";
-import { useHiddenFields } from "../../useHiddenFields";
-import { Table } from "../../components/Table";
-import { Actions } from "../components/Actions";
-import { ActionsCell } from "./ActionsCell";
-import { fuzzyMatch } from "../match";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { RelativeDate } from "../../components/RelativeDate";
+import { Table } from "../../components/Table";
+import { useHiddenFields } from "../../useHiddenFields";
+import { Actions } from "../components/Actions";
+import { fuzzyMatch } from "../match";
+import { ActionsCell } from "./ActionsCell";
 import { dateSort } from "./sort";
 
 export const storageKeyHiddenFields = "fpc-collected-pens-table-hidden-fields";

--- a/app/javascript/src/collected_pens/table/CollectedPensTable.spec.jsx
+++ b/app/javascript/src/collected_pens/table/CollectedPensTable.spec.jsx
@@ -1,6 +1,5 @@
 // @ts-check
-import React from "react";
-import { render, act, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CollectedPensTable, storageKeyHiddenFields } from "./CollectedPensTable";
 

--- a/app/javascript/src/color-picker/index.jsx
+++ b/app/javascript/src/color-picker/index.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { createRoot } from "react-dom/client";
+import { useEffect, useState } from "react";
 import { ChromePicker } from "react-color";
+import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "../ErrorBoundary";
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/app/javascript/src/components/Autocomplete.jsx
+++ b/app/javascript/src/components/Autocomplete.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
 import PropTypes from "prop-types";
+import { useCallback, useEffect, useRef, useState } from "react";
 import "./autocomplete.scss";
 
 /**

--- a/app/javascript/src/components/Autocomplete.spec.jsx
+++ b/app/javascript/src/components/Autocomplete.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Autocomplete } from "./Autocomplete";
 
 describe("Autocomplete", () => {

--- a/app/javascript/src/components/Card.jsx
+++ b/app/javascript/src/components/Card.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./card.scss";
 
 export const Card = ({ className = "", ...rest }) => (

--- a/app/javascript/src/components/CardPlaceholder.jsx
+++ b/app/javascript/src/components/CardPlaceholder.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Card } from "./Card";
 
 export const CardPlaceholder = () => (

--- a/app/javascript/src/components/CardPlaceholder.spec.jsx
+++ b/app/javascript/src/components/CardPlaceholder.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, act } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { CardsPlaceholder } from "./CardsPlaceholder";
 
 describe("<CardsPlaceholder />", () => {

--- a/app/javascript/src/components/CardsPlaceholder.jsx
+++ b/app/javascript/src/components/CardsPlaceholder.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDelayedRender } from "../useDelayedRender";
 import { CardPlaceholder } from "./CardPlaceholder";
 import "./cards.scss";

--- a/app/javascript/src/components/LayoutToggle.jsx
+++ b/app/javascript/src/components/LayoutToggle.jsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 /**
  * @param {{ activeLayout: "card" | "table"; onChange: (e: import('react').ChangeEvent) => void; }} props
  */

--- a/app/javascript/src/components/LayoutToggle.spec.jsx
+++ b/app/javascript/src/components/LayoutToggle.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LayoutToggle } from "./LayoutToggle";

--- a/app/javascript/src/components/RelativeDate.jsx
+++ b/app/javascript/src/components/RelativeDate.jsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState } from "react";
-import { startOfToday, parseISO, formatDistanceStrict, formatISO } from "date-fns";
+import { formatDistanceStrict, formatISO, parseISO, startOfToday } from "date-fns";
+import { useMemo, useState } from "react";
 
 export const RelativeDate = ({ date, relativeAsDefault = true }) => {
   const relativeDate = useMemo(() => relativeDateString(date), [date]);

--- a/app/javascript/src/components/RelativeDate.spec.jsx
+++ b/app/javascript/src/components/RelativeDate.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { RelativeDate } from "./RelativeDate";
 import { add, formatISO9075 } from "date-fns";
+import { RelativeDate } from "./RelativeDate";
 
 describe("<RelativeDate>", () => {
   it("renders nothing when no date passed", () => {

--- a/app/javascript/src/components/Switch.jsx
+++ b/app/javascript/src/components/Switch.jsx
@@ -1,4 +1,4 @@
-import React, { useId } from "react";
+import { useId } from "react";
 
 /**
  * @see https://getbootstrap.com/docs/5.3/forms/checks-radios/#switches

--- a/app/javascript/src/components/Switch.spec.jsx
+++ b/app/javascript/src/components/Switch.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Switch } from "./Switch";

--- a/app/javascript/src/components/Table.jsx
+++ b/app/javascript/src/components/Table.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { flexRender } from "@tanstack/react-table";
 
 export const Table = ({

--- a/app/javascript/src/components/Table.spec.jsx
+++ b/app/javascript/src/components/Table.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Table } from "./Table";

--- a/app/javascript/src/components/TablePlaceholder.jsx
+++ b/app/javascript/src/components/TablePlaceholder.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useDelayedRender } from "../useDelayedRender";
 
 export const TablePlaceholder = () => {

--- a/app/javascript/src/components/TablePlaceholder.spec.jsx
+++ b/app/javascript/src/components/TablePlaceholder.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, act } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { TablePlaceholder } from "./TablePlaceholder";
 
 describe("<TablePlaceholder />", () => {

--- a/app/javascript/src/currently_inked/CurrentlyInked.jsx
+++ b/app/javascript/src/currently_inked/CurrentlyInked.jsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect, useCallback } from "react";
 import Jsona from "jsona";
+import _ from "lodash";
+import { useCallback, useEffect, useState } from "react";
+import { CardsPlaceholder } from "../components/CardsPlaceholder";
+import { TablePlaceholder } from "../components/TablePlaceholder";
 import { getRequest } from "../fetch";
 import { useLayout } from "../useLayout";
 import { useScreen } from "../useScreen";
-import { CardsPlaceholder } from "../components/CardsPlaceholder";
-import { TablePlaceholder } from "../components/TablePlaceholder";
 import { CurrentlyInkedCards } from "./cards/CurrentlyInkedCards";
 import { CurrentlyInkedTable } from "./table/CurrentlyInkedTable";
-import _ from "lodash";
 
 const formatter = new Jsona();
 

--- a/app/javascript/src/currently_inked/CurrentlyInked.spec.jsx
+++ b/app/javascript/src/currently_inked/CurrentlyInked.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { CurrentlyInked, storageKeyLayout } from "./CurrentlyInked";
 
 const setup = (jsx, options) => {

--- a/app/javascript/src/currently_inked/cards/Cards.jsx
+++ b/app/javascript/src/currently_inked/cards/Cards.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { CurrentlyInkedCard } from "./CurrentlyInkedCard";
 import "./cards.scss";
 

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { Card } from "../../components/Card";
-import { UsageButton } from "../components/UsageButton";
 import { RelativeDate } from "../../components/RelativeDate";
+import { UsageButton } from "../components/UsageButton";
 import "./currently-inked-card.scss";
 
 /**

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.spec.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCard.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CurrentlyInkedCard } from "./CurrentlyInkedCard";

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.jsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useHiddenFields } from "../../useHiddenFields";
 import { Actions } from "../components/Actions";
-import { Cards } from "./Cards";
 import { fuzzyMatch } from "../match";
+import { Cards } from "./Cards";
 
 export const storageKeyHiddenFields = "fpc-currently-inked-cards-hidden-fields";
 

--- a/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.spec.jsx
+++ b/app/javascript/src/currently_inked/cards/CurrentlyInkedCards.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CurrentlyInkedCards, storageKeyHiddenFields } from "./CurrentlyInkedCards";

--- a/app/javascript/src/currently_inked/components/Actions.jsx
+++ b/app/javascript/src/currently_inked/components/Actions.jsx
@@ -1,8 +1,8 @@
 import _ from "lodash";
-import React, { useMemo, useState } from "react";
-import { useFieldSwitcher } from "../../useFieldSwitcher";
+import { useMemo, useState } from "react";
 import { LayoutToggle } from "../../components/LayoutToggle";
 import { Switch } from "../../components/Switch";
+import { useFieldSwitcher } from "../../useFieldSwitcher";
 import "./actions.scss";
 
 /**

--- a/app/javascript/src/currently_inked/components/Actions.spec.jsx
+++ b/app/javascript/src/currently_inked/components/Actions.spec.jsx
@@ -1,5 +1,4 @@
 // @ts-check
-import React from "react";
 import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Actions } from "./Actions";

--- a/app/javascript/src/currently_inked/components/UsageButton.jsx
+++ b/app/javascript/src/currently_inked/components/UsageButton.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
 import Jsona from "jsona";
+import { useState } from "react";
 import { postRequest } from "../../fetch";
 
 const formatter = new Jsona();

--- a/app/javascript/src/currently_inked/components/UsageButton.spec.jsx
+++ b/app/javascript/src/currently_inked/components/UsageButton.spec.jsx
@@ -1,9 +1,8 @@
 // @ts-check
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { UsageButton } from "./UsageButton";
 
 const jsonApiResponse = {

--- a/app/javascript/src/currently_inked/index.jsx
+++ b/app/javascript/src/currently_inked/index.jsx
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { CurrentlyInked } from "./CurrentlyInked";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { CurrentlyInked } from "./CurrentlyInked";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll("#currently-inked-app");

--- a/app/javascript/src/currently_inked/table/ActionsCell.jsx
+++ b/app/javascript/src/currently_inked/table/ActionsCell.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { UsageButton } from "../components/UsageButton";
 
 export const ActionsCell = ({ id, refillable, ink_name, used_today, onUsageRecorded }) => {

--- a/app/javascript/src/currently_inked/table/ActionsCell.spec.jsx
+++ b/app/javascript/src/currently_inked/table/ActionsCell.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import { ActionsCell } from "./ActionsCell";
 

--- a/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
+++ b/app/javascript/src/currently_inked/table/CurrentlyInkedTable.jsx
@@ -1,18 +1,18 @@
-import React, { useMemo, useEffect, useCallback, useState } from "react";
 import {
-  useReactTable,
+  flexRender,
   getCoreRowModel,
   getSortedRowModel,
-  flexRender
+  useReactTable
 } from "@tanstack/react-table";
 import _ from "lodash";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { RelativeDate } from "../../components/RelativeDate";
+import { Table } from "../../components/Table";
 import { useHiddenFields } from "../../useHiddenFields";
 import { Actions } from "../components/Actions";
 import { fuzzyMatch } from "../match";
-import { Table } from "../../components/Table";
-import { colorSort } from "./sort";
 import { ActionsCell } from "./ActionsCell";
-import { RelativeDate } from "../../components/RelativeDate";
+import { colorSort } from "./sort";
 
 export const storageKeyHiddenFields = "fpc-currently-inked-table-hidden-fields";
 

--- a/app/javascript/src/currently_inked/table/CurrentlyInkedTable.spec.jsx
+++ b/app/javascript/src/currently_inked/table/CurrentlyInkedTable.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, act, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { CurrentlyInkedTable, storageKeyHiddenFields } from "./CurrentlyInkedTable";
 

--- a/app/javascript/src/dashboard/currently_inked_summary_widget.jsx
+++ b/app/javascript/src/dashboard/currently_inked_summary_widget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useContext } from "react";
 import { Widget, WidgetDataContext } from "./widgets";
 

--- a/app/javascript/src/dashboard/dashboard_config.jsx
+++ b/app/javascript/src/dashboard/dashboard_config.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { WIDGET_REGISTRY_MAP } from "./widget_registry";
 
 export const HiddenWidget = ({ id, onAdd }) => {

--- a/app/javascript/src/dashboard/index.jsx
+++ b/app/javascript/src/dashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "../ErrorBoundary";
 import { DraggableWidget, HiddenWidget, useDragReorder } from "./dashboard_config";

--- a/app/javascript/src/dashboard/inks_grouped_by_brand_widget.jsx
+++ b/app/javascript/src/dashboard/inks_grouped_by_brand_widget.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { useContext } from "react";
-import { Pie, PieChart, Tooltip, Cell } from "recharts";
-import { Widget, WidgetDataContext, WidgetWidthContext } from "./widgets";
+import { Cell, Pie, PieChart, Tooltip } from "recharts";
 import { dataWithOtherEntry, generateColors } from "./charting";
+import { Widget, WidgetDataContext, WidgetWidthContext } from "./widgets";
 
 export const InksGroupedByBrandWidget = ({ renderWhenInvisible }) => (
   <Widget

--- a/app/javascript/src/dashboard/inks_summary_widget.jsx
+++ b/app/javascript/src/dashboard/inks_summary_widget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useContext } from "react";
 import { Widget, WidgetDataContext } from "./widgets";
 

--- a/app/javascript/src/dashboard/inks_visualization_widget.jsx
+++ b/app/javascript/src/dashboard/inks_visualization_widget.jsx
@@ -1,6 +1,4 @@
-import React from "react";
-import { useState } from "react";
-import { useContext } from "react";
+import { useContext, useState } from "react";
 import { colorSort } from "../color-sorting";
 import { Widget, WidgetDataContext, WidgetWidthContext } from "./widgets";
 

--- a/app/javascript/src/dashboard/leaderboard_ranking_widget.jsx
+++ b/app/javascript/src/dashboard/leaderboard_ranking_widget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useContext } from "react";
 import { Widget, WidgetDataContext } from "./widgets";
 

--- a/app/javascript/src/dashboard/pen_and_ink_suggestion_widget.jsx
+++ b/app/javascript/src/dashboard/pen_and_ink_suggestion_widget.jsx
@@ -1,9 +1,8 @@
-import React from "react";
-import { useState } from "react";
 import _ from "lodash";
-import { Widget } from "./widgets";
+import { useState } from "react";
 import { getRequest } from "../fetch";
 import "./pen_and_ink_suggestion_widget.css";
+import { Widget } from "./widgets";
 
 export const PenAndInkSuggestionWidget = ({ renderWhenInvisible }) => (
   <Widget

--- a/app/javascript/src/dashboard/pens_grouped_by_brand_widget.jsx
+++ b/app/javascript/src/dashboard/pens_grouped_by_brand_widget.jsx
@@ -1,8 +1,7 @@
-import React from "react";
 import { useContext } from "react";
-import { Pie, PieChart, Tooltip, Cell } from "recharts";
+import { Cell, Pie, PieChart, Tooltip } from "recharts";
+import { dataWithOtherEntry, generateColors } from "./charting";
 import { Widget, WidgetDataContext, WidgetWidthContext } from "./widgets";
-import { generateColors, dataWithOtherEntry } from "./charting";
 
 export const PensGroupedByBrandWidget = ({ renderWhenInvisible }) => (
   <Widget

--- a/app/javascript/src/dashboard/pens_summary_widget.jsx
+++ b/app/javascript/src/dashboard/pens_summary_widget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useContext } from "react";
 import { Widget, WidgetDataContext } from "./widgets";
 

--- a/app/javascript/src/dashboard/sponsor_widget.jsx
+++ b/app/javascript/src/dashboard/sponsor_widget.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Widget } from "./widgets";
 
 export const SponsorWidget = ({ renderWhenInvisible }) => (

--- a/app/javascript/src/dashboard/usage_visualization_widget.jsx
+++ b/app/javascript/src/dashboard/usage_visualization_widget.jsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import convert from "color-convert";
-import { Widget, WidgetDataContext } from "./widgets";
+import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { getRequest, putRequest } from "../fetch";
 import * as storage from "../localStorage";
+import { Widget, WidgetDataContext } from "./widgets";
 
 const RANGE_OPTIONS = [
   { value: "1m", label: "1 month" },

--- a/app/javascript/src/dashboard/widgets.jsx
+++ b/app/javascript/src/dashboard/widgets.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
-import ResizeObserver from "rc-resize-observer";
-import TrackVisibility from "react-on-screen";
 import Jsona from "jsona";
+import ResizeObserver from "rc-resize-observer";
+import React, { useEffect, useState } from "react";
+import TrackVisibility from "react-on-screen";
 
 import { getRequest } from "../fetch";
 

--- a/app/javascript/src/edit-colors/app.jsx
+++ b/app/javascript/src/edit-colors/app.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import { useMemo, useState } from "react";
 import { computeAverageColor } from "./color-utils";
 
 export function App({

--- a/app/javascript/src/edit-colors/index.jsx
+++ b/app/javascript/src/edit-colors/index.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { App } from "./app";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll(".fpc-edit-colors");

--- a/app/javascript/src/ink-search-hint/index.jsx
+++ b/app/javascript/src/ink-search-hint/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { ErrorBoundary } from "../ErrorBoundary";
 

--- a/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
+++ b/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import App from "../app";
 import Table from "../table";

--- a/app/javascript/src/public_inks/index.jsx
+++ b/app/javascript/src/public_inks/index.jsx
@@ -1,7 +1,6 @@
-import * as React from "react";
 import { createRoot } from "react-dom/client";
-import App from "./app";
 import { ErrorBoundary } from "../ErrorBoundary";
+import App from "./app";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("new-public-inks");

--- a/app/javascript/src/public_inks/table.jsx
+++ b/app/javascript/src/public_inks/table.jsx
@@ -1,6 +1,6 @@
+import _ from "lodash";
 import * as React from "react";
 import ReactTable from "react-table-6";
-import _ from "lodash";
 
 export default class Table extends React.Component {
   constructor(props) {

--- a/app/javascript/src/review-submission/app.jsx
+++ b/app/javascript/src/review-submission/app.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { postRequest } from "../fetch";
 
 export const App = ({ url }) => {

--- a/app/javascript/src/review-submission/index.jsx
+++ b/app/javascript/src/review-submission/index.jsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { App } from "./app";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { App } from "./app";
 
 document.addEventListener("DOMContentLoaded", () => {
   const elements = document.querySelectorAll(".fpc-review-submission");

--- a/app/javascript/src/usage_records/UsageRecordForm.jsx
+++ b/app/javascript/src/usage_records/UsageRecordForm.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useMemo } from "react";
 import Jsona from "jsona";
+import { useEffect, useMemo, useState } from "react";
 import Select from "react-select";
 import { getRequest } from "../fetch";
 

--- a/app/javascript/src/usage_records/UsageRecordForm.spec.jsx
+++ b/app/javascript/src/usage_records/UsageRecordForm.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 import { UsageRecordForm } from "./UsageRecordForm";
 
 // Mock react-select to make testing easier

--- a/app/javascript/src/usage_records/index.jsx
+++ b/app/javascript/src/usage_records/index.jsx
@@ -1,8 +1,7 @@
 /* istanbul ignore file */
-import React from "react";
 import { createRoot } from "react-dom/client";
-import { UsageRecordForm } from "./UsageRecordForm";
 import { ErrorBoundary } from "../ErrorBoundary";
+import { UsageRecordForm } from "./UsageRecordForm";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("usage-record-form-app");

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", ["@babel/preset-react", { "runtime": "automatic" }]]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ export default [
     compat.extends(
       "eslint:recommended",
       "plugin:react/recommended",
+      "plugin:react/jsx-runtime",
       "plugin:react-hooks/recommended"
     )
   ).map((config) => ({

--- a/spec/javascript/ErrorBoundary.spec.jsx
+++ b/spec/javascript/ErrorBoundary.spec.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 
 jest.mock("@honeybadger-io/js", () => ({

--- a/spec/javascript/src/add-ink-button/add.spec.jsx
+++ b/spec/javascript/src/add-ink-button/add.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 
 import { App } from "add-ink-button/app";
 

--- a/spec/javascript/src/add-ink-button/loader-and-add-flow.spec.jsx
+++ b/spec/javascript/src/add-ink-button/loader-and-add-flow.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 
 import { App } from "add-ink-button/app";
 

--- a/spec/javascript/src/admin/micro-clusters/index.spec.jsx
+++ b/spec/javascript/src/admin/micro-clusters/index.spec.jsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import React from "react";
 
 // Mock all the dependencies
 jest.mock("react-dom/client", () => ({

--- a/spec/javascript/src/currently_inked/components/UsageButton.spec.jsx
+++ b/spec/javascript/src/currently_inked/components/UsageButton.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 
 import { UsageButton } from "currently_inked/components/UsageButton";
 

--- a/spec/javascript/src/dashboard/currently_inked_summary_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/currently_inked_summary_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { CurrentlyInkedSummaryWidget } from "dashboard/currently_inked_summary_widget";
 

--- a/spec/javascript/src/dashboard/dashboard_config.spec.jsx
+++ b/spec/javascript/src/dashboard/dashboard_config.spec.jsx
@@ -1,7 +1,5 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { renderHook, act } from "@testing-library/react";
-import { HiddenWidget, DraggableWidget, useDragReorder } from "dashboard/dashboard_config";
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { DraggableWidget, HiddenWidget, useDragReorder } from "dashboard/dashboard_config";
 
 describe("HiddenWidget", () => {
   it("renders the widget content and add button", () => {

--- a/spec/javascript/src/dashboard/index.spec.jsx
+++ b/spec/javascript/src/dashboard/index.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 jest.mock("dashboard/widget_registry", () => {
   const WidgetA = () => <div data-testid="widget-a">Widget A</div>;
@@ -25,8 +24,8 @@ jest.mock("dashboard/useDashboardPreferences", () => ({
   useDashboardPreferences: jest.fn()
 }));
 
-import { useDashboardPreferences } from "dashboard/useDashboardPreferences";
 import { Dashboard } from "dashboard/index";
+import { useDashboardPreferences } from "dashboard/useDashboardPreferences";
 
 function setupPreferences(visibleIds = ["widget_a", "widget_b", "widget_c"]) {
   mockSetVisibleWidgetIds.mockClear();

--- a/spec/javascript/src/dashboard/inks_grouped_by_brand_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/inks_grouped_by_brand_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { InksGroupedByBrandWidget } from "dashboard/inks_grouped_by_brand_widget";
 

--- a/spec/javascript/src/dashboard/inks_summary_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/inks_summary_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { InksSummaryWidget } from "dashboard/inks_summary_widget";
 

--- a/spec/javascript/src/dashboard/inks_visualization_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/inks_visualization_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { InksVisualizationWidget } from "dashboard/inks_visualization_widget";
 

--- a/spec/javascript/src/dashboard/leaderboard_ranking_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/leaderboard_ranking_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { LeaderboardRankingWidget } from "dashboard/leaderboard_ranking_widget";
 

--- a/spec/javascript/src/dashboard/pens_grouped_by_brand_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/pens_grouped_by_brand_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { PensGroupedByBrandWidget } from "dashboard/pens_grouped_by_brand_widget";
 

--- a/spec/javascript/src/dashboard/pens_summary_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/pens_summary_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { PensSummaryWidget } from "dashboard/pens_summary_widget";
 

--- a/spec/javascript/src/dashboard/usage_visualization_widget.spec.jsx
+++ b/spec/javascript/src/dashboard/usage_visualization_widget.spec.jsx
@@ -1,7 +1,6 @@
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
-import { render, screen } from "@testing-library/react";
 
 import { UsageVisualizationWidget, buildGrid } from "dashboard/usage_visualization_widget";
 

--- a/spec/javascript/src/edit-colors/app.spec.jsx
+++ b/spec/javascript/src/edit-colors/app.spec.jsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { App } from "edit-colors/app";
 
 describe("EditColors App", () => {

--- a/spec/javascript/src/review-submission/app.spec.jsx
+++ b/spec/javascript/src/review-submission/app.spec.jsx
@@ -1,8 +1,7 @@
-import React from "react";
-import { rest } from "msw";
-import { setupServer } from "msw/node";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
 
 import { App } from "review-submission/app";
 


### PR DESCRIPTION
Since React 17, `React` no longer needs to be in scope for JSX. By using the `automatic` JSX runtime rather than the default `classic` one, we can remove all unused `React` imports.

(The only exception is `table.jsx` as it uses an older React version for the table, but the import isn't unused in that file anyway.)