### PR TITLE
Resolve image URL redirects before attaching to ReviewFinder prompt

### DIFF
--- a/app/agents/review_finder.rb
+++ b/app/agents/review_finder.rb
@@ -105,7 +105,7 @@ class ReviewFinder
   end
 
   def perform
-    ask(user_prompt, with: page_data.image.presence)
+    ask(user_prompt, with: resolved_image_url)
     agent_log.waiting_for_approval!
   end
 
@@ -135,5 +135,9 @@ class ReviewFinder
 
   def page_data
     @page_data ||= Unfurler.new(page.url, with_full_metadata: true).perform
+  end
+
+  def resolved_image_url
+    ResolveImageUrl.new(page_data.image).perform
   end
 end

--- a/app/operations/resolve_image_url.rb
+++ b/app/operations/resolve_image_url.rb
@@ -1,0 +1,35 @@
+require "faraday/follow_redirects"
+
+class ResolveImageUrl
+  OPEN_TIMEOUT = 3
+  READ_TIMEOUT = 5
+  MAX_REDIRECTS = 5
+
+  def initialize(url)
+    self.url = url
+  end
+
+  def perform
+    return nil if url.blank?
+
+    response = connection.head(url)
+    return nil unless response.success?
+    return nil unless response.headers["content-type"].to_s.start_with?("image/")
+
+    response.env.url.to_s
+  rescue Faraday::Error, URI::InvalidURIError, ArgumentError
+    nil
+  end
+
+  private
+
+  attr_accessor :url
+
+  def connection
+    Faraday.new do |f|
+      f.response :follow_redirects, limit: MAX_REDIRECTS
+      f.options.open_timeout = OPEN_TIMEOUT
+      f.options.timeout = READ_TIMEOUT
+    end
+  end
+end

--- a/spec/agents/review_finder_spec.rb
+++ b/spec/agents/review_finder_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe ReviewFinder do
   end
 
   before { allow_any_instance_of(Unfurler).to receive(:perform).and_return(unfurler_result) }
+  before do
+    allow(ResolveImageUrl).to receive(:new) do |passed_url|
+      double("ResolveImageUrl", perform: passed_url.presence)
+    end
+  end
 
   subject { described_class.new(page) }
 
@@ -383,6 +388,23 @@ RSpec.describe ReviewFinder do
               end
           }
           .at_least_once
+      end
+
+      context "when ResolveImageUrl returns nil (e.g. broken image link)" do
+        before { allow(ResolveImageUrl).to receive(:new).and_return(double(perform: nil)) }
+
+        it "sends no image_url part" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, openai_url)
+            .with { |req|
+              body = JSON.parse(req.body)
+              user_msg = body["messages"].find { |m| m["role"] == "user" }
+              content = user_msg["content"]
+              content.is_a?(Array) ? content.none? { |p| p["type"] == "image_url" } : true
+            }
+            .at_least_once
+        end
       end
 
       context "with a YouTube page" do

--- a/spec/operations/resolve_image_url_spec.rb
+++ b/spec/operations/resolve_image_url_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe ResolveImageUrl do
+  describe "#perform" do
+    it "returns nil for a blank URL" do
+      expect(described_class.new("").perform).to be_nil
+      expect(described_class.new(nil).perform).to be_nil
+    end
+
+    it "returns the URL when HEAD returns an image content-type" do
+      url = "https://cdn.example.com/photo.jpg"
+      stub_request(:head, url).to_return(status: 200, headers: { "Content-Type" => "image/jpeg" })
+
+      expect(described_class.new(url).perform).to eq(url)
+    end
+
+    it "follows redirects and returns the final URL when it serves an image" do
+      start_url = "https://example.com/og-image"
+      final_url = "https://cdn.example.com/real.png"
+      stub_request(:head, start_url).to_return(status: 301, headers: { "Location" => final_url })
+      stub_request(:head, final_url).to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "image/png"
+        }
+      )
+
+      expect(described_class.new(start_url).perform).to eq(final_url)
+    end
+
+    it "returns nil when the redirect chain ends on a non-image response" do
+      start_url = "https://example.com/maybe-image"
+      final_url = "https://example.com/landing"
+      stub_request(:head, start_url).to_return(status: 302, headers: { "Location" => final_url })
+      stub_request(:head, final_url).to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "text/html"
+        }
+      )
+
+      expect(described_class.new(start_url).perform).to be_nil
+    end
+
+    it "returns nil when the redirect chain exceeds MAX_REDIRECTS" do
+      urls = (0..described_class::MAX_REDIRECTS).map { |i| "https://example.com/r#{i}" }
+      urls.each_with_index do |u, i|
+        next_u = urls[i + 1] || "https://example.com/final"
+        stub_request(:head, u).to_return(status: 301, headers: { "Location" => next_u })
+      end
+
+      expect(described_class.new(urls.first).perform).to be_nil
+    end
+
+    it "returns nil on a 404" do
+      url = "https://example.com/missing"
+      stub_request(:head, url).to_return(status: 404)
+
+      expect(described_class.new(url).perform).to be_nil
+    end
+
+    it "returns nil on a connection failure" do
+      url = "https://example.com/down"
+      stub_request(:head, url).to_raise(Faraday::ConnectionFailed.new("nope"))
+
+      expect(described_class.new(url).perform).to be_nil
+    end
+
+    it "returns nil for an invalid URL" do
+      expect(described_class.new("not a url").perform).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes Honeybadger fault 130765305 (`RubyLLM::UnsupportedAttachmentError` in `FetchReviews::ProcessWebPageForReview`).
- RubyLLM's `Connection.basic` Faraday client does not follow redirects. When `og:image` points at a 301 (e.g. Squarespace CDN), the gem fetches the redirect body (HTML/empty), Marcel classifies the MIME as non-image, and `Attachment#type` becomes `:unknown`. The OpenAI media formatter has no case for `:unknown` and raises.
- Adds `ResolveImageUrl` operation: HEAD with `faraday-follow_redirects` (already a transitive dep, locked at 0.5.0), short timeouts, returns the resolved URL only when the final response is `image/*`, else `nil`.
- `ReviewFinder#perform` now passes the resolved URL to `ask`. `build_user_content` already drops `nil` attachments, so a bad image link no longer crashes the job — the agent just runs without the thumbnail.