### PR TITLE
Guard Pens::Model.embedding_search against blank queries

### DIFF
--- a/app/models/macro_cluster.rb
+++ b/app/models/macro_cluster.rb
@@ -102,6 +102,8 @@ class MacroCluster < ApplicationRecord
 
   # NOTE: This is not performant, and should only be used in the background
   def self.embedding_search(query)
+    return [] if query.blank?
+
     connection.execute("SET hnsw.ef_search = 200")
     query_embedding = EmbeddingsClient.new.fetch(query)
     # This needs to do multiple queries as it is not possible to do the filtering

--- a/app/models/pens/model.rb
+++ b/app/models/pens/model.rb
@@ -28,6 +28,8 @@ class Pens::Model < ApplicationRecord
   end
 
   def self.embedding_search(query)
+    return [] if query.blank?
+
     connection.execute("SET hnsw.ef_search = 1000")
     query_embedding = EmbeddingsClient.new.fetch(query)
     model_embeddings =

--- a/spec/models/macro_cluster_spec.rb
+++ b/spec/models/macro_cluster_spec.rb
@@ -251,4 +251,13 @@ describe MacroCluster do
       expect(cluster.manual_edits?).to be true
     end
   end
+
+  describe ".embedding_search" do
+    it "returns an empty array for a blank query without calling the embeddings client" do
+      expect(EmbeddingsClient).not_to receive(:new)
+
+      expect(described_class.embedding_search(nil)).to eq([])
+      expect(described_class.embedding_search("")).to eq([])
+    end
+  end
 end

--- a/spec/models/pens/model_spec.rb
+++ b/spec/models/pens/model_spec.rb
@@ -36,4 +36,13 @@ describe Pens::Model do
       expect(described_class.search("two")).to eq([m2])
     end
   end
+
+  describe "embedding_search" do
+    it "returns an empty array for a blank query without calling the embeddings client" do
+      expect(EmbeddingsClient).not_to receive(:new)
+
+      expect(described_class.embedding_search(nil)).to eq([])
+      expect(described_class.embedding_search("")).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Bare `GET /pen_models` (no `q` param) passed `nil` through `EmbeddingsClient#fetch`, hitting `Digest::MD5.hexdigest(nil)` and raising `TypeError: no implicit conversion of nil into String`.
- Short-circuit `Pens::Model.embedding_search` to return `[]` for a blank query, mirroring the existing pattern in `Pens::Model.search` and avoiding a wasted OpenAI embeddings call.
- Honeybadger fault: https://app.honeybadger.io/projects/107098/faults/123770788 (32 occurrences, last seen 2026-05-04).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty or blank queries in the embedding search feature to prevent unnecessary operations.

* **Tests**
  * Added comprehensive test coverage for blank query scenarios in embedding search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->