### PR TITLE
Fix reviews stats accuracy calculation

### DIFF
--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -177,8 +177,8 @@ class ReviewApprover
     data =
       [admin_reviews, user_reviews].flat_map do |relation|
           [
-            relation.where(extra_data: { action: "approve_review" }),
-            relation.where(extra_data: { action: "reject_review" })
+            relation.where("ink_reviews.extra_data->>'action' = ?", "approve_review"),
+            relation.where("ink_reviews.extra_data->>'action' = ?", "reject_review")
           ]
         end
         .flat_map { |relation| relation.approved.limit(5).map { |r| format_review_data(r) } }
@@ -189,8 +189,8 @@ class ReviewApprover
     data =
       [admin_reviews, user_reviews].flat_map do |relation|
           [
-            relation.where(extra_data: { action: "approve_review" }),
-            relation.where(extra_data: { action: "reject_review" })
+            relation.where("ink_reviews.extra_data->>'action' = ?", "approve_review"),
+            relation.where("ink_reviews.extra_data->>'action' = ?", "reject_review")
           ]
         end
         .flat_map { |relation| relation.rejected.limit(5).map { |r| format_review_data(r) } }

--- a/app/controllers/admins/reviews_controller.rb
+++ b/app/controllers/admins/reviews_controller.rb
@@ -42,51 +42,61 @@ class Admins::ReviewsController < Admins::BaseController
         .pluck(:id)
     rel = InkReview.where(id: ids)
 
-    analysis = { total: {}, approved: {}, rejected: {} }
+    analysis = {}
+    analysis[:total] = stats_for(rel)
 
-    approved = rel.approved
-    approved_correct = approved.where(extra_data: { action: "approve_review" })
-    approved_incorrect = approved.where(extra_data: { action: "reject_review" })
-    analysis[:approved] = {
-      count: approved.count,
-      correct: approved_correct.count,
-      incorrect: approved_incorrect.count
-    }
+    actions = rel.distinct.pluck(Arel.sql("extra_data->>'action'")).compact.sort
+    actions.each { |action| analysis[action] = stats_for(rel, agent_action: action) }
 
-    rejected = rel.rejected
-    rejected_correct = rejected.where(extra_data: { action: "reject_review" })
-    rejected_incorrect = rejected.where(extra_data: { action: "approve_review" })
-    analysis[:rejected] = {
-      count: rejected.count,
-      correct: rejected_correct.count,
-      incorrect: rejected_incorrect.count
-    }
-
-    analysis[:approved].keys.each do |key|
-      analysis[:total][key] = analysis[:approved][key] + analysis[:rejected][key]
-    end
-
-    agent_submitted =
-      rel
-        .joins(:ink_review_submissions)
-        .where(ink_review_submissions: { user: User.find_by(email: "urban@bettong.net") })
-        .where("ink_reviews.created_at > ?", Time.parse("2025-05-08 12:25 +0200"))
-
-    analysis[:agent_submitted] = {
-      count: agent_submitted.count,
-      correct: agent_submitted.approved.count,
-      incorrect: agent_submitted.rejected.count
-    }
-
-    %i[total approved rejected agent_submitted].each do |key|
-      analysis[key][:correct_percentage] = (
-        analysis[key][:correct].to_f / analysis[key][:count].to_f * 100
-      )
-      analysis[key][:incorrect_percentage] = (
-        analysis[key][:incorrect].to_f / analysis[key][:count].to_f * 100
-      )
-    end
-
+    analysis[:agent_submitted] = stats_for_agent_submitted(rel)
     analysis
+  end
+
+  def stats_for(rel, agent_action: nil)
+    scope = agent_action ? rel.where("extra_data->>'action' = ?", agent_action) : rel
+    approved = scope.approved.count
+    rejected = scope.rejected.count
+    count = approved + rejected
+
+    case agent_action
+    when "approve_review"
+      correct = approved
+      incorrect = rejected
+    when "reject_review"
+      correct = rejected
+      incorrect = approved
+    else
+      correct =
+        scope.approved.where("extra_data->>'action' = ?", "approve_review").count +
+          scope.rejected.where("extra_data->>'action' = ?", "reject_review").count
+      incorrect = count - correct
+    end
+
+    { count: count, correct: correct, incorrect: incorrect }.merge(
+      percentages(count, correct, incorrect)
+    )
+  end
+
+  def stats_for_agent_submitted(rel)
+    agent_submitted =
+      rel.joins(:ink_review_submissions).where(
+        ink_review_submissions: {
+          user: User.find_by(email: "urban@bettong.net")
+        }
+      )
+    count = agent_submitted.count
+    correct = agent_submitted.approved.count
+    incorrect = agent_submitted.rejected.count
+    { count: count, correct: correct, incorrect: incorrect }.merge(
+      percentages(count, correct, incorrect)
+    )
+  end
+
+  def percentages(count, correct, incorrect)
+    return { correct_percentage: 0.0, incorrect_percentage: 0.0 } if count.zero?
+    {
+      correct_percentage: correct.to_f / count * 100,
+      incorrect_percentage: incorrect.to_f / count * 100
+    }
   end
 end

--- a/spec/agents/review_approver_spec.rb
+++ b/spec/agents/review_approver_spec.rb
@@ -620,6 +620,35 @@ RSpec.describe ReviewApprover do
         expect(approved_data).to be_an(Array)
         expect(rejected_data).to be_an(Array)
       end
+
+      it "matches reviews whose extra_data has keys beyond `action`" do
+        approved_with_explanation =
+          create(
+            :ink_review,
+            title: "Approved with explanation",
+            url: "https://example.com/approved-explanation",
+            macro_cluster: macro_cluster,
+            approved_at: 1.day.ago,
+            extra_data: {
+              action: "approve_review",
+              explanation_of_decision: "Looks like a real review"
+            }
+          )
+        create(
+          :ink_review_submission,
+          ink_review: approved_with_explanation,
+          user: user,
+          macro_cluster: macro_cluster,
+          url: approved_with_explanation.url
+        )
+
+        approver = described_class.new(ink_review.id)
+        approved_message = approver.send(:approved_reviews_data)
+        approved_data =
+          JSON.parse(approved_message.gsub("Here are some examples of approved reviews: ", ""))
+
+        expect(approved_data.map { |r| r["title"] }).to include("Approved with explanation")
+      end
     end
 
     describe "#format_cluster_data" do

--- a/spec/requests/admins/reviews_spec.rb
+++ b/spec/requests/admins/reviews_spec.rb
@@ -16,6 +16,99 @@ describe "Admins::Reviews" do
         get "/admins/reviews"
         expect(response).to be_successful
       end
+
+      describe "stats table" do
+        def manually_processed_review(agent_action:, final:)
+          review =
+            create(
+              :ink_review,
+              extra_data: {
+                "action" => agent_action,
+                "explanation_of_decision" => "..."
+              }
+            )
+          create(
+            :ink_review_submission,
+            ink_review: review,
+            macro_cluster: review.macro_cluster,
+            url: review.url
+          )
+          if final == :approved
+            review.approve!
+          else
+            review.reject!
+          end
+          review
+        end
+
+        it "renders a table even when there are no reviews to analyse" do
+          get "/admins/reviews"
+          expect(response.body).to include("total")
+          expect(response.body).to include("0.000%")
+          expect(response.body).not_to include("NaN")
+        end
+
+        it "counts agent decisions that match the human verdict as correct and mismatches as incorrect" do
+          # 3 cases where the agent approved
+          2.times { manually_processed_review(agent_action: "approve_review", final: :approved) }
+          manually_processed_review(agent_action: "approve_review", final: :rejected)
+
+          # 5 cases where the agent rejected
+          4.times { manually_processed_review(agent_action: "reject_review", final: :rejected) }
+          manually_processed_review(agent_action: "reject_review", final: :approved)
+
+          # Excluded: empty extra_data
+          create(:ink_review, extra_data: {}).approve!
+          # Excluded: still waiting on a human (agent_processed scope)
+          waiting =
+            create(
+              :ink_review,
+              image: "http://example.com/img.png",
+              extra_data: {
+                "action" => "approve_review"
+              },
+              approved_at: Time.current,
+              agent_approved: true
+            )
+          create(
+            :ink_review_submission,
+            ink_review: waiting,
+            macro_cluster: waiting.macro_cluster,
+            url: waiting.url
+          )
+
+          get "/admins/reviews"
+          stats = controller.instance_variable_get(:@stats)
+
+          expect(stats[:total]).to include(count: 8, correct: 6, incorrect: 2)
+          expect(stats["approve_review"]).to include(count: 3, correct: 2, incorrect: 1)
+          expect(stats["reject_review"]).to include(count: 5, correct: 4, incorrect: 1)
+        end
+
+        it "reports agent-submitted reviews when the bettong.net user owns the submission" do
+          agent_user = create(:user, :admin, email: "urban@bettong.net")
+          other_user = create(:user)
+
+          agent_review = manually_processed_review(agent_action: "approve_review", final: :approved)
+          agent_review.ink_review_submissions.create!(
+            user: agent_user,
+            macro_cluster: agent_review.macro_cluster,
+            url: agent_review.url
+          )
+
+          other_review = manually_processed_review(agent_action: "approve_review", final: :approved)
+          other_review.ink_review_submissions.create!(
+            user: other_user,
+            macro_cluster: other_review.macro_cluster,
+            url: other_review.url
+          )
+
+          get "/admins/reviews"
+          stats = controller.instance_variable_get(:@stats)
+
+          expect(stats[:agent_submitted]).to include(count: 1, correct: 1, incorrect: 0)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The accuracy percentages on `/admins/reviews` always read as 0% correct because `where(extra_data: { action: "..." })` on a jsonb column compiles to strict equality on Rails 8.1, and `ReviewApprover` stores both `action` and `explanation_of_decision` so no rows ever matched. Switch the stats query and the agent's example-review queries to the `extra_data->>'action' = ?` fragment, restructure the stats table to break down by agent action like the `ink_clusterer` page does, drop the stale hardcoded `2025-05-08` cutoff from `agent_submitted`, and guard the percentage math against divide-by-zero.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect statistics calculations in the admin reviews dashboard, including preventing NaN percentage values when no reviews exist and improving accuracy of agent decision tracking.

* **Tests**
  * Added test coverage for edge cases in admin review statistics, including scenarios with zero reviews and reviews with additional metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->