### PR TITLE
Show ReviewApprover transcript on admin reviews page

### DIFF
--- a/app/controllers/admins/reviews_controller.rb
+++ b/app/controllers/admins/reviews_controller.rb
@@ -1,6 +1,6 @@
 class Admins::ReviewsController < Admins::BaseController
   def index
-    query = InkReview.agent_processed.order("created_at asc")
+    query = InkReview.agent_processed.includes(:agent_logs).order("created_at asc")
     @ink_reviews = query.page(params[:page])
     @ink_reviews = query.page(0) if @ink_reviews.empty?
 

--- a/app/views/admins/reviews/index.html.slim
+++ b/app/views/admins/reviews/index.html.slim
@@ -64,4 +64,13 @@ table class="table table-striped"
         pre= JSON.pretty_generate(ink_review.extra_data)
         pre= JSON.pretty_generate(ink_review.ink_review_submissions.pluck(:extra_data))
 
+    - review_log = ink_review.agent_logs.select { |l| l.name == "ReviewApprover" }.max_by(&:created_at)
+    - if review_log&.transcript.present?
+      dt class="col-sm-3" Transcript
+      dd class="col-sm-9"
+        details
+          summary= "Show LLM conversation (#{review_log.transcript.size} messages)"
+          - review_log.transcript.each do |message|
+            pre= jsonify(message)
+
 = paginate @ink_reviews

--- a/spec/requests/admins/reviews_spec.rb
+++ b/spec/requests/admins/reviews_spec.rb
@@ -17,6 +17,74 @@ describe "Admins::Reviews" do
         expect(response).to be_successful
       end
 
+      describe "transcript section" do
+        let(:agent_processed_review) do
+          review =
+            create(
+              :ink_review,
+              extra_data: {
+                "action" => "approve_review",
+                "explanation_of_decision" => "ok"
+              },
+              approved_at: Time.current,
+              agent_approved: true
+            )
+          create(
+            :ink_review_submission,
+            ink_review: review,
+            macro_cluster: review.macro_cluster,
+            url: review.url
+          )
+          review
+        end
+
+        it "renders the latest ReviewApprover transcript inside a collapsed <details>" do
+          agent_processed_review.agent_logs.create!(
+            name: "ReviewApprover",
+            state: "approved",
+            transcript: [
+              { "role" => "system", "content" => "system msg" },
+              { "role" => "user", "content" => "user msg" },
+              { "role" => "assistant", "content" => "assistant msg" }
+            ]
+          )
+
+          get "/admins/reviews"
+
+          expect(response.body).to include("Transcript")
+          expect(response.body).to include("<details>")
+          expect(response.body).to include("Show LLM conversation (3 messages)")
+          expect(response.body).to include("system msg")
+          expect(response.body).to include("user msg")
+          expect(response.body).to include("assistant msg")
+        end
+
+        it "picks the latest ReviewApprover log when multiple exist" do
+          agent_processed_review.agent_logs.create!(
+            name: "ReviewApprover",
+            state: "rejected",
+            transcript: [{ "role" => "user", "content" => "old run" }],
+            created_at: 2.days.ago
+          )
+          agent_processed_review.agent_logs.create!(
+            name: "ReviewApprover",
+            state: "approved",
+            transcript: [{ "role" => "user", "content" => "latest run" }]
+          )
+
+          get "/admins/reviews"
+
+          expect(response.body).to include("latest run")
+          expect(response.body).not_to include("old run")
+        end
+
+        it "omits the transcript section when no ReviewApprover log exists" do
+          agent_processed_review # ensure review exists without an agent log
+          get "/admins/reviews"
+          expect(response.body).not_to include("Show LLM conversation")
+        end
+      end
+
       describe "stats table" do
         def manually_processed_review(agent_action:, final:)
           review =


### PR DESCRIPTION
Debugging a bad agent decision on /admins/reviews currently means dropping into the Rails console to pull `InkReview#agent_logs` — annoying enough that bad decisions often go uninvestigated. The transcript is now rendered inline under each review in a collapsed `<details>` block, matching the raw-JSON-per-message style already used on `/admins/agents/ink_clusterer`. Sub-agent transcripts (WebPageSummarizer / YoutubeSummarizer) stay out of scope for now; the parent transcript already carries the summarizer output as a tool-result message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Transcript" section to the admin reviews interface, displaying LLM conversation messages in a collapsible details block
  * Shows the latest conversation transcript when multiple transcripts are available
  * Transcript section automatically hides when no conversation data exists

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->