### PR TITLE
Defer InkClusterer enqueues until transaction commits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ end
 
 gem "rails", "~> 8.1.3"
 
+gem "after_commit_everywhere"
 gem "apipie-rails"
 gem "bcrypt"
 gem "bootsnap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    after_commit_everywhere (1.6.0)
+      activerecord (>= 4.2)
+      activesupport
     apipie-rails (1.5.0)
       actionpack (>= 5.0)
       activesupport (>= 5.0)
@@ -588,6 +591,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  after_commit_everywhere
   apipie-rails
   bcrypt
   bootsnap

--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -1,5 +1,6 @@
 class InkClusterer
   include RubyLlmAgent
+  include AfterCommitEverywhere
 
   class BaseTool < RubyLLM::Tool
     attr_accessor :micro_cluster, :agent_log
@@ -243,11 +244,11 @@ class InkClusterer
       case agent_log.extra_data["action"]
       when "assign_to_cluster"
         micro_cluster.update!(macro_cluster_id: agent_log.extra_data["cluster_id"])
-        UpdateMicroCluster.perform_async(micro_cluster.id)
+        after_commit { UpdateMicroCluster.perform_async(micro_cluster.id) }
       when "create_new_cluster"
         cluster = MacroCluster.create!(ink_name: SecureRandom.uuid)
         micro_cluster.update!(macro_cluster_id: cluster.id)
-        UpdateMicroCluster.perform_async(micro_cluster.id)
+        after_commit { UpdateMicroCluster.perform_async(micro_cluster.id) }
       when "ignore_ink"
         micro_cluster.update!(ignored: true)
       when "hand_over_to_human"

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -654,6 +654,18 @@ RSpec.describe InkClusterer do
         expect(subject.agent_log.reload.state).to eq("approved")
         expect(subject.agent_log.agent_approved).to be true
       end
+
+      it "defers UpdateMicroCluster enqueue until the outer transaction commits" do
+        size_inside = nil
+        ActiveRecord::Base.transaction do
+          subject.approve!
+          size_inside = UpdateMicroCluster.jobs.size
+        end
+
+        expect(size_inside).to eq(0)
+        expect(UpdateMicroCluster.jobs.size).to eq(1)
+        expect(UpdateMicroCluster.jobs.last["args"]).to eq([micro_cluster.id])
+      end
     end
 
     context "create_new_cluster action" do
@@ -673,6 +685,18 @@ RSpec.describe InkClusterer do
         cluster = micro_cluster.reload.macro_cluster
         expect(cluster.ink_name).to be_present
         expect(cluster.ink_name).not_to eq("")
+      end
+
+      it "defers UpdateMicroCluster enqueue until the outer transaction commits" do
+        size_inside = nil
+        ActiveRecord::Base.transaction do
+          subject.approve!
+          size_inside = UpdateMicroCluster.jobs.size
+        end
+
+        expect(size_inside).to eq(0)
+        expect(UpdateMicroCluster.jobs.size).to eq(1)
+        expect(UpdateMicroCluster.jobs.last["args"]).to eq([micro_cluster.id])
       end
     end
 


### PR DESCRIPTION
## Summary

- `InkClusterer#approve!` enqueued `UpdateMicroCluster.perform_async` inside `AgentLog.transaction`. Sidekiq could pick the job up before the transaction committed, read the `MicroCluster` with the pre-update `macro_cluster_id` (`nil`), and re-queue `RunInkClustererAgent` instead of `UpdateMacroCluster`. Today's `already_resolved?` guard (`daed05c3`) then bailed on the retry because `macro_cluster_id` was set by then, leaving the freshly created `MacroCluster` stuck with `ink_name: <UUID>` and empty brand/line/ink names. The same race previously produced duplicate `MacroCluster`s (the symptom `2965d092` was chasing); the new guard just changed the failure mode from "duplicate cluster" to "orphaned UUID cluster".
- Wrap each `UpdateMicroCluster.perform_async` in `after_commit { ... }` via the [`after_commit_everywhere`](https://github.com/envek/after_commit_everywhere) gem so it fires only after the enclosing transaction commits.
- Out of scope: the residual `InkClusterer#perform` race where two concurrent jobs can each create distinct `AgentLog` rows. The `2965d092` row lock only guards duplicate work on the same row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized cluster update operations to ensure background work is reliably scheduled following database transaction completion, improving system robustness

* **Chores**
  * Added new dependency for advanced transaction management

* **Tests**
  * Added extensive test coverage for cluster operations to verify proper scheduling of background work across different update scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->