### PR TITLE
Debounce ink clusterer LLM by 30s

### DIFF
--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -122,6 +122,8 @@ class InkClusterer
 
   MODEL_ID = "gpt-4.1"
 
+  DEBOUNCE_WINDOW = 30.seconds
+
   SYSTEM_DIRECTIVE = <<~TEXT
     You are a clustering algorithm that groups similar inks together based on their properties.
 
@@ -177,6 +179,11 @@ class InkClusterer
 
   def perform
     return if already_resolved?
+
+    if recent_activity?
+      RunInkClustererAgent.perform_in(DEBOUNCE_WINDOW, "InkClusterer", micro_cluster.id)
+      return
+    end
 
     if micro_cluster.collected_inks.present?
       ask!(user_prompt)
@@ -261,6 +268,11 @@ class InkClusterer
   private
 
   attr_accessor :micro_cluster, :agent_log_id
+
+  def recent_activity?
+    last_update = micro_cluster.collected_inks.maximum(:updated_at)
+    last_update.present? && last_update > DEBOUNCE_WINDOW.ago
+  end
 
   def already_resolved?
     return true if micro_cluster.ignored?

--- a/app/workers/update_micro_cluster.rb
+++ b/app/workers/update_micro_cluster.rb
@@ -8,7 +8,7 @@ class UpdateMicroCluster
     if cluster.macro_cluster_id
       UpdateMacroCluster.perform_async(cluster.macro_cluster_id)
     else
-      RunInkClustererAgent.perform_async("InkClusterer", cluster.id)
+      RunInkClustererAgent.perform_in(InkClusterer::DEBOUNCE_WINDOW, "InkClusterer", cluster.id)
     end
   end
 end

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe InkClusterer do
     end
   end
 
+  # Age inks past the debounce window so the agent runs immediately during tests.
+  before(:each) { CollectedInk.update_all(updated_at: 1.hour.ago) }
+
   describe "#perform" do
     let(:assign_to_cluster_response) do
       {
@@ -442,7 +445,8 @@ RSpec.describe InkClusterer do
             }
           )
         log.update_columns(updated_at: 1.hour.ago)
-        collected_ink_1.touch
+        # Updated after the prior log but still outside the debounce window.
+        collected_ink_1.update_columns(updated_at: 5.minutes.ago)
 
         subject.perform
 
@@ -500,6 +504,37 @@ RSpec.describe InkClusterer do
 
         expect(existing.reload.state).to eq("waiting-for-approval")
         expect(micro_cluster.agent_logs.ink_clusterer.count).to eq(1)
+      end
+    end
+
+    context "debounce" do
+      before(:each) do
+        stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+          status: 200,
+          body: assign_to_cluster_response.to_json,
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+      end
+
+      it "reschedules itself when a collected ink was updated within the debounce window" do
+        collected_ink_1.update_columns(updated_at: 5.seconds.ago)
+
+        expect { subject.perform }.not_to change { AgentLog.count }
+        expect(WebMock).not_to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+        expect(RunInkClustererAgent.jobs.size).to eq(1)
+        expect(RunInkClustererAgent.jobs.last["args"]).to eq(["InkClusterer", micro_cluster.id])
+        expect(RunInkClustererAgent.jobs.last["at"]).to be_within(2).of(
+          (Time.current + InkClusterer::DEBOUNCE_WINDOW).to_f
+        )
+      end
+
+      it "runs the LLM once no collected ink has been updated within the debounce window" do
+        subject.perform
+
+        expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+        expect(subject.agent_log.reload.state).to eq("waiting-for-approval")
       end
     end
   end
@@ -1452,6 +1487,7 @@ RSpec.describe InkClusterer do
       end
 
       it "handles special characters in ink data" do
+        CollectedInk.update_all(updated_at: 1.hour.ago)
         subject.perform
 
         transcript = subject.agent_log.transcript
@@ -1521,6 +1557,7 @@ RSpec.describe InkClusterer do
       end
 
       it "handles very long ink names" do
+        CollectedInk.update_all(updated_at: 1.hour.ago)
         expect { subject.perform }.not_to raise_error
 
         transcript = subject.agent_log.transcript


### PR DESCRIPTION
Users often save an ink with a typo, then correct it within a few seconds — each save triggered a separate LLM call to the clusterer. The `InkClusterer` agent now waits 30 seconds and self-reschedules if any collected_ink in the micro_cluster was updated within the window, so only the final edit reaches the LLM. The follow-up `CheckInkClustering` stage is still enqueued immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added debouncing mechanism to clustering operations. When recent updates are detected, operations defer and automatically reschedule instead of executing immediately.

* **Tests**
  * Updated test suite to validate debounce behavior, verify rescheduling when recent activity occurs, and confirm normal execution when no updates are detected within the window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ujh/fountainpencompanion/pull/3541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->