### PR TITLE
Repair mid-transcript dangling tool_calls on restore

### DIFF
--- a/app/agents/concerns/ruby_llm_agent.rb
+++ b/app/agents/concerns/ruby_llm_agent.rb
@@ -167,19 +167,29 @@ module RubyLlmAgent
     end
   end
 
-  # If the transcript ends with an assistant message containing tool_calls
-  # but the corresponding tool responses are missing (e.g. due to a crash),
-  # remove the dangling assistant message so the API won't reject the transcript.
+  # Enforce the OpenAI invariant: every tool_call_id in an assistant message
+  # must be followed by a tool message with that tool_call_id. If a worker
+  # crashed mid-tool-loop the saved transcript can violate this — sometimes
+  # with the dangling assistant at the end (single tool_call), sometimes in
+  # the middle (parallel tool_calls partially completed, or an ask! nudge
+  # appended after a partial save). Walk the transcript and truncate at the
+  # first assistant-with-tool_calls that is missing any response.
   def trim_dangling_tool_calls(transcript)
     entries = transcript.map(&:deep_symbolize_keys)
-    return entries if entries.empty?
 
-    last = entries.last
-    if last[:tool_calls].present? && last[:role].to_s == "assistant"
-      entries[0...-1]
-    else
-      entries
+    entries.each_with_index do |entry, idx|
+      next unless entry[:role].to_s == "assistant" && entry[:tool_calls].present?
+
+      required_ids = entry[:tool_calls].map { |tc| tc.deep_symbolize_keys[:id] }
+      later_tool_ids =
+        entries[(idx + 1)..].each_with_object([]) do |e, acc|
+          acc << e[:tool_call_id] if e[:role].to_s == "tool" && e[:tool_call_id]
+        end
+
+      return entries[0...idx] unless required_ids.all? { |id| later_tool_ids.include?(id) }
     end
+
+    entries
   end
 
   def deserialize_tool_calls(tool_calls_array)

--- a/spec/agents/concerns/ruby_llm_agent_spec.rb
+++ b/spec/agents/concerns/ruby_llm_agent_spec.rb
@@ -163,6 +163,71 @@ RSpec.describe RubyLlmAgent do
       result = agent.send(:trim_dangling_tool_calls, transcript)
       expect(result.length).to eq(1)
     end
+
+    it "truncates at an assistant with parallel tool_calls when one response is missing" do
+      transcript = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: "call_a", name: "my_tool", arguments: {} },
+            { id: "call_b", name: "my_tool", arguments: {} }
+          ]
+        },
+        { role: "tool", content: "result a", tool_call_id: "call_a" }
+      ]
+
+      result = agent.send(:trim_dangling_tool_calls, transcript)
+      expect(result.length).to eq(1)
+      expect(result.first[:role].to_s).to eq("user")
+    end
+
+    it "keeps an assistant with parallel tool_calls when all responses are present" do
+      transcript = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [
+            { id: "call_a", name: "my_tool", arguments: {} },
+            { id: "call_b", name: "my_tool", arguments: {} }
+          ]
+        },
+        { role: "tool", content: "result a", tool_call_id: "call_a" },
+        { role: "tool", content: "result b", tool_call_id: "call_b" }
+      ]
+
+      result = agent.send(:trim_dangling_tool_calls, transcript)
+      expect(result.length).to eq(4)
+    end
+
+    it "truncates at a mid-transcript assistant whose tool response is missing" do
+      transcript = [
+        { role: "user", content: "hello" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ id: "call_1", name: "my_tool", arguments: {} }]
+        },
+        { role: "user", content: "nudge" }
+      ]
+
+      result = agent.send(:trim_dangling_tool_calls, transcript)
+      expect(result.length).to eq(1)
+      expect(result.first[:role].to_s).to eq("user")
+    end
+
+    it "leaves transcripts with no tool_calls untouched" do
+      transcript = [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi there" },
+        { role: "user", content: "thanks" }
+      ]
+
+      result = agent.send(:trim_dangling_tool_calls, transcript)
+      expect(result.length).to eq(3)
+    end
   end
 
   describe "#ask!" do


### PR DESCRIPTION
Honeybadger fault [130727523](https://app.honeybadger.io/projects/107098/faults/130727523) (`RubyLLM::BadRequestError: ... tool_call_ids did not have response messages`) was a stuck retry loop: `trim_dangling_tool_calls` only inspected the last transcript entry, so it healed the simplest crash shape (single `tool_call` saved before the response) but missed the production case where parallel `tool_calls` had one response persisted before the worker died — the dangling assistant then sat mid-transcript and every replay re-sent it to OpenAI for a 400. Walking the whole transcript and truncating at the first assistant-with-tool_calls whose ids are not all answered later fixes that shape and the `ask!`-nudge variant too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved robustness of tool call handling in AI agent transcripts to better enforce consistency when managing parallel or sequential tool executions.

* **Tests**
  * Extended test coverage for various tool call scenarios, including missing responses and parallel execution cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->