### PR TITLE
Make InkClusterer approve!/reject! idempotent

### DIFF
--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -220,29 +220,39 @@ class InkClusterer
   end
 
   def reject!(agent: false)
-    to_reprocess = [micro_cluster]
-    to_reprocess += Array(clean_up_rejected_approval!) if agent_log.approved?
-    to_reprocess = to_reprocess.uniq.reject { |mi| mi.collected_inks.empty? }
-    to_reprocess.map(&:touch)
-    agent ? agent_log.reject_by_agent! : agent_log.reject!
-    to_reprocess
+    AgentLog.transaction do
+      agent_log.lock!
+      return [] if agent_log.state == AgentLog::REJECTED
+
+      to_reprocess = [micro_cluster]
+      to_reprocess += Array(clean_up_rejected_approval!) if agent_log.approved?
+      to_reprocess = to_reprocess.uniq.reject { |mi| mi.collected_inks.empty? }
+      to_reprocess.map(&:touch)
+      agent ? agent_log.reject_by_agent! : agent_log.reject!
+      to_reprocess
+    end
   end
 
   def approve!(agent: false)
-    case agent_log.extra_data["action"]
-    when "assign_to_cluster"
-      micro_cluster.update!(macro_cluster_id: agent_log.extra_data["cluster_id"])
-      UpdateMicroCluster.perform_async(micro_cluster.id)
-    when "create_new_cluster"
-      cluster = MacroCluster.create!(ink_name: SecureRandom.uuid)
-      micro_cluster.update!(macro_cluster_id: cluster.id)
-      UpdateMicroCluster.perform_async(micro_cluster.id)
-    when "ignore_ink"
-      micro_cluster.update!(ignored: true)
-    when "hand_over_to_human"
-      micro_cluster.touch # Move it to the end of the queue for now
+    AgentLog.transaction do
+      agent_log.lock!
+      return if agent_log.approved?
+
+      case agent_log.extra_data["action"]
+      when "assign_to_cluster"
+        micro_cluster.update!(macro_cluster_id: agent_log.extra_data["cluster_id"])
+        UpdateMicroCluster.perform_async(micro_cluster.id)
+      when "create_new_cluster"
+        cluster = MacroCluster.create!(ink_name: SecureRandom.uuid)
+        micro_cluster.update!(macro_cluster_id: cluster.id)
+        UpdateMicroCluster.perform_async(micro_cluster.id)
+      when "ignore_ink"
+        micro_cluster.update!(ignored: true)
+      when "hand_over_to_human"
+        micro_cluster.touch # Move it to the end of the queue for now
+      end
+      agent ? agent_log.approve_by_agent! : agent_log.approve!
     end
-    agent ? agent_log.approve_by_agent! : agent_log.approve!
   end
 
   private

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -564,6 +564,27 @@ RSpec.describe InkClusterer do
         expect(subject.agent_log.state).to eq("approved")
       end
     end
+
+    context "idempotency" do
+      before { subject.agent_log.update!(extra_data: { "action" => "create_new_cluster" }) }
+
+      it "does not create a second MacroCluster when called twice" do
+        expect { subject.approve! }.to change { MacroCluster.count }.by(1)
+        macro_cluster_id = micro_cluster.reload.macro_cluster_id
+
+        expect { subject.approve! }.not_to change { MacroCluster.count }
+        expect(micro_cluster.reload.macro_cluster_id).to eq(macro_cluster_id)
+        expect(UpdateMicroCluster.jobs.size).to eq(1)
+      end
+
+      it "does not run the action block when the log is already approved" do
+        subject.agent_log.update!(state: "approved")
+
+        expect { subject.approve! }.not_to change { MacroCluster.count }
+        expect(micro_cluster.reload.macro_cluster_id).to be_nil
+        expect(UpdateMicroCluster.jobs.size).to eq(0)
+      end
+    end
   end
 
   describe "#reject!" do


### PR DESCRIPTION
Honeybadger fault [125364239](https://app.honeybadger.io/projects/107098/faults/125364239) (`ActiveRecord::RecordNotUnique` on `index_macro_clusters_on_brand_name_and_line_name_and_ink_name`) traces to a double-invocation of `InkClusterer#approve!` for the same agent_log: the state transition lived at the bottom of the method, so two callers (sidekiq retry of the CheckInkClustering follow-up, or a manual approve overlapping with the agent flow) each ran the action block, each created a MacroCluster, and the second one collided when `UpdateMacroCluster` later materialised the popular `(brand, line, ink)` triple already occupied by the orphan first cluster. Wrapping the action dispatch in a transaction with a row lock on the agent_log and bailing on already-terminal state makes a duplicate call a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency and atomicity of approval and rejection operations
  * Enhanced handling of edge cases to prevent duplicate operations when approvals or rejections are retried

* **Tests**
  * Added test coverage for idempotency to ensure operations safely handle repeated calls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3516?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->