### PR TITLE
Surface rejection reasons to subsequent ink clustering runs

### DIFF
--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -306,21 +306,39 @@ class InkClusterer
   end
 
   def processed_tries_data
-    data =
-      processed_tries.map do |log|
-        case log.extra_data["action"]
-        when "assign_to_cluster"
-          "Assigning ink to existing cluster with id #{log.extra_data["cluster_id"]}. Assignments to other clusters can be considered."
-        when "create_new_cluster"
-          "Creating a new cluster for ink"
-        when "ignore_ink"
-          "Ignoring this ink"
-        end
-      end
+    entries = processed_tries.map { |log| processed_try_entry(log) }.compact
 
     "This ink was processed before #{processed_tries.count} times and the action taken
-    was manually rejected. Therefore the following outcomes cannot be taken again:
-    #{data.map { |str| "* #{str}" }.join("\n")}"
+    was rejected. Therefore the following outcomes cannot be taken again:
+    #{entries.map { |entry| "* #{entry}" }.join("\n")}"
+  end
+
+  def processed_try_entry(log)
+    data = log.extra_data || {}
+    summary = action_summary(data)
+    return nil unless summary
+
+    parts = [summary]
+    if data["manual_rejection_note"].present?
+      parts << "Rejection reason: #{data["manual_rejection_note"]}"
+    elsif data["follow_up_action"] == "reject" && data["follow_up_action_explanation"].present?
+      if data["explanation_of_decision"].present?
+        parts << "AI reasoning: #{data["explanation_of_decision"]}"
+      end
+      parts << "Rejection reason: #{data["follow_up_action_explanation"]}"
+    end
+    parts.join(" | ")
+  end
+
+  def action_summary(data)
+    case data["action"]
+    when "assign_to_cluster"
+      "Assigning ink to existing cluster with id #{data["cluster_id"]}. Assignments to other clusters can be considered."
+    when "create_new_cluster"
+      "Creating a new cluster for ink"
+    when "ignore_ink"
+      "Ignoring this ink"
+    end
   end
 
   def micro_cluster_data

--- a/app/controllers/admins/agents/ink_clusterer_controller.rb
+++ b/app/controllers/admins/agents/ink_clusterer_controller.rb
@@ -32,6 +32,7 @@ class Admins::Agents::InkClustererController < Admins::BaseController
   end
 
   def destroy
+    persist_manual_rejection_note!
     if agent_log.agent_approved?
       if agent_log.approved?
         # If agent approved it, but it needed to be rejected we need to clean
@@ -51,7 +52,16 @@ class Admins::Agents::InkClustererController < Admins::BaseController
   private
 
   def agent_log
-    AgentLog.find(params[:id])
+    @agent_log ||= AgentLog.find(params[:id])
+  end
+
+  def persist_manual_rejection_note!
+    note = params[:manual_rejection_note].to_s.strip
+    return if note.blank?
+
+    agent_log.update!(
+      extra_data: (agent_log.extra_data || {}).merge("manual_rejection_note" => note)
+    )
   end
 
   def micro_cluster

--- a/app/javascript/admin.js
+++ b/app/javascript/admin.js
@@ -5,9 +5,11 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 import "./color-mode";
 import "./src/admin/graphs";
+import "./src/admin/ink-clusterer-shortcuts";
 import "./src/admin/micro-clusters";
 import "./src/admin/pens-micro-clusters";
 import "./src/admin/pens-model-micro-clusters";
+import "./src/admin/reject-with-note";
 import "./src/admin/stats";
 import "./stylesheets/admin.scss";
 

--- a/app/javascript/src/admin/ink-clusterer-shortcuts.js
+++ b/app/javascript/src/admin/ink-clusterer-shortcuts.js
@@ -1,0 +1,18 @@
+var SHORTCUTS = {
+  a: "approve",
+  r: "reject",
+  d: "reject-delete",
+  s: "search"
+};
+
+document.addEventListener("keydown", function (event) {
+  if (event.metaKey || event.ctrlKey || event.altKey) return;
+  var target = event.target;
+  if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return;
+  var shortcut = SHORTCUTS[event.key.toLowerCase()];
+  if (!shortcut) return;
+  var el = document.querySelector('[data-shortcut="' + shortcut + '"]');
+  if (!el) return;
+  event.preventDefault();
+  el.click();
+});

--- a/app/javascript/src/admin/reject-with-note.js
+++ b/app/javascript/src/admin/reject-with-note.js
@@ -1,0 +1,13 @@
+document.addEventListener("click", function (event) {
+  var btn = event.target.closest(".reject-btn");
+  if (!btn) return;
+  var form = btn.closest("form.reject-form");
+  if (!form) return;
+  var note = form.querySelector(".reject-note");
+  if (!note) return;
+  if (note.dataset.shown === "true") return;
+  event.preventDefault();
+  note.style.cssText = "";
+  note.dataset.shown = "true";
+  note.focus();
+});

--- a/app/views/admins/agents/ink_clusterer/index.html.slim
+++ b/app/views/admins/agents/ink_clusterer/index.html.slim
@@ -67,17 +67,22 @@ table class="table"
       dd class="col-sm-9"
         - if agent_log.agent_approved?
           - if agent_log.approved?
-            = link_to "Approve", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-success me-5'
-            = link_to "Reject approval and reprocess", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, class: 'btn btn-danger me-5'
-            = link_to "Reject approval and reprocess (delete history)", admins_agents_ink_clusterer_path(agent_log, page: params[:page], delete_history: true), method: :delete, class: 'btn btn-danger me-5'
+            = link_to "Approve (a)", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-success me-5', data: { shortcut: "approve" }
+            = form_with url: admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, local: true, class: "d-inline reject-form" do |f|
+              = f.text_field :manual_rejection_note, class: "form-control d-inline-block w-auto me-3 reject-note", placeholder: "Optional rejection note", style: "display: none !important;"
+              = f.submit "Reject approval and reprocess (r)", class: "btn btn-danger me-5 reject-btn", data: { shortcut: "reject" }
+              button.btn.btn-danger.me-5.reject-btn type="submit" formaction=admins_agents_ink_clusterer_path(agent_log, page: params[:page], delete_history: true) data-shortcut="reject-delete"
+                | Reject approval and reprocess (delete history) (d)
           - else
             / Note how the URLs are switched around as if it's already rejected then a rejection will be the implicit approval.
-            = link_to "Approve rejection", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, class: 'btn btn-success me-5'
-            = link_to "Should have been approved", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-danger me-5'
+            = link_to "Approve rejection (a)", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, class: 'btn btn-success me-5', data: { shortcut: "approve" }
+            = link_to "Should have been approved (r)", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-danger me-5', data: { shortcut: "reject" }
         - else
-          = link_to "Approve", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-success me-5'
-          = link_to "Reject", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, class: 'btn btn-danger me-5'
-        = link_to "Search", "https://www.google.com/search?#{{q: agent_log.owner.all_names.first}.to_query}", class: 'btn btn-secondary', target: "_blank"
+          = link_to "Approve (a)", admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :put, class: 'btn btn-success me-5', data: { shortcut: "approve" }
+          = form_with url: admins_agents_ink_clusterer_path(agent_log, page: params[:page]), method: :delete, local: true, class: "d-inline reject-form" do |f|
+            = f.text_field :manual_rejection_note, class: "form-control d-inline-block w-auto me-3 reject-note", placeholder: "Optional rejection note", style: "display: none !important;"
+            = f.submit "Reject (r)", class: "btn btn-danger me-5 reject-btn", data: { shortcut: "reject" }
+        = link_to "Search (s)", "https://www.google.com/search?#{{q: agent_log.owner.all_names.first}.to_query}", class: 'btn btn-secondary', target: "_blank", data: { shortcut: "search" }
     dt class="col-sm-3" Transcript
     dd class="col-sm-9"
       - agent_log.transcript.each do |transcript|

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -939,6 +939,92 @@ RSpec.describe InkClusterer do
         expect(subject.agent_log.extra_data["action"]).to eq("ignore_ink")
         expect(subject.agent_log.extra_data["explanation_of_decision"]).to include("custom mix")
       end
+
+      context "with manual rejection notes and auto-checker explanations" do
+        before do
+          rejected_assign_log.update!(
+            extra_data:
+              rejected_assign_log.extra_data.merge(
+                "explanation_of_decision" => "Looks like Kon-peki",
+                "manual_rejection_note" => "Wrong cluster, the colors differ a lot"
+              )
+          )
+          rejected_create_log.update!(
+            extra_data:
+              rejected_create_log.extra_data.merge(
+                "explanation_of_decision" => "Not in DB yet",
+                "follow_up_action" => "reject",
+                "follow_up_action_explanation" => "Auto-checker found a near duplicate"
+              )
+          )
+        end
+
+        it "surfaces manual notes and auto-checker rejection reasons in the prompt" do
+          subject.perform
+
+          processed_tries_message =
+            subject.agent_log.transcript.find do |msg|
+              msg["content"]&.include?("processed before")
+            end[
+              "content"
+            ]
+
+          expect(processed_tries_message).to include(
+            "Rejection reason: Wrong cluster, the colors differ a lot"
+          )
+          expect(processed_tries_message).not_to include("AI reasoning: Looks like Kon-peki")
+          expect(processed_tries_message).to include("AI reasoning: Not in DB yet")
+          expect(processed_tries_message).to include(
+            "Rejection reason: Auto-checker found a near duplicate"
+          )
+        end
+
+        it "ignores follow_up_action_explanation when follow_up_action is not reject" do
+          rejected_create_log.update!(
+            extra_data:
+              rejected_create_log.extra_data.merge(
+                "follow_up_action" => "approve",
+                "follow_up_action_explanation" => "Auto-checker approved this"
+              )
+          )
+
+          subject.perform
+
+          processed_tries_message =
+            subject.agent_log.transcript.find do |msg|
+              msg["content"]&.include?("processed before")
+            end[
+              "content"
+            ]
+
+          expect(processed_tries_message).not_to include("Auto-checker approved this")
+          expect(processed_tries_message).not_to include("AI reasoning: Not in DB yet")
+        end
+
+        it "omits AI reasoning for manual rejection without a note" do
+          rejected_create_log.destroy!
+          rejected_assign_log.update!(
+            extra_data: {
+              "action" => "assign_to_cluster",
+              "cluster_id" => existing_macro_cluster.id,
+              "explanation_of_decision" => "Looks like Kon-peki"
+            }
+          )
+
+          subject.perform
+
+          processed_tries_message =
+            subject.agent_log.transcript.find do |msg|
+              msg["content"]&.include?("processed before")
+            end[
+              "content"
+            ]
+
+          expect(processed_tries_message).to include("Assigning ink to existing cluster")
+          expect(processed_tries_message).not_to include("AI reasoning")
+          expect(processed_tries_message).not_to include("Rejection reason")
+        end
+      end
     end
 
     context "with ink similarity search integration" do

--- a/spec/requests/admins/agents/ink_clusterer_controller_spec.rb
+++ b/spec/requests/admins/agents/ink_clusterer_controller_spec.rb
@@ -18,4 +18,101 @@ describe Admins::Agents::InkClustererController do
       end
     end
   end
+
+  describe "#destroy" do
+    let(:user) { create(:user) }
+    let!(:collected_ink) { create(:collected_ink, user: user) }
+    let!(:micro_cluster) do
+      cluster = create(:micro_cluster)
+      cluster.collected_inks = [collected_ink]
+      cluster
+    end
+    let!(:agent_log) do
+      AgentLog.create!(
+        name: "InkClusterer",
+        owner: micro_cluster,
+        transcript: [],
+        state: "waiting-for-approval",
+        extra_data: {
+          "action" => "assign_to_cluster",
+          "cluster_id" => 99,
+          "explanation_of_decision" => "Initial reasoning"
+        }
+      )
+    end
+
+    before(:each) { sign_in(admin) }
+
+    it "persists the manual_rejection_note on the agent log" do
+      delete "/admins/agents/ink_clusterer/#{agent_log.id}",
+             params: {
+               manual_rejection_note: "Color is clearly different"
+             }
+
+      expect(agent_log.reload.extra_data["manual_rejection_note"]).to eq(
+        "Color is clearly different"
+      )
+      expect(agent_log.extra_data["explanation_of_decision"]).to eq("Initial reasoning")
+      expect(agent_log.state).to eq(AgentLog::REJECTED)
+    end
+
+    it "ignores blank/whitespace-only notes" do
+      delete "/admins/agents/ink_clusterer/#{agent_log.id}",
+             params: {
+               manual_rejection_note: "   "
+             }
+
+      expect(agent_log.reload.extra_data).not_to have_key("manual_rejection_note")
+      expect(agent_log.state).to eq(AgentLog::REJECTED)
+    end
+
+    it "still works without a note param" do
+      delete "/admins/agents/ink_clusterer/#{agent_log.id}"
+
+      expect(agent_log.reload.extra_data).not_to have_key("manual_rejection_note")
+      expect(agent_log.state).to eq(AgentLog::REJECTED)
+    end
+
+    context "when the agent already approved" do
+      before do
+        agent_log.update!(
+          state: AgentLog::APPROVED,
+          agent_approved: true,
+          approved_at: Time.current
+        )
+      end
+
+      it "persists the note and reprocesses" do
+        delete "/admins/agents/ink_clusterer/#{agent_log.id}",
+               params: {
+                 manual_rejection_note: "Wrong cluster"
+               }
+
+        expect(agent_log.reload.extra_data["manual_rejection_note"]).to eq("Wrong cluster")
+        expect(agent_log.state).to eq(AgentLog::REJECTED)
+      end
+    end
+
+    context "when the agent already rejected" do
+      before do
+        agent_log.update!(
+          state: AgentLog::APPROVED,
+          agent_approved: true,
+          approved_at: Time.current
+        )
+        agent_log.update!(state: "rejected", rejected_at: Time.current)
+      end
+
+      it "still attaches the note even though no reprocess is triggered" do
+        delete "/admins/agents/ink_clusterer/#{agent_log.id}",
+               params: {
+                 manual_rejection_note: "Confirming the rejection"
+               }
+
+        expect(agent_log.reload.extra_data["manual_rejection_note"]).to eq(
+          "Confirming the rejection"
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
The InkClusterer prompt for re-runs only listed what action was rejected, not why, so the LLM kept hitting the same wrong reasoning. Auto-checker rejections now flow their explanation into the prompt, and admins can attach a manual rejection note in the queue UI that takes precedence over (and suppresses) the AI's original reasoning. Also adds a/r/d/s keyboard shortcuts on the admin queue page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admins can now add rejection notes when rejecting items in the ink clusterer workflow.
  * Added keyboard shortcuts for quick admin actions: Approve (a), Reject (r), Delete (d), Search (s).
  * Admin UI buttons now display keyboard shortcut hints for convenient reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->