### PR TITLE
Sort usage record entries alphabetically

### DIFF
--- a/app/javascript/src/usage_records/UsageRecordForm.jsx
+++ b/app/javascript/src/usage_records/UsageRecordForm.jsx
@@ -45,6 +45,11 @@ const csrfToken = () => {
   return el ? el.getAttribute("content") : null;
 };
 
+const fullName = (entry) => `${entry.pen_name} - ${entry.ink_name}`;
+
+const sortByFullName = (a, b) =>
+  fullName(a).localeCompare(fullName(b), undefined, { sensitivity: "base" });
+
 export const UsageRecordForm = () => {
   const [entries, setEntries] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -58,13 +63,7 @@ export const UsageRecordForm = () => {
       try {
         const active = await fetchAllCurrentlyInked("false");
 
-        const sortByInkedOn = (a, b) => {
-          if (a.inked_on < b.inked_on) return -1;
-          if (a.inked_on > b.inked_on) return 1;
-          return 0;
-        };
-
-        active.sort(sortByInkedOn);
+        active.sort(sortByFullName);
 
         setEntries(active.map((e) => ({ ...e, group: "active" })));
       } finally {
@@ -94,13 +93,7 @@ export const UsageRecordForm = () => {
       try {
         const archived = await fetchAllCurrentlyInked("true");
 
-        const sortByInkedOn = (a, b) => {
-          if (a.inked_on < b.inked_on) return -1;
-          if (a.inked_on > b.inked_on) return 1;
-          return 0;
-        };
-
-        archived.sort(sortByInkedOn);
+        archived.sort(sortByFullName);
 
         if (!cancelled) {
           setEntries((prev) => [

--- a/app/javascript/src/usage_records/UsageRecordForm.spec.jsx
+++ b/app/javascript/src/usage_records/UsageRecordForm.spec.jsx
@@ -229,4 +229,125 @@ describe("<UsageRecordForm />", () => {
     const form = select.closest("form");
     expect(form.getAttribute("action")).toBe("/currently_inked/1/usage_record");
   });
+
+  it("orders active entries alphabetically by full name", async () => {
+    const zebra = {
+      id: "10",
+      type: "currently_inked",
+      attributes: {
+        inked_on: "2024-01-01",
+        archived_on: null,
+        pen_name: "Zebra Pen",
+        ink_name: "Zebra Ink",
+        archived: false
+      },
+      relationships: {}
+    };
+    const apple = {
+      id: "11",
+      type: "currently_inked",
+      attributes: {
+        inked_on: "2026-01-01",
+        archived_on: null,
+        pen_name: "Apple Pen",
+        ink_name: "Apple Ink",
+        archived: false
+      },
+      relationships: {}
+    };
+    const middle = {
+      id: "12",
+      type: "currently_inked",
+      attributes: {
+        inked_on: "2025-01-01",
+        archived_on: null,
+        pen_name: "Mango Pen",
+        ink_name: "Mango Ink",
+        archived: false
+      },
+      relationships: {}
+    };
+
+    server.use(
+      rest.get("/api/v1/currently_inked.json", (req, res, ctx) => {
+        const archived = req.url.searchParams.get("filter[archived]");
+        if (archived === "false") {
+          return res(ctx.json(makeResponse([zebra, apple, middle])));
+        }
+        return res(ctx.json(makeResponse([])));
+      })
+    );
+
+    setup(<UsageRecordForm />);
+
+    await screen.findByLabelText("Currently inked");
+
+    const labels = screen
+      .getAllByRole("option")
+      .map((o) => o.textContent)
+      .filter((t) => t.includes(" - "));
+
+    expect(labels).toEqual([
+      "Apple Pen - Apple Ink",
+      "Mango Pen - Mango Ink",
+      "Zebra Pen - Zebra Ink"
+    ]);
+  });
+
+  it("orders archived entries alphabetically by full name", async () => {
+    const zebra = {
+      id: "20",
+      type: "currently_inked",
+      attributes: {
+        inked_on: "2024-01-01",
+        archived_on: "2024-12-31",
+        pen_name: "Zebra Pen",
+        ink_name: "Zebra Ink",
+        archived: true
+      },
+      relationships: {}
+    };
+    const apple = {
+      id: "21",
+      type: "currently_inked",
+      attributes: {
+        inked_on: "2025-01-01",
+        archived_on: "2025-12-31",
+        pen_name: "Apple Pen",
+        ink_name: "Apple Ink",
+        archived: true
+      },
+      relationships: {}
+    };
+
+    server.use(
+      rest.get("/api/v1/currently_inked.json", (req, res, ctx) => {
+        const archived = req.url.searchParams.get("filter[archived]");
+        if (archived === "false") {
+          return res(ctx.json(makeResponse([activeEntry])));
+        }
+        if (archived === "true") {
+          return res(ctx.json(makeResponse([zebra, apple])));
+        }
+        return res(ctx.json(makeResponse([])));
+      })
+    );
+
+    const { user } = setup(<UsageRecordForm />);
+
+    await screen.findByLabelText("Currently inked");
+    await user.click(screen.getByLabelText("Include archived entries"));
+
+    await screen.findByText(/Apple Pen - Apple Ink/);
+
+    const labels = screen
+      .getAllByRole("option")
+      .map((o) => o.textContent)
+      .filter((t) => t.includes(" - "));
+
+    const appleIdx = labels.findIndex((l) => l.startsWith("Apple Pen"));
+    const zebraIdx = labels.findIndex((l) => l.startsWith("Zebra Pen"));
+    expect(appleIdx).toBeGreaterThanOrEqual(0);
+    expect(zebraIdx).toBeGreaterThan(appleIdx);
+  });
 });


### PR DESCRIPTION
## Summary
- The "Add usage record" dropdown previously ordered entries by `inked_on` date, which looked random to users.
- Sort entries by their displayed full name (`pen_name - ink_name`) using `localeCompare` instead, so they appear in predictable alphabetical order in both the Active and Archived groups.
- De-duplicated the two identical sort comparators into a single top-level helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sorting behavior for pen and ink entries in the usage records form. Entries are now sorted alphabetically by pen and ink names (case-insensitive) instead of by the date they were inked. This applies to both active and archived entries, providing more consistent and predictable ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->