### PR TITLE
Window /admins/reviews stats to last 6 months

### DIFF
--- a/app/controllers/admins/reviews_controller.rb
+++ b/app/controllers/admins/reviews_controller.rb
@@ -32,15 +32,15 @@ class Admins::ReviewsController < Admins::BaseController
     end
   end
 
+  STATS_WINDOW = 6.months
+
   def calculate_stats
-    ids =
+    cutoff = STATS_WINDOW.ago
+    rel =
       InkReview
         .manually_processed
         .where.not(extra_data: {})
-        .order(created_at: :desc)
-        .limit(1000)
-        .pluck(:id)
-    rel = InkReview.where(id: ids)
+        .where("approved_at >= :cutoff OR rejected_at >= :cutoff", cutoff: cutoff)
 
     analysis = {}
     analysis[:total] = stats_for(rel)

--- a/spec/requests/admins/reviews_spec.rb
+++ b/spec/requests/admins/reviews_spec.rb
@@ -144,6 +144,9 @@ describe "Admins::Reviews" do
             macro_cluster: waiting.macro_cluster,
             url: waiting.url
           )
+          # Excluded: verdict older than the 6-month stats window
+          stale = manually_processed_review(agent_action: "approve_review", final: :approved)
+          stale.update_columns(approved_at: 7.months.ago)
 
           get "/admins/reviews"
           stats = controller.instance_variable_get(:@stats)


### PR DESCRIPTION
The stats query was capped at the 1000 most-recently-created `manually_processed` rows. Because the page lists oldest agent-decided reviews first, the admin's verdicts land on rows whose `created_at` is too old to enter that creation-time window — so the stats never moved on click. Even for rows inside the window, one-in/one-out bumping at the LIMIT boundary often cancelled visible change.

Filter by `approved_at`/`rejected_at` within the last 6 months instead. Old data isn't relevant for judging current agent accuracy, and every admin click now moves the counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Admin review statistics calculation now uses a rolling 6-month window based on approval and rejection dates, replacing the previous approach of including the last 1000 manually processed reviews.

* **Tests**
  * Tests updated to verify statistics correctly exclude reviews outside the 6-month window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->