### PR TITLE
Fix slim-select layout conflict with Bootstrap form-control class

### DIFF
--- a/app/javascript/src/slim-select-init.js
+++ b/app/javascript/src/slim-select-init.js
@@ -11,6 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   if (penSelect) {
+    penSelect.classList.remove("form-control", "form-select");
     new SlimSelect({
       select: penSelect,
       settings: {
@@ -21,6 +22,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   if (inkSelect) {
+    inkSelect.classList.remove("form-control", "form-select");
     new SlimSelect({
       select: inkSelect,
       settings: {


### PR DESCRIPTION
## Summary

simple_form's `vertical_form` wrapper applies `form-control` to the underlying `<select>`. slim-select copies the original element's classList onto both its rendered `.ss-main` and `.ss-content` wrappers (`node_modules/slim-select/src/slim-select/index.ts:118` and `render.ts:242-243`). Bootstrap's `.form-control { display: block; padding; ... }` then wins against `.ss-main { display: flex }` (same specificity, Bootstrap loaded later in the cascade), which together with `.ss-main`'s `overflow: hidden` causes the deselect (X) button, arrow caret, and dropdown list scroll to break on the currently-inked add/edit pages — slim-select still initializes fine and search works, but the layout is broken.

Stripping `form-control` / `form-select` from the `<select>` before constructing the SlimSelect instance prevents those classes from being copied onto the wrapper. The hidden native select doesn't need them either, since slim-select sets `display: none` on it.

<img width="705" height="465" alt="Screenshot 2026-05-03 at 21 35 58" src="https://github.com/user-attachments/assets/5966e856-b5df-40a7-83f3-a02666a7184d" />
