### PR TITLE
Feed YouTube thumbnails, tags, comments, and captions to review agents

### DIFF
--- a/app/agents/concerns/ruby_llm_agent.rb
+++ b/app/agents/concerns/ruby_llm_agent.rb
@@ -15,8 +15,9 @@ module RubyLlmAgent
 
   # Use this instead of chat.ask to ensure the transcript is saved
   # before the API call, matching the old AgentTranscript behavior.
-  def ask(prompt)
-    chat.add_message(role: :user, content: prompt)
+  # Pass `with:` (URL/path or array) to attach images/files for vision-capable models.
+  def ask(prompt, with: nil)
+    chat.add_message(role: :user, content: build_user_content(prompt, with))
     save_transcript
     chat.complete
   end
@@ -25,8 +26,8 @@ module RubyLlmAgent
   # tool_choice: required only forces the first response to include a tool call,
   # but after that RubyLLM resets it. If the LLM calls a non-halting tool first
   # and then responds with text, we retry with a nudge message.
-  def ask!(prompt)
-    chat.add_message(role: :user, content: prompt)
+  def ask!(prompt, with: nil)
+    chat.add_message(role: :user, content: build_user_content(prompt, with))
     save_transcript
     chat.with_tool(nil, choice: :required)
     result = chat.complete
@@ -58,6 +59,16 @@ module RubyLlmAgent
   end
 
   private
+
+  # Wraps text + optional attachments into a RubyLLM::Content when attachments
+  # are present, otherwise returns the plain string. Attachments may be a single
+  # URL/path or an array.
+  def build_user_content(prompt, with)
+    attachments = Array(with).compact.reject { |a| a.respond_to?(:blank?) && a.blank? }
+    return prompt if attachments.empty?
+
+    RubyLLM::Content.new(prompt, attachments)
+  end
 
   def model_id
     self.class::MODEL_ID
@@ -131,11 +142,20 @@ module RubyLlmAgent
 
   def serialize_messages(messages)
     messages.map do |msg|
-      entry = { role: msg.role.to_s, content: sanitize_for_pg(msg.content.to_s) }
+      entry = { role: msg.role.to_s, content: sanitize_for_pg(extract_text(msg.content)) }
       entry[:tool_calls] = serialize_tool_calls(msg.tool_calls) if msg.tool_call?
       entry[:tool_call_id] = msg.tool_call_id if msg.tool_result?
       entry
     end
+  end
+
+  # Attachments (RubyLLM::Content) are not persisted in the transcript — only
+  # the text portion is. On resume, the original image is lost; this is
+  # acceptable because resumes only continue tool loops, not re-pose the
+  # original prompt.
+  def extract_text(content)
+    return content.text if content.respond_to?(:text)
+    content.to_s
   end
 
   def serialize_tool_calls(tool_calls)

--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -62,10 +62,12 @@ class ReviewApprover
     end
 
     def execute
-      page_data = Unfurler.new(ink_review.url).perform
-      if page_data.you_tube_channel_id.present?
-        "This is a Youtube video. I can't summarize it."
+      if ink_review.you_tube_channel_id.present?
+        ink_review.ensure_youtube_metadata!
+        summary = YoutubeSummarizer.new(agent_log, ink_review).perform
+        "Here is a summary of the YouTube video:\n\n#{summary}"
       else
+        page_data = Unfurler.new(ink_review.url).perform
         summary = WebPageSummarizer.new(agent_log, page_data.raw_html).perform
         "Here is a summary of the page:\n\n#{summary}"
       end
@@ -89,9 +91,17 @@ class ReviewApprover
       that the ink does not appear in the review, after all.
     * Reviews that are not submitted by user "System" have a higher likelihood of being correct.
 
-    If the review is not a Youtube video, you can also use the `summarize` function to get a summary of the page
-    to better understand which inks are being reviewed. For Youtube videos, you need to rely on the
-    information provided in the review.
+    For both web pages and Youtube videos you can call the `summarize` function to get a summary.
+    For Youtube videos the summary draws on the video's captions (when available) and thumbnail.
+
+    For Youtube videos the review data also includes `youtube_tags`, the top three relevance-ranked
+    `top_comments`, and a `has_captions` boolean. Use these to judge the review without always calling
+    `summarize` — call it for borderline cases or when `has_captions` is true and you want the
+    transcript-derived content.
+
+    A thumbnail image of the video or page is attached to this message. Use it to confirm the ink
+    identity when the text is ambiguous — many ink-review thumbnails show the ink bottle and/or the
+    ink name as a text overlay.
   TEXT
 
   def initialize(ink_review_id)
@@ -99,7 +109,8 @@ class ReviewApprover
   end
 
   def perform
-    ask!(user_prompt)
+    ink_review.ensure_youtube_metadata!
+    ask!(user_prompt, with: ink_review.image.presence)
     agent_log.update!(extra_data: ink_review.extra_data)
     agent_log.waiting_for_approval!
   end
@@ -169,6 +180,9 @@ class ReviewApprover
     if review.you_tube_channel
       data[:is_you_tube_video] = true
       data[:is_youtube_short] = review.you_tube_short?
+      data[:youtube_tags] = review.youtube_tags
+      data[:top_comments] = review.youtube_comments.first(3).map { |c| c.slice("author", "text") }
+      data[:has_captions] = review.youtube_captions.present?
     end
     data
   end

--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -181,7 +181,9 @@ class ReviewApprover
       data[:is_you_tube_video] = true
       data[:is_youtube_short] = review.you_tube_short?
       data[:youtube_tags] = review.youtube_tags
-      data[:top_comments] = review.youtube_comments.first(3).map { |c| c.slice("author", "text") }
+      data[:top_comments] = Array(review.youtube_comments)
+        .first(3)
+        .map { |c| c.slice("author", "text") }
       data[:has_captions] = review.youtube_captions.present?
     end
     data

--- a/app/agents/review_finder.rb
+++ b/app/agents/review_finder.rb
@@ -56,7 +56,8 @@ class ReviewFinder
 
     def execute
       if page_data.you_tube_channel_id.present?
-        "This is a Youtube video. I can't summarize it."
+        summary = YoutubeSummarizer.new(agent_log, page_data).perform
+        "Here is a summary of the YouTube video:\n\n#{summary}"
       else
         summary = WebPageSummarizer.new(agent_log, page_data.raw_html).perform
         "Here is a summary of the page:\n\n#{summary}"
@@ -85,11 +86,18 @@ class ReviewFinder
        reviews.
 
     You will be given a prompt with the page data, which contains information
-    about the page or video, such as its title, description, and content. You
-    can use this information to determine if the page or video contains reviews
-    of inks. For web pages call the `summarize` function to get a more detailed
-    summary of the page, which might contain more information than is available
-    in the page data.
+    about the page or video, such as its title, description, and content. For
+    Youtube videos the page data also includes a `youtube` sub-hash with tags,
+    top comments, and captions (when available). Use these to determine if the
+    page or video contains reviews of inks.
+
+    For web pages and Youtube videos alike you can call the `summarize` function
+    to get a more detailed summary. For Youtube videos the summary draws on the
+    captions and thumbnail.
+
+    A thumbnail image of the page or video is attached to this message. Use it
+    to confirm the ink identity when the text is ambiguous — many ink-review
+    thumbnails show the ink bottle and/or the ink name as a text overlay.
   TEXT
 
   def initialize(page)
@@ -97,7 +105,7 @@ class ReviewFinder
   end
 
   def perform
-    ask(user_prompt)
+    ask(user_prompt, with: page_data.image.presence)
     agent_log.waiting_for_approval!
   end
 
@@ -126,6 +134,6 @@ class ReviewFinder
   end
 
   def page_data
-    @page_data ||= Unfurler.new(page.url).perform
+    @page_data ||= Unfurler.new(page.url, with_full_metadata: true).perform
   end
 end

--- a/app/agents/youtube_summarizer.rb
+++ b/app/agents/youtube_summarizer.rb
@@ -1,0 +1,77 @@
+class YoutubeSummarizer
+  include RubyLlmAgent
+
+  MODEL_ID = "gpt-4.1-mini"
+
+  SYSTEM_DIRECTIVE = <<~TEXT
+    You will be given a YouTube video's metadata: title, description, tags, top
+    comments, captions (when available), and a thumbnail image. Summarize which
+    fountain pen inks (if any) are reviewed in the video, what the reviewer
+    says about each ink, and whether the video is a focused ink review or
+    something else (unboxing, currently-inked, live stream, passing mention).
+    Be concise and factual.
+  TEXT
+
+  def initialize(parent_agent_log, source)
+    self.parent_agent_log = parent_agent_log
+    self.source = source
+  end
+
+  def perform
+    response = ask(prompt_text, with: source_image.presence)
+    agent_log.waiting_for_approval!
+    response.content
+  end
+
+  def agent_log = find_or_create_agent_log(parent_agent_log)
+
+  private
+
+  attr_accessor :parent_agent_log, :source
+
+  def prompt_text
+    [
+      "Title: #{source_title}",
+      "Description: #{source_description}",
+      "Tags: #{Array(source_tags).join(", ")}",
+      "Top comments: #{format_comments(source_comments)}",
+      "Captions: #{source_captions.presence || "(none available)"}"
+    ].join("\n\n")
+  end
+
+  def format_comments(comments)
+    return "(none)" if comments.blank?
+    Array(comments)
+      .first(3)
+      .map { |c| "- #{c[:author] || c["author"]}: #{c[:text] || c["text"]}" }
+      .join("\n")
+  end
+
+  def source_title = source.respond_to?(:title) ? source.title.to_s : ""
+  def source_description = source.respond_to?(:description) ? source.description.to_s : ""
+  def source_image = source.respond_to?(:image) ? source.image.to_s : ""
+
+  def source_tags
+    if source.respond_to?(:youtube_tags)
+      source.youtube_tags
+    elsif source.respond_to?(:youtube)
+      source.youtube&.[](:tags)
+    end
+  end
+
+  def source_comments
+    if source.respond_to?(:youtube_comments)
+      source.youtube_comments
+    elsif source.respond_to?(:youtube)
+      source.youtube&.[](:comments)
+    end
+  end
+
+  def source_captions
+    if source.respond_to?(:youtube_captions)
+      source.youtube_captions
+    elsif source.respond_to?(:youtube)
+      source.youtube&.[](:captions)
+    end
+  end
+end

--- a/app/lib/youtube/video_id_parser.rb
+++ b/app/lib/youtube/video_id_parser.rb
@@ -1,0 +1,21 @@
+class Youtube
+  module VideoIdParser
+    module_function
+
+    def parse(url)
+      uri = URI(url)
+      if uri.host =~ /youtube\.com/
+        Rack::Utils.parse_query(uri.query)["v"] || shorts_id(uri.path)
+      elsif uri.host =~ /youtu\.be/
+        uri.path[1..-1]
+      end
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def shorts_id(path)
+      match = path.match(%r{/shorts/([^/]+)})
+      match && match[1]
+    end
+  end
+end

--- a/app/lib/youtube/video_id_parser.rb
+++ b/app/lib/youtube/video_id_parser.rb
@@ -4,9 +4,10 @@ class Youtube
 
     def parse(url)
       uri = URI(url)
-      if uri.host =~ /youtube\.com/
+      host = uri.host.to_s.downcase
+      if host == "youtube.com" || host.end_with?(".youtube.com")
         Rack::Utils.parse_query(uri.query)["v"] || shorts_id(uri.path)
-      elsif uri.host =~ /youtu\.be/
+      elsif host == "youtu.be" || host.end_with?(".youtu.be")
         uri.path[1..-1]
       end
     rescue URI::InvalidURIError

--- a/app/models/ink_review.rb
+++ b/app/models/ink_review.rb
@@ -128,11 +128,15 @@ class InkReview < ApplicationRecord
     vid = video_id
     return if vid.blank?
 
-    update!(
-      youtube_comments: Unfurler::Youtube::Comments.new(vid).fetch,
-      youtube_captions: Unfurler::Youtube::Captions.new(vid).fetch,
-      youtube_metadata_fetched_at: Time.current
-    )
+    with_lock do
+      return if youtube_metadata_fetched_at.present?
+
+      update!(
+        youtube_comments: Unfurler::Youtube::Comments.new(vid).fetch,
+        youtube_captions: Unfurler::Youtube::Captions.new(vid).fetch,
+        youtube_metadata_fetched_at: Time.current
+      )
+    end
   end
 
   def video_id

--- a/app/models/ink_review.rb
+++ b/app/models/ink_review.rb
@@ -117,6 +117,28 @@ class InkReview < ApplicationRecord
     macro_cluster.ink_reviews.live.exists?
   end
 
+  # Fetches YouTube comments and captions and persists them on the review.
+  # Lazy / fetch-once: re-runs are skipped once youtube_metadata_fetched_at is
+  # set. Tags are not (re-)fetched here — they're populated synchronously in
+  # ProcessInkReviewSubmission from the snippet response.
+  def ensure_youtube_metadata!
+    return if you_tube_channel_id.blank?
+    return if youtube_metadata_fetched_at.present?
+
+    vid = video_id
+    return if vid.blank?
+
+    update!(
+      youtube_comments: Unfurler::Youtube::Comments.new(vid).fetch,
+      youtube_captions: Unfurler::Youtube::Captions.new(vid).fetch,
+      youtube_metadata_fetched_at: Time.current
+    )
+  end
+
+  def video_id
+    Youtube::VideoIdParser.parse(url)
+  end
+
   private
 
   def set_host!(value)

--- a/app/operations/unfurler.rb
+++ b/app/operations/unfurler.rb
@@ -40,15 +40,11 @@ class Unfurler
   end
 
   def youtube?
-    uri.host =~ /youtube.com|youtu.be/ && video_id.present?
+    video_id.present?
   end
 
   def video_id
-    if uri.host =~ /youtube.com/
-      Rack::Utils.parse_query(uri.query)["v"]
-    elsif uri.host =~ /youtu.be/
-      uri.path[1..-1]
-    end
+    @video_id ||= ::Youtube::VideoIdParser.parse(uri.to_s)
   end
 
   def html

--- a/app/operations/unfurler.rb
+++ b/app/operations/unfurler.rb
@@ -8,25 +8,35 @@ class Unfurler
       :author,
       :you_tube_channel_id,
       :is_youtube_short,
-      :raw_html
+      :raw_html,
+      :youtube
     )
 
-  def initialize(url)
+  def initialize(url, with_full_metadata: false)
     self.uri = URI(url)
+    self.with_full_metadata = with_full_metadata
   end
 
   def perform
     result = unfurler.perform
     result.url ||= uri.to_s
+    enrich_youtube_metadata(result) if with_full_metadata && result.you_tube_channel_id.present?
     result
   end
 
   private
 
-  attr_accessor :uri
+  attr_accessor :uri, :with_full_metadata
 
   def unfurler
     youtube? ? Unfurler::Youtube.new(video_id) : Unfurler::Html.new(html)
+  end
+
+  def enrich_youtube_metadata(result)
+    yt = result.youtube || { tags: [], comments: nil, captions: nil }
+    yt[:comments] ||= Unfurler::Youtube::Comments.new(video_id).fetch
+    yt[:captions] ||= Unfurler::Youtube::Captions.new(video_id).fetch
+    result.youtube = yt
   end
 
   def youtube?

--- a/app/operations/unfurler/youtube.rb
+++ b/app/operations/unfurler/youtube.rb
@@ -5,7 +5,9 @@ class Unfurler
     end
 
     def perform
-      Result.new(url, title, description, image, author, channel_id, is_short)
+      result =
+        Result.new(url, title, description, image, author, channel_id, is_short, nil, youtube_data)
+      result
     end
 
     private
@@ -40,6 +42,12 @@ class Unfurler
 
     def is_short
       Faraday.get("https://www.youtube.com/shorts/#{video_id}").status == 200
+    end
+
+    # Eager: tags ship with the snippet call we already make. Comments and
+    # captions are fetched lazily by the caller when needed.
+    def youtube_data
+      { tags: Array(video.snippet.tags), comments: nil, captions: nil }
     end
 
     def video

--- a/app/operations/unfurler/youtube/captions.rb
+++ b/app/operations/unfurler/youtube/captions.rb
@@ -51,7 +51,7 @@ class Unfurler
       end
 
       def default_connection
-        Faraday.new { |c| c.response :follow_redirects }
+        Faraday.new(request: { open_timeout: 3, timeout: 8 }) { |c| c.response :follow_redirects }
       end
     end
   end

--- a/app/operations/unfurler/youtube/captions.rb
+++ b/app/operations/unfurler/youtube/captions.rb
@@ -1,0 +1,58 @@
+class Unfurler
+  class Youtube
+    class Captions
+      MAX_CHARS = 8_000
+      ENDPOINT = "https://www.youtube.com/api/timedtext".freeze
+
+      # Try human-authored tracks first, then auto-generated (ASR). Most
+      # ink-review channels rely on auto-captions; without ASR fallback the
+      # coverage drops by an order of magnitude.
+      ATTEMPTS = [
+        { lang: "en" },
+        { lang: "en-US" },
+        { lang: "en", kind: "asr" },
+        { lang: "en-US", kind: "asr" }
+      ].freeze
+
+      def initialize(video_id, connection: default_connection)
+        self.video_id = video_id
+        self.connection = connection
+      end
+
+      def fetch
+        ATTEMPTS.each do |params|
+          text = fetch_attempt(params)
+          return text if text.present?
+        end
+        nil
+      end
+
+      private
+
+      attr_accessor :video_id, :connection
+
+      def fetch_attempt(params)
+        response = connection.get(ENDPOINT, params.merge(v: video_id))
+        return nil unless response.success?
+        return nil if response.body.to_s.strip.empty?
+
+        parse(response.body)
+      rescue Faraday::Error
+        nil
+      end
+
+      def parse(xml)
+        doc = Nokogiri.XML(xml)
+        text = doc.css("text").map { |node| CGI.unescapeHTML(node.text.to_s) }.join(" ")
+        text = text.gsub(/\s+/, " ").strip
+        return nil if text.empty?
+
+        text.length > MAX_CHARS ? text[0, MAX_CHARS] : text
+      end
+
+      def default_connection
+        Faraday.new { |c| c.response :follow_redirects }
+      end
+    end
+  end
+end

--- a/app/operations/unfurler/youtube/comments.rb
+++ b/app/operations/unfurler/youtube/comments.rb
@@ -1,0 +1,41 @@
+class Unfurler
+  class Youtube
+    class Comments
+      MAX_RESULTS = 10
+
+      def initialize(video_id, client: ::Youtube::Client.new)
+        self.video_id = video_id
+        self.client = client
+      end
+
+      def fetch
+        response =
+          client.list_comment_threads(
+            "snippet",
+            video_id: video_id,
+            order: "relevance",
+            max_results: MAX_RESULTS
+          )
+        Array(response.items).map { |item| transform(item) }
+      rescue Google::Apis::ClientError => e
+        return [] if comments_unavailable?(e)
+        raise
+      end
+
+      private
+
+      attr_accessor :video_id, :client
+
+      def transform(item)
+        top = item.snippet.top_level_comment.snippet
+        { author: top.author_display_name, text: top.text_display, like_count: top.like_count }
+      end
+
+      def comments_unavailable?(error)
+        message = error.message.to_s
+        message.include?("commentsDisabled") || message.include?("forbidden") ||
+          message.include?("disabled comments")
+      end
+    end
+  end
+end

--- a/app/operations/unfurler/youtube/comments.rb
+++ b/app/operations/unfurler/youtube/comments.rb
@@ -33,8 +33,7 @@ class Unfurler
 
       def comments_unavailable?(error)
         message = error.message.to_s
-        message.include?("commentsDisabled") || message.include?("forbidden") ||
-          message.include?("disabled comments")
+        message.include?("commentsDisabled") || message.include?("disabled comments")
       end
     end
   end

--- a/app/workers/process_ink_review_submission.rb
+++ b/app/workers/process_ink_review_submission.rb
@@ -26,7 +26,11 @@ class ProcessInkReviewSubmission
     end
     if you_tube_channel_id
       channel = YouTubeChannel.find_or_create_by(channel_id: you_tube_channel_id)
-      ink_review.update!(you_tube_channel: channel, you_tube_short: is_youtube_short)
+      ink_review.update!(
+        you_tube_channel: channel,
+        you_tube_short: is_youtube_short,
+        youtube_tags: Array(page_data.youtube&.[](:tags))
+      )
       if ink_review.auto_reject?
         ink_review.auto_reject!
         schedule_approval = false

--- a/db/migrate/20260522123500_add_youtube_metadata_to_ink_reviews.rb
+++ b/db/migrate/20260522123500_add_youtube_metadata_to_ink_reviews.rb
@@ -1,0 +1,8 @@
+class AddYoutubeMetadataToInkReviews < ActiveRecord::Migration[8.1]
+  def change
+    add_column :ink_reviews, :youtube_tags, :jsonb, default: [], null: false
+    add_column :ink_reviews, :youtube_comments, :jsonb, default: [], null: false
+    add_column :ink_reviews, :youtube_captions, :text
+    add_column :ink_reviews, :youtube_metadata_fetched_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -576,7 +576,11 @@ CREATE TABLE public.ink_reviews (
     you_tube_short boolean DEFAULT false,
     agent_approved boolean DEFAULT false,
     next_check_at timestamp(6) without time zone,
-    check_count integer DEFAULT 0 NOT NULL
+    check_count integer DEFAULT 0 NOT NULL,
+    youtube_tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    youtube_comments jsonb DEFAULT '[]'::jsonb NOT NULL,
+    youtube_captions text,
+    youtube_metadata_fetched_at timestamp(6) without time zone
 );
 
 
@@ -2389,6 +2393,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260522123500'),
 ('20260413083719'),
 ('20260325150042'),
 ('20260308164655'),

--- a/spec/agents/concerns/ruby_llm_agent_spec.rb
+++ b/spec/agents/concerns/ruby_llm_agent_spec.rb
@@ -409,4 +409,137 @@ RSpec.describe RubyLlmAgent do
       expect(result).to be_a(RubyLLM::Tool::Halt)
     end
   end
+
+  describe "#ask with attachments" do
+    let(:agent_with_tools) { test_class_with_tools.new(agent_log, decide_tool_class.new) }
+
+    def text_completion
+      {
+        "id" => "chatcmpl-attach",
+        "object" => "chat.completion",
+        "created" => 1_677_652_288,
+        "model" => "gpt-4.1-mini",
+        "choices" => [
+          {
+            "index" => 0,
+            "message" => {
+              "role" => "assistant",
+              "content" => "ok"
+            },
+            "finish_reason" => "stop"
+          }
+        ],
+        "usage" => {
+          "prompt_tokens" => 10,
+          "completion_tokens" => 5,
+          "total_tokens" => 15
+        }
+      }
+    end
+
+    it "sends a multipart user message when `with:` is a URL" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+        status: 200,
+        body: text_completion.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+
+      agent_with_tools.ask("Describe this", with: "https://example.com/img.jpg")
+
+      expect(WebMock).to have_requested(
+        :post,
+        "https://api.openai.com/v1/chat/completions"
+      ).with { |req|
+        body = JSON.parse(req.body)
+        user_msg = body["messages"].find { |m| m["role"] == "user" }
+        parts = user_msg["content"]
+        parts.is_a?(Array) && parts.any? { |p| p["type"] == "image_url" } &&
+          parts.any? { |p| p["type"] == "text" }
+      }
+    end
+
+    it "sends a multipart user message when `with:` is an array of URLs" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+        status: 200,
+        body: text_completion.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+
+      agent_with_tools.ask(
+        "Describe these",
+        with: %w[https://example.com/a.jpg https://example.com/b.jpg]
+      )
+
+      expect(WebMock).to have_requested(
+        :post,
+        "https://api.openai.com/v1/chat/completions"
+      ).with { |req|
+        body = JSON.parse(req.body)
+        user_msg = body["messages"].find { |m| m["role"] == "user" }
+        parts = user_msg["content"]
+        parts.is_a?(Array) && parts.count { |p| p["type"] == "image_url" } == 2
+      }
+    end
+
+    it "sends a plain string user message when `with:` is nil" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+        status: 200,
+        body: text_completion.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+
+      agent_with_tools.ask("Just text")
+
+      expect(WebMock).to have_requested(
+        :post,
+        "https://api.openai.com/v1/chat/completions"
+      ).with { |req|
+        body = JSON.parse(req.body)
+        user_msg = body["messages"].find { |m| m["role"] == "user" }
+        user_msg["content"] == "Just text"
+      }
+    end
+
+    it "sends a plain string user message when `with:` is blank" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+        status: 200,
+        body: text_completion.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+
+      agent_with_tools.ask("Just text", with: "")
+
+      expect(WebMock).to have_requested(
+        :post,
+        "https://api.openai.com/v1/chat/completions"
+      ).with { |req|
+        body = JSON.parse(req.body)
+        user_msg = body["messages"].find { |m| m["role"] == "user" }
+        user_msg["content"] == "Just text"
+      }
+    end
+
+    it "persists only the text portion of an attachment message in the transcript" do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+        status: 200,
+        body: text_completion.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+
+      agent_with_tools.ask("Describe this", with: "https://example.com/img.jpg")
+
+      user_entry = agent_log.reload.transcript.find { |m| m["role"] == "user" }
+      expect(user_entry["content"]).to eq("Describe this")
+    end
+  end
 end

--- a/spec/agents/review_approver_spec.rb
+++ b/spec/agents/review_approver_spec.rb
@@ -128,6 +128,16 @@ RSpec.describe ReviewApprover do
 
   subject { described_class.new(ink_review.id) }
 
+  def user_message_text(body)
+    user_msg = body["messages"].find { |m| m["role"] == "user" }
+    content = user_msg&.[]("content")
+    return content if content.is_a?(String)
+    return "" unless content.is_a?(Array)
+
+    text_part = content.find { |p| p["type"] == "text" }
+    text_part&.[]("text") || ""
+  end
+
   describe "#initialize" do
     it "creates agent with correct owner" do
       approver = described_class.new(ink_review.id)
@@ -279,16 +289,22 @@ RSpec.describe ReviewApprover do
         )
       end
 
-      it "returns message for YouTube videos without calling WebPageSummarizer" do
-        allow(Unfurler).to receive(:new).with(ink_review.url).and_return(
-          double(perform: youtube_unfurler_result)
+      it "summarizes YouTube videos via YoutubeSummarizer" do
+        ink_review.update!(
+          you_tube_channel: youtube_channel,
+          url: "https://www.youtube.com/watch?v=abc123"
         )
+        allow(ink_review).to receive(:ensure_youtube_metadata!)
         allow(WebPageSummarizer).to receive(:new)
+        allow(YoutubeSummarizer).to receive(:new).with(tool_agent_log, ink_review).and_return(
+          double(perform: "Reviews Pilot Tsuki-yo.")
+        )
 
         tool = described_class.new(ink_review, tool_agent_log)
         result = tool.call({})
 
-        expect(result).to eq("This is a Youtube video. I can't summarize it.")
+        expect(result).to eq("Here is a summary of the YouTube video:\n\nReviews Pilot Tsuki-yo.")
+        expect(ink_review).to have_received(:ensure_youtube_metadata!)
         expect(WebPageSummarizer).not_to have_received(:new)
       end
     end
@@ -426,18 +442,108 @@ RSpec.describe ReviewApprover do
         expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
           .with { |req|
             body = JSON.parse(req.body)
-            content = body["messages"].find { |m| m["role"] == "user" }&.[]("content")
+            text = user_message_text(body)
 
-            expect(content).to include("The data for the ink is:")
-            expect(content).to include("Pilot Iroshizuku Tsuki-yo")
-            expect(content).to include("The review data is:")
-            expect(content).to include("Great ink review")
-            expect(content).to include("Here are some examples of approved reviews:")
-            expect(content).to include("Here are some examples of rejected reviews:")
+            expect(text).to include("The data for the ink is:")
+            expect(text).to include("Pilot Iroshizuku Tsuki-yo")
+            expect(text).to include("The review data is:")
+            expect(text).to include("Great ink review")
+            expect(text).to include("Here are some examples of approved reviews:")
+            expect(text).to include("Here are some examples of rejected reviews:")
 
             true
           }
           .at_least_once
+      end
+
+      it "attaches the thumbnail as an image_url part" do
+        subject.perform
+
+        expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+          .with { |req|
+            body = JSON.parse(req.body)
+            user_msg = body["messages"].find { |m| m["role"] == "user" }
+            parts = user_msg["content"]
+
+            parts.is_a?(Array) &&
+              parts.any? do |p|
+                p["type"] == "image_url" && p["image_url"]["url"] == ink_review.image
+              end
+          }
+          .at_least_once
+      end
+
+      context "when the review has a blank image" do
+        before { ink_review.update_column(:image, "") }
+
+        it "sends a plain string user message" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+            .with { |req|
+              body = JSON.parse(req.body)
+              user_msg = body["messages"].find { |m| m["role"] == "user" }
+              user_msg["content"].is_a?(String)
+            }
+            .at_least_once
+        end
+      end
+
+      context "for a YouTube review with metadata" do
+        before do
+          create(
+            :ink_review_submission,
+            ink_review: youtube_ink_review,
+            user: user,
+            macro_cluster: macro_cluster,
+            url: youtube_ink_review.url
+          )
+          youtube_ink_review.update!(
+            youtube_tags: %w[ink review pilot],
+            youtube_comments: [
+              { author: "Alice", text: "Tsuki-yo is gorgeous", like_count: 5 },
+              { author: "Bob", text: "Which nib?", like_count: 2 },
+              { author: "Carol", text: "Great review!", like_count: 1 },
+              { author: "Dave", text: "I prefer Asa-gao", like_count: 0 }
+            ],
+            youtube_captions: "We are reviewing Pilot Iroshizuku Tsuki-yo today.",
+            youtube_metadata_fetched_at: Time.current
+          )
+        end
+
+        subject { described_class.new(youtube_ink_review.id) }
+
+        it "includes youtube_tags, top_comments, and has_captions in the prompt JSON" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+            .with { |req|
+              body = JSON.parse(req.body)
+              text = user_message_text(body)
+
+              expect(text).to include("youtube_tags")
+              expect(text).to include("pilot")
+              expect(text).to include("top_comments")
+              expect(text).to include("Tsuki-yo is gorgeous")
+              expect(text).to include("has_captions")
+
+              true
+            }
+            .at_least_once
+        end
+
+        it "caps top_comments at three" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+            .with { |req|
+              body = JSON.parse(req.body)
+              text = user_message_text(body)
+              # Dave's comment is fourth — must not appear.
+              !text.include?("I prefer Asa-gao")
+            }
+            .at_least_once
+        end
       end
     end
 

--- a/spec/agents/review_finder_spec.rb
+++ b/spec/agents/review_finder_spec.rb
@@ -42,6 +42,16 @@ RSpec.describe ReviewFinder do
 
   subject { described_class.new(page) }
 
+  def user_message_text(body)
+    user_msg = body["messages"].find { |m| m["role"] == "user" }
+    content = user_msg&.[]("content")
+    return content if content.is_a?(String)
+    return "" unless content.is_a?(Array)
+
+    text_part = content.find { |p| p["type"] == "text" }
+    text_part&.[]("text") || ""
+  end
+
   describe "#initialize" do
     it "creates agent with correct page" do
       finder = described_class.new(page)
@@ -171,13 +181,17 @@ RSpec.describe ReviewFinder do
         )
       end
 
-      it "returns message for YouTube videos without calling WebPageSummarizer" do
+      it "summarizes YouTube videos via YoutubeSummarizer" do
         allow(WebPageSummarizer).to receive(:new)
+        allow(YoutubeSummarizer).to receive(:new).with(
+          tool_agent_log,
+          youtube_unfurler_result
+        ).and_return(double(perform: "Reviews Pilot Tsuki-yo."))
 
         tool = described_class.new(youtube_unfurler_result, tool_agent_log)
         result = tool.call({})
 
-        expect(result).to eq("This is a Youtube video. I can't summarize it.")
+        expect(result).to eq("Here is a summary of the YouTube video:\n\nReviews Pilot Tsuki-yo.")
         expect(WebPageSummarizer).not_to have_received(:new)
       end
     end
@@ -344,14 +358,75 @@ RSpec.describe ReviewFinder do
         expect(WebMock).to have_requested(:post, openai_url)
           .with { |req|
             body = JSON.parse(req.body)
-            content = body["messages"].find { |m| m["role"] == "user" }&.[]("content")
+            text = user_message_text(body)
 
-            expect(content).to include("page data")
-            expect(content).to include(page.url)
+            expect(text).to include("page data")
+            expect(text).to include(page.url)
 
             true
           }
           .at_least_once
+      end
+
+      it "attaches the thumbnail as an image_url part" do
+        subject.perform
+
+        expect(WebMock).to have_requested(:post, openai_url)
+          .with { |req|
+            body = JSON.parse(req.body)
+            user_msg = body["messages"].find { |m| m["role"] == "user" }
+            parts = user_msg["content"]
+
+            parts.is_a?(Array) &&
+              parts.any? do |p|
+                p["type"] == "image_url" && p["image_url"]["url"] == unfurler_result.image
+              end
+          }
+          .at_least_once
+      end
+
+      context "with a YouTube page" do
+        let(:youtube_unfurler_result_with_metadata) do
+          Unfurler::Result.new(
+            "https://www.youtube.com/watch?v=abc123",
+            "YouTube Ink Review",
+            "Video review",
+            "https://img.youtube.com/vi/abc123/maxresdefault.jpg",
+            "Channel",
+            "UC123",
+            false,
+            nil,
+            {
+              tags: %w[fountain-pen ink-review],
+              comments: [{ author: "Eve", text: "Loved this!", like_count: 3 }],
+              captions: "Today we review Pilot Tsuki-yo."
+            }
+          )
+        end
+
+        before do
+          allow_any_instance_of(Unfurler).to receive(:perform).and_return(
+            youtube_unfurler_result_with_metadata
+          )
+        end
+
+        it "passes through the full YouTube metadata in the prompt JSON" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, openai_url)
+            .with { |req|
+              body = JSON.parse(req.body)
+              text = user_message_text(body)
+
+              expect(text).to include("fountain-pen")
+              expect(text).to include("ink-review")
+              expect(text).to include("Loved this!")
+              expect(text).to include("Today we review Pilot Tsuki-yo")
+
+              true
+            }
+            .at_least_once
+        end
       end
     end
 

--- a/spec/agents/youtube_summarizer_spec.rb
+++ b/spec/agents/youtube_summarizer_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+
+RSpec.describe YoutubeSummarizer do
+  let(:user) { create(:user) }
+  let(:parent_agent_log) do
+    AgentLog.create!(name: "ParentAgent", owner: user, state: "processing", transcript: [])
+  end
+
+  let(:macro_cluster) { create(:macro_cluster) }
+  let(:youtube_channel) { create(:you_tube_channel, channel_id: "UC123") }
+  let(:source) do
+    create(
+      :ink_review,
+      title: "Pilot Tsuki-yo Review",
+      description: "Today we review Tsuki-yo",
+      image: "https://img.youtube.com/vi/abc/maxresdefault.jpg",
+      url: "https://www.youtube.com/watch?v=abc",
+      you_tube_channel: youtube_channel,
+      macro_cluster: macro_cluster,
+      youtube_tags: %w[ink review],
+      youtube_comments: [{ author: "Alice", text: "Stunning ink", like_count: 9 }],
+      youtube_captions: "Pilot Iroshizuku Tsuki-yo is a dark blue ink with sheen."
+    )
+  end
+
+  let(:summary_response) do
+    {
+      "id" => "chatcmpl-yt",
+      "object" => "chat.completion",
+      "created" => 1_677_652_288,
+      "model" => "gpt-4.1-mini",
+      "choices" => [
+        {
+          "index" => 0,
+          "message" => {
+            "role" => "assistant",
+            "content" => "The video is a focused review of Pilot Iroshizuku Tsuki-yo."
+          },
+          "finish_reason" => "stop"
+        }
+      ],
+      "usage" => {
+        "prompt_tokens" => 250,
+        "completion_tokens" => 30,
+        "total_tokens" => 280
+      }
+    }
+  end
+
+  before do
+    stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+      status: 200,
+      body: summary_response.to_json,
+      headers: {
+        "Content-Type" => "application/json"
+      }
+    )
+  end
+
+  subject { described_class.new(parent_agent_log, source) }
+
+  it "creates an agent log under the parent" do
+    subject.perform
+    log = subject.agent_log
+    expect(log.owner).to eq(parent_agent_log)
+    expect(log.name).to eq("YoutubeSummarizer")
+    expect(log.reload.state).to eq("waiting-for-approval")
+  end
+
+  it "returns the LLM summary text" do
+    expect(subject.perform).to eq("The video is a focused review of Pilot Iroshizuku Tsuki-yo.")
+  end
+
+  it "sends title, description, tags, comments, and captions in the user prompt" do
+    subject.perform
+
+    expect(WebMock).to have_requested(
+      :post,
+      "https://api.openai.com/v1/chat/completions"
+    ).with { |req|
+      body = JSON.parse(req.body)
+      user_msg = body["messages"].find { |m| m["role"] == "user" }
+      content = user_msg["content"]
+      text = content.is_a?(Array) ? content.find { |p| p["type"] == "text" }&.[]("text") : content
+
+      text.include?("Pilot Tsuki-yo Review") && text.include?("Today we review Tsuki-yo") &&
+        text.include?("ink, review") && text.include?("Alice") && text.include?("Stunning ink") &&
+        text.include?("dark blue ink with sheen")
+    }
+  end
+
+  it "attaches the thumbnail as an image_url part" do
+    subject.perform
+
+    expect(WebMock).to have_requested(
+      :post,
+      "https://api.openai.com/v1/chat/completions"
+    ).with { |req|
+      body = JSON.parse(req.body)
+      user_msg = body["messages"].find { |m| m["role"] == "user" }
+      parts = user_msg["content"]
+      parts.is_a?(Array) &&
+        parts.any? { |p| p["type"] == "image_url" && p["image_url"]["url"] == source.image }
+    }
+  end
+
+  it "renders captions placeholder when none are present" do
+    source.update_column(:youtube_captions, nil)
+
+    subject.perform
+
+    expect(WebMock).to have_requested(
+      :post,
+      "https://api.openai.com/v1/chat/completions"
+    ).with { |req|
+      body = JSON.parse(req.body)
+      user_msg = body["messages"].find { |m| m["role"] == "user" }
+      content = user_msg["content"]
+      text = content.is_a?(Array) ? content.find { |p| p["type"] == "text" }&.[]("text") : content
+      text.include?("(none available)")
+    }
+  end
+
+  it "accepts an Unfurler::Result duck-typed source" do
+    unfurler_source =
+      Unfurler::Result.new(
+        "https://www.youtube.com/watch?v=xyz",
+        "Yet Another Review",
+        "Description",
+        "https://img.youtube.com/vi/xyz/maxresdefault.jpg",
+        "Channel",
+        "UC456",
+        false,
+        nil,
+        { tags: %w[a b], comments: [{ author: "Z", text: "hi", like_count: 0 }], captions: "C." }
+      )
+
+    result = described_class.new(parent_agent_log, unfurler_source).perform
+
+    expect(result).to be_a(String)
+    expect(WebMock).to have_requested(
+      :post,
+      "https://api.openai.com/v1/chat/completions"
+    ).with { |req|
+      body = JSON.parse(req.body)
+      user_msg = body["messages"].find { |m| m["role"] == "user" }
+      content = user_msg["content"]
+      text = content.is_a?(Array) ? content.find { |p| p["type"] == "text" }&.[]("text") : content
+      text.include?("Yet Another Review") && text.include?("a, b") && text.include?("C.")
+    }
+  end
+end

--- a/spec/factories/ink_reviews.rb
+++ b/spec/factories/ink_reviews.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     title { "MyText" }
     sequence(:url) { |n| "http://example#{n}.com" }
     description { "MyText" }
-    image { "MyText" }
+    sequence(:image) { |n| "https://example.com/image#{n}.jpg" }
     macro_cluster
   end
 end

--- a/spec/lib/youtube/video_id_parser_spec.rb
+++ b/spec/lib/youtube/video_id_parser_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe Youtube::VideoIdParser do
+  describe ".parse" do
+    it "extracts v= from a youtube.com URL" do
+      expect(described_class.parse("https://www.youtube.com/watch?v=abc123")).to eq("abc123")
+    end
+
+    it "extracts the path id from a youtu.be URL" do
+      expect(described_class.parse("https://youtu.be/xyz789")).to eq("xyz789")
+    end
+
+    it "extracts the shorts id from a youtube.com/shorts URL" do
+      expect(described_class.parse("https://www.youtube.com/shorts/short42")).to eq("short42")
+    end
+
+    it "returns nil for non-YouTube hosts that happen to contain 'youtube.com'" do
+      expect(described_class.parse("https://notyoutube.com/watch?v=abc")).to be_nil
+    end
+
+    it "returns nil for non-YouTube hosts that happen to contain 'youtu.be'" do
+      expect(described_class.parse("https://youtu.beware.example/abc")).to be_nil
+    end
+
+    it "returns nil for invalid URIs" do
+      expect(described_class.parse("not a url at all !!!")).to be_nil
+    end
+
+    it "is case-insensitive on the host" do
+      expect(described_class.parse("https://WWW.YOUTUBE.COM/watch?v=abc123")).to eq("abc123")
+    end
+  end
+end

--- a/spec/models/ink_review_spec.rb
+++ b/spec/models/ink_review_spec.rb
@@ -169,6 +169,20 @@ describe InkReview do
       review.ensure_youtube_metadata!
     end
 
+    it "re-checks the fetched-at flag inside with_lock to avoid concurrent double-fetches" do
+      # Simulate a competing worker that finished the fetch between the
+      # pre-check and the lock acquisition. The reloaded record inside the
+      # lock now has youtube_metadata_fetched_at present, so the body skips.
+      allow(review).to receive(:with_lock).and_wrap_original do |orig, &block|
+        review.update_column(:youtube_metadata_fetched_at, Time.current)
+        orig.call(&block)
+      end
+
+      expect(Unfurler::Youtube::Comments).not_to receive(:new)
+      expect(Unfurler::Youtube::Captions).not_to receive(:new)
+      review.ensure_youtube_metadata!
+    end
+
     it "handles nil captions gracefully" do
       allow(Unfurler::Youtube::Comments).to receive(:new).and_return(double(fetch: []))
       allow(Unfurler::Youtube::Captions).to receive(:new).and_return(double(fetch: nil))

--- a/spec/models/ink_review_spec.rb
+++ b/spec/models/ink_review_spec.rb
@@ -131,4 +131,71 @@ describe InkReview do
       expect(InkReview.due_for_check).not_to include(removed)
     end
   end
+
+  describe "#ensure_youtube_metadata!" do
+    let(:channel) { create(:you_tube_channel, channel_id: "UCabc") }
+    let(:review) do
+      create(:ink_review, url: "https://www.youtube.com/watch?v=vid_abc", you_tube_channel: channel)
+    end
+
+    it "fetches and persists comments and captions" do
+      comments = [{ author: "A", text: "nice", like_count: 1 }]
+      allow(Unfurler::Youtube::Comments).to receive(:new).with("vid_abc").and_return(
+        double(fetch: comments)
+      )
+      allow(Unfurler::Youtube::Captions).to receive(:new).with("vid_abc").and_return(
+        double(fetch: "Some caption text")
+      )
+
+      review.ensure_youtube_metadata!
+      review.reload
+
+      expect(review.youtube_comments.first.symbolize_keys).to eq(comments.first)
+      expect(review.youtube_captions).to eq("Some caption text")
+      expect(review.youtube_metadata_fetched_at).to be_present
+    end
+
+    it "does nothing for non-YouTube reviews" do
+      non_yt = create(:ink_review, url: "https://example.com/x")
+      expect(Unfurler::Youtube::Comments).not_to receive(:new)
+      expect(Unfurler::Youtube::Captions).not_to receive(:new)
+      non_yt.ensure_youtube_metadata!
+    end
+
+    it "is idempotent: skips when already fetched" do
+      review.update_column(:youtube_metadata_fetched_at, 1.day.ago)
+      expect(Unfurler::Youtube::Comments).not_to receive(:new)
+      expect(Unfurler::Youtube::Captions).not_to receive(:new)
+      review.ensure_youtube_metadata!
+    end
+
+    it "handles nil captions gracefully" do
+      allow(Unfurler::Youtube::Comments).to receive(:new).and_return(double(fetch: []))
+      allow(Unfurler::Youtube::Captions).to receive(:new).and_return(double(fetch: nil))
+
+      review.ensure_youtube_metadata!
+      review.reload
+
+      expect(review.youtube_captions).to be_nil
+      expect(review.youtube_comments).to eq([])
+      expect(review.youtube_metadata_fetched_at).to be_present
+    end
+  end
+
+  describe "#video_id" do
+    it "extracts the v param from a youtube.com URL" do
+      review = build(:ink_review, url: "https://www.youtube.com/watch?v=abc123")
+      expect(review.video_id).to eq("abc123")
+    end
+
+    it "extracts the path from a youtu.be URL" do
+      review = build(:ink_review, url: "https://youtu.be/xyz789")
+      expect(review.video_id).to eq("xyz789")
+    end
+
+    it "extracts the path from a YouTube shorts URL" do
+      review = build(:ink_review, url: "https://www.youtube.com/shorts/short42")
+      expect(review.video_id).to eq("short42")
+    end
+  end
 end

--- a/spec/operations/unfurler/youtube/captions_spec.rb
+++ b/spec/operations/unfurler/youtube/captions_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Unfurler::Youtube::Captions do
+  let(:video_id) { "abc123" }
+
+  def stub_timedtext(params, status:, body: "")
+    query = params.merge(v: video_id)
+    stub_request(:get, "https://www.youtube.com/api/timedtext").with(query: query).to_return(
+      status: status,
+      body: body
+    )
+  end
+
+  def sample_track
+    <<~XML
+      <?xml version="1.0" encoding="utf-8"?>
+      <transcript>
+        <text start="0.0" dur="2.0">Today we review</text>
+        <text start="2.0" dur="2.0">Pilot Iroshizuku Tsuki-yo &amp; its sheen</text>
+      </transcript>
+    XML
+  end
+
+  it "returns parsed text from the first successful track" do
+    stub_timedtext({ lang: "en" }, status: 200, body: sample_track)
+    result = described_class.new(video_id).fetch
+    expect(result).to eq("Today we review Pilot Iroshizuku Tsuki-yo & its sheen")
+  end
+
+  it "falls back to en-US when en returns empty body" do
+    stub_timedtext({ lang: "en" }, status: 200, body: "")
+    stub_timedtext({ lang: "en-US" }, status: 200, body: sample_track)
+    expect(described_class.new(video_id).fetch).to include("Pilot Iroshizuku")
+  end
+
+  it "falls back to ASR when human tracks are absent" do
+    stub_timedtext({ lang: "en" }, status: 404)
+    stub_timedtext({ lang: "en-US" }, status: 404)
+    stub_timedtext({ lang: "en", kind: "asr" }, status: 200, body: sample_track)
+    expect(described_class.new(video_id).fetch).to include("Pilot Iroshizuku")
+  end
+
+  it "returns nil when all attempts fail or are empty" do
+    stub_timedtext({ lang: "en" }, status: 404)
+    stub_timedtext({ lang: "en-US" }, status: 404)
+    stub_timedtext({ lang: "en", kind: "asr" }, status: 404)
+    stub_timedtext({ lang: "en-US", kind: "asr" }, status: 404)
+    expect(described_class.new(video_id).fetch).to be_nil
+  end
+
+  it "truncates captions exceeding MAX_CHARS" do
+    long_text = "x" * (described_class::MAX_CHARS + 500)
+    long_body = "<transcript><text>#{long_text}</text></transcript>"
+    stub_timedtext({ lang: "en" }, status: 200, body: long_body)
+    result = described_class.new(video_id).fetch
+    expect(result.length).to eq(described_class::MAX_CHARS)
+  end
+
+  it "returns nil when Faraday raises" do
+    allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(
+      Faraday::ConnectionFailed.new("boom")
+    )
+    expect(described_class.new(video_id).fetch).to be_nil
+  end
+end

--- a/spec/operations/unfurler/youtube/comments_spec.rb
+++ b/spec/operations/unfurler/youtube/comments_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe Unfurler::Youtube::Comments do
     expect(fetcher.fetch).to eq([])
   end
 
-  it "returns an empty array when access is forbidden" do
+  it "re-raises generic forbidden errors so auth/quota issues surface" do
     allow(client).to receive(:list_comment_threads).and_raise(
       Google::Apis::ClientError.new("forbidden")
     )
-    expect(fetcher.fetch).to eq([])
+    expect { fetcher.fetch }.to raise_error(Google::Apis::ClientError)
   end
 
   it "re-raises other client errors" do

--- a/spec/operations/unfurler/youtube/comments_spec.rb
+++ b/spec/operations/unfurler/youtube/comments_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Unfurler::Youtube::Comments do
+  let(:video_id) { "abc123" }
+  let(:client) { double(:client) }
+  subject(:fetcher) { described_class.new(video_id, client: client) }
+
+  def make_thread(author:, text:, like_count: 0)
+    snippet =
+      double(:snippet, author_display_name: author, text_display: text, like_count: like_count)
+    top_level = double(:top_level_comment, snippet: snippet)
+    thread_snippet = double(:thread_snippet, top_level_comment: top_level)
+    double(:thread, snippet: thread_snippet)
+  end
+
+  it "maps each thread to author/text/like_count" do
+    response =
+      double(
+        :response,
+        items: [
+          make_thread(author: "Alice", text: "Great review!", like_count: 5),
+          make_thread(author: "Bob", text: "Which nib?", like_count: 2)
+        ]
+      )
+    expect(client).to receive(:list_comment_threads).with(
+      "snippet",
+      video_id: video_id,
+      order: "relevance",
+      max_results: 10
+    ).and_return(response)
+
+    result = fetcher.fetch
+
+    expect(result).to eq(
+      [
+        { author: "Alice", text: "Great review!", like_count: 5 },
+        { author: "Bob", text: "Which nib?", like_count: 2 }
+      ]
+    )
+  end
+
+  it "returns an empty array when comments are disabled" do
+    allow(client).to receive(:list_comment_threads).and_raise(
+      Google::Apis::ClientError.new("commentsDisabled: Comments are disabled.")
+    )
+    expect(fetcher.fetch).to eq([])
+  end
+
+  it "returns an empty array when access is forbidden" do
+    allow(client).to receive(:list_comment_threads).and_raise(
+      Google::Apis::ClientError.new("forbidden")
+    )
+    expect(fetcher.fetch).to eq([])
+  end
+
+  it "re-raises other client errors" do
+    allow(client).to receive(:list_comment_threads).and_raise(
+      Google::Apis::ClientError.new("quotaExceeded")
+    )
+    expect { fetcher.fetch }.to raise_error(Google::Apis::ClientError)
+  end
+
+  it "returns an empty array when the API returns no items" do
+    allow(client).to receive(:list_comment_threads).and_return(double(:response, items: nil))
+    expect(fetcher.fetch).to eq([])
+  end
+end

--- a/spec/operations/unfurler/youtube_spec.rb
+++ b/spec/operations/unfurler/youtube_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Unfurler::Youtube do
+  let(:video_id) { "abc123" }
+
+  def build_video(tags:)
+    snippet =
+      double(
+        :snippet,
+        title: "Title",
+        description: "Description",
+        thumbnails: double(:thumbnails, maxres: double(:t, url: "thumb.jpg")),
+        channel_title: "Channel",
+        channel_id: "UC123",
+        tags: tags
+      )
+    double(:video, snippet: snippet)
+  end
+
+  before { stub_request(:get, "https://www.youtube.com/shorts/#{video_id}").to_return(status: 404) }
+
+  it "populates the :youtube sub-hash with tags from the snippet" do
+    client = double(:client, list_videos: double(:r, items: [build_video(tags: %w[a b])]))
+    allow_any_instance_of(described_class).to receive(:client).and_return(client)
+
+    result = described_class.new(video_id).perform
+
+    expect(result.youtube).to eq(tags: %w[a b], comments: nil, captions: nil)
+  end
+
+  it "returns an empty tags array when the snippet has no tags" do
+    client = double(:client, list_videos: double(:r, items: [build_video(tags: nil)]))
+    allow_any_instance_of(described_class).to receive(:client).and_return(client)
+
+    result = described_class.new(video_id).perform
+
+    expect(result.youtube[:tags]).to eq([])
+  end
+end

--- a/spec/operations/unfurler_spec.rb
+++ b/spec/operations/unfurler_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Unfurler do
+  describe "#perform" do
+    it "routes YouTube watch URLs to Unfurler::Youtube" do
+      expect(Unfurler::Youtube).to receive(:new).with("abc123").and_return(
+        double(perform: Unfurler::Result.new("u", "t", "d", "i", "a", "UC", false, nil, {}))
+      )
+      described_class.new("https://www.youtube.com/watch?v=abc123").perform
+    end
+
+    it "routes YouTube Shorts URLs to Unfurler::Youtube (not Html)" do
+      expect(Unfurler::Html).not_to receive(:new)
+      expect(Unfurler::Youtube).to receive(:new).with("short42").and_return(
+        double(perform: Unfurler::Result.new("u", "t", "d", "i", "a", "UC", true, nil, {}))
+      )
+      described_class.new("https://www.youtube.com/shorts/short42").perform
+    end
+
+    it "routes youtu.be URLs to Unfurler::Youtube" do
+      expect(Unfurler::Youtube).to receive(:new).with("xyz789").and_return(
+        double(perform: Unfurler::Result.new("u", "t", "d", "i", "a", "UC", false, nil, {}))
+      )
+      described_class.new("https://youtu.be/xyz789").perform
+    end
+
+    it "does not route notyoutube.com to Unfurler::Youtube" do
+      expect(Unfurler::Youtube).not_to receive(:new)
+      stub_request(:get, "https://notyoutube.com/watch?v=abc").to_return(
+        body: "<html><head><title>x</title></head></html>"
+      )
+      described_class.new("https://notyoutube.com/watch?v=abc").perform
+    end
+  end
+end

--- a/spec/workers/process_ink_review_submission_spec.rb
+++ b/spec/workers/process_ink_review_submission_spec.rb
@@ -93,7 +93,8 @@ describe ProcessInkReviewSubmission do
             description: "description",
             thumbnails: double(:thumbnails, maxres: double(:t, url: "url")),
             channel_title: "channel title",
-            channel_id: "channel_id"
+            channel_id: "channel_id",
+            tags: %w[ink review fountain-pen]
           }
         )
       video = double(:video, snippet: video_snippet)
@@ -133,6 +134,22 @@ describe ProcessInkReviewSubmission do
       described_class.new.perform(ink_review_submission.id)
       review = InkReview.first
       expect(review.you_tube_short).to eq(true)
+    end
+
+    it "persists youtube tags from the video snippet" do
+      described_class.new.perform(ink_review_submission.id)
+      review = InkReview.first
+      expect(review.youtube_tags).to eq(%w[ink review fountain-pen])
+    end
+
+    it "does not fetch comments or captions during submission processing" do
+      expect(Unfurler::Youtube::Comments).not_to receive(:new)
+      expect(Unfurler::Youtube::Captions).not_to receive(:new)
+      described_class.new.perform(ink_review_submission.id)
+      review = InkReview.first
+      expect(review.youtube_comments).to eq([])
+      expect(review.youtube_captions).to be_nil
+      expect(review.youtube_metadata_fetched_at).to be_nil
     end
   end
 


### PR DESCRIPTION
## Summary

YouTube ink reviews were slipping through the automation because both ReviewFinder (matching) and ReviewApprover (approval) only saw the video title and description — fine when the description names the ink, blind otherwise. The agents now also receive the thumbnail as a real image input, the YouTube tags, the top three relevance-ranked comments, and a YouTube-aware summary built from captions (via YouTube's free `timedtext` endpoint with an ASR fallback) plus thumbnail vision when the agent calls `summarize`. The pipeline avoids a paid transcription service for now and only pays for the extra YouTube API calls when an agent actually needs them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for attaching images and files to agent prompts for enhanced context.
  * Improved YouTube video handling with intelligent metadata capture (tags, comments, captions) and dedicated summarization logic.
  * YouTube reviews now leverage platform-specific metadata for more accurate and contextual summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->