### PR TITLE
Preserve in-flight Sidekiq jobs across Fly deploys

### DIFF
--- a/app/workers/run_failed_cluster_jobs.rb
+++ b/app/workers/run_failed_cluster_jobs.rb
@@ -9,13 +9,11 @@ class RunFailedClusterJobs
 
   def run_failed_ink_clusterer_jobs
     failed_ink_clusterer_jobs.find_each do |log|
-      cluster = log.owner
-      log.destroy!
-      RunInkClustererAgent.perform_async("InkClusterer", cluster.id)
+      RunInkClustererAgent.perform_async("InkClusterer", log.owner_id)
     end
   end
 
   def failed_ink_clusterer_jobs
-    AgentLog.ink_clusterer.processing.where("created_at < ?", 1.hour.ago)
+    AgentLog.ink_clusterer.processing.where("created_at < ?", 15.minutes.ago)
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:timeout: 25
+:timeout: 90
 :concurrency: <%= ENV.fetch('SIDEKIQ_CONCURRENCY', 5) %>
 :queues:
   - mailers

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,7 @@ app = 'fountainpencompanion'
 primary_region = 'ewr'
 console_command = '/app/bin/rails console'
 swap_size_mb = 512
+kill_timeout = '120s'
 
 [build]
 build-target = 'prod'

--- a/spec/workers/run_failed_cluster_jobs_spec.rb
+++ b/spec/workers/run_failed_cluster_jobs_spec.rb
@@ -2,18 +2,19 @@ require "rails_helper"
 
 describe RunFailedClusterJobs do
   describe "#perform" do
-    it "deletes processing ink_clusterer agent logs older than 1 hour" do
+    it "preserves processing ink_clusterer agent logs so the transcript is reused" do
       cluster = create(:micro_cluster)
-      log = create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 2.hours.ago)
+      log =
+        create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 30.minutes.ago)
 
-      expect { described_class.new.perform }.to change { AgentLog.exists?(log.id) }.from(true).to(
-        false
-      )
+      described_class.new.perform
+
+      expect(AgentLog.exists?(log.id)).to be true
     end
 
     it "enqueues a new RunInkClustererAgent job for the cluster" do
       cluster = create(:micro_cluster)
-      create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 2.hours.ago)
+      create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 30.minutes.ago)
 
       described_class.new.perform
 
@@ -21,10 +22,10 @@ describe RunFailedClusterJobs do
       expect(RunInkClustererAgent.jobs.first["args"]).to eq(["InkClusterer", cluster.id])
     end
 
-    it "does not restart processing logs less than 1 hour old" do
+    it "does not restart processing logs less than 15 minutes old" do
       cluster = create(:micro_cluster)
       log =
-        create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 30.minutes.ago)
+        create(:agent_log, :ink_clusterer, :processing, owner: cluster, created_at: 5.minutes.ago)
 
       described_class.new.perform
 


### PR DESCRIPTION
## Summary

Stacked on top of #3518.

Without an explicit `kill_timeout`, Fly.io SIGKILLs each VM ~5s after SIGTERM, so Sidekiq's graceful shutdown never gets to re-push busy jobs back to Redis. `InkClusterer` runs averaged 30s and peaked at 650s in the last 72h — any in-flight job during a deploy was silently dropped, leaving the `AgentLog` stuck in `processing` until the hourly sweeper destroyed it and started over from scratch.

Three changes:

- **`fly.toml`** — set `kill_timeout = '120s'` so Sidekiq has runway to finish short jobs and re-push longer ones before the VM is killed. Pairs naturally with the health-check wrapper added in #3518: the wrapper forwards SIGTERM to Sidekiq and `wait`s on it, so the longer kill_timeout lets the wrapped Sidekiq drain.
- **`config/sidekiq.yml`** — raise `:timeout` from 25 → 90. Most jobs finish inside this window; keeps strictly below `kill_timeout` so the re-push step still has buffer.
- **`app/workers/run_failed_cluster_jobs.rb`** — tighten the safety net from 1 hour → 15 minutes and stop destroying the `AgentLog`. The agent's existing finder (`ink_clusterer.rb:170-175`) reuses any `processing` log for the same `micro_cluster`, and `restore_transcript` + `trim_dangling_tool_calls` (`ruby_llm_agent.rb:153-193`) replay its messages — so re-enqueuing without destroying preserves prior LLM tokens instead of burning them again.