### PR TITLE
Exclude auto-decided rows from /admins/reviews stats

### DIFF
--- a/app/models/ink_review.rb
+++ b/app/models/ink_review.rb
@@ -20,7 +20,7 @@ class InkReview < ApplicationRecord
   scope :approved, -> { where.not(approved_at: nil) }
   scope :rejected, -> { where.not(rejected_at: nil) }
   scope :processed, -> { where.not(approved_at: nil).or(where.not(rejected_at: nil)) }
-  scope :manually_processed, -> { processed.where(agent_approved: false) }
+  scope :manually_processed, -> { processed.where(agent_approved: false, auto_approved: false) }
   scope :agent_processed, -> { processed.where(agent_approved: true) }
   scope :live, -> { approved.where(check_count: 0) }
   scope :due_for_check, -> { approved.where("next_check_at <= ?", Time.zone.now) }

--- a/spec/requests/admins/reviews_spec.rb
+++ b/spec/requests/admins/reviews_spec.rb
@@ -127,6 +127,25 @@ describe "Admins::Reviews" do
 
           # Excluded: empty extra_data
           create(:ink_review, extra_data: {}).approve!
+          # Excluded: final state set by auto_approve!/auto_reject! after the
+          # admin had already clicked through; current state no longer
+          # reflects a manual verdict
+          auto_overridden =
+            create(
+              :ink_review,
+              extra_data: {
+                "action" => "approve_review"
+              },
+              approved_at: Time.current,
+              agent_approved: false,
+              auto_approved: true
+            )
+          create(
+            :ink_review_submission,
+            ink_review: auto_overridden,
+            macro_cluster: auto_overridden.macro_cluster,
+            url: auto_overridden.url
+          )
           # Excluded: still waiting on a human (agent_processed scope)
           waiting =
             create(


### PR DESCRIPTION
The stats table on `/admins/reviews` compares the `ReviewApprover` agent's proposed verdict (`extra_data['action']`) against the review's current `approved_at`/`rejected_at` state — meant to measure how often the agent agrees with the admin's manual call.

The `manually_processed` scope only required `agent_approved: false`, which let through rows whose final state was set by `auto_approve!`/`auto_reject!`. On a re-submission, `ProcessInkReviewSubmission` re-runs the multi-submission / YouTube-short auto path; those methods flip `approved_at`/`rejected_at` and set `auto_approved: true` without touching `agent_approved`. After an admin had already clicked through such a row, the current verdict shown to the stats was the auto rule's, not the admin's. In the current production DB this leaks ~47 of 4722 rows (~1%) into the counts. Tightening the scope so both `agent_approved` and `auto_approved` must be false fixes it; the same scope is also used by `ReviewApprover` to sample example reviews for the prompt, and excluding auto-decided rows there is desirable too (they were never human-vetted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed review statistics calculation to more accurately identify manually processed reviews by properly excluding auto-overridden reviews from counts. This improves the reliability of reporting metrics for better insight into actual manual review activities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3538?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->