### PR TITLE
Security: stored XSS in diff views, Devise throttles, account enumeration

### DIFF
--- a/app/controllers/admins/descriptions/brands_controller.rb
+++ b/app/controllers/admins/descriptions/brands_controller.rb
@@ -16,7 +16,7 @@ class Admins::Descriptions::BrandsController < Admins::BaseController
   def calculate_diff(version)
     return "" unless version.changeset.key?("description")
 
-    changes = version.changeset["description"].reverse.map(&:to_s)
+    changes = version.changeset["description"].reverse.map { |c| ERB::Util.html_escape(c.to_s) }
     Differ.diff_by_word(*changes).format_as(:html).html_safe
   end
 end

--- a/app/controllers/admins/descriptions/inks_controller.rb
+++ b/app/controllers/admins/descriptions/inks_controller.rb
@@ -24,7 +24,7 @@ class Admins::Descriptions::InksController < Admins::BaseController
         old_color, new_color = version.changeset["color"]
         { label: label, type: :color, old_color: old_color, new_color: new_color }
       else
-        changes = version.changeset[field].reverse.map(&:to_s)
+        changes = version.changeset[field].reverse.map { |c| ERB::Util.html_escape(c.to_s) }
         diff = Differ.diff_by_word(*changes).format_as(:html).html_safe
         { label: label, type: :text, diff: diff }
       end

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -4,7 +4,8 @@ class CustomSessionsController < Devise::SessionsController
   def create
     super and return if create_params[:password].present?
 
-    resource = resource_class.find_by(email: create_params[:email].downcase)
+    normalized_email = create_params[:email].to_s.strip.downcase.presence
+    resource = normalized_email && resource_class.find_by(email: normalized_email)
     resource&.send_magic_link(remember_me: create_params[:remember_me])
     set_flash_message(:notice, :magic_link_sent_paranoid, now: true)
 

--- a/app/controllers/custom_sessions_controller.rb
+++ b/app/controllers/custom_sessions_controller.rb
@@ -4,13 +4,9 @@ class CustomSessionsController < Devise::SessionsController
   def create
     super and return if create_params[:password].present?
 
-    self.resource = resource_class.find_by(email: create_params[:email].downcase)
-    if resource
-      resource.send_magic_link(remember_me: create_params[:remember_me])
-      set_flash_message(:notice, :magic_link_sent, now: true)
-    else
-      set_flash_message(:alert, :not_found_in_database, now: true)
-    end
+    resource = resource_class.find_by(email: create_params[:email].downcase)
+    resource&.send_magic_link(remember_me: create_params[:remember_me])
+    set_flash_message(:notice, :magic_link_sent_paranoid, now: true)
 
     self.resource = resource_class.new(create_params)
     render :new

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -33,10 +33,12 @@ class HistoriesController < ApplicationController
         automatic_line_name = object.automatic_line_name.to_s
         old_display = old_value ? "" : automatic_line_name
         new_display = new_value ? "" : automatic_line_name
-        diff = Differ.diff_by_word(new_display, old_display).format_as(:html).html_safe
+        escaped_new = ERB::Util.html_escape(new_display)
+        escaped_old = ERB::Util.html_escape(old_display)
+        diff = Differ.diff_by_word(escaped_new, escaped_old).format_as(:html).html_safe
         { label: "Line Name", type: :text, diff: diff }
       else
-        changes = version.changeset[field].reverse.map(&:to_s)
+        changes = version.changeset[field].reverse.map { |c| ERB::Util.html_escape(c.to_s) }
         diff = Differ.diff_by_word(*changes).format_as(:html).html_safe
         { label: label, type: :text, diff: diff }
       end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -75,7 +75,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,6 +3,36 @@ Rack::Attack.throttle("api requests", limit: 15, period: 30) do |request|
   request.env["HTTP_AUTHORIZATION"] if request.env["HTTP_AUTHORIZATION"].present?
 end
 
+# Brute-force / credential-stuffing protection on Devise endpoints.
+# Throttle sign-in / sign-up / password-reset by both IP and submitted email so
+# that distributed attacks against a single account and noisy single-IP attacks
+# are both blunted. Magic-link sends are covered by the sign-in throttles since
+# they share the same endpoint.
+
+def fpc_devise_email(request)
+  request.params.dig("user", "email").to_s.downcase.strip.presence
+end
+
+Rack::Attack.throttle("logins/ip", limit: 5, period: 20.seconds) do |request|
+  request.ip if request.post? && request.path == "/users/sign_in"
+end
+
+Rack::Attack.throttle("logins/email", limit: 5, period: 60.seconds) do |request|
+  fpc_devise_email(request) if request.post? && request.path == "/users/sign_in"
+end
+
+Rack::Attack.throttle("password_reset/ip", limit: 5, period: 1.hour) do |request|
+  request.ip if request.post? && request.path == "/users/password"
+end
+
+Rack::Attack.throttle("password_reset/email", limit: 3, period: 1.hour) do |request|
+  fpc_devise_email(request) if request.post? && request.path == "/users/password"
+end
+
+Rack::Attack.throttle("signups/ip", limit: 5, period: 1.hour) do |request|
+  request.ip if request.post? && request.path == "/users"
+end
+
 Rack::Attack.throttle("full text search limit", limit: 1, period: 3) do |request|
   request.ip if request.path.starts_with?("/inks") && request.query_string.include?("q=")
 end

--- a/spec/requests/admins/descriptions/brands_controller_spec.rb
+++ b/spec/requests/admins/descriptions/brands_controller_spec.rb
@@ -172,6 +172,25 @@ describe Admins::Descriptions::BrandsController do
         expect(Differ).to have_received(:diff_by_word).with("", "Old description")
       end
     end
+
+    context "with HTML in changeset values (XSS regression)" do
+      let(:version) do
+        double("version", changeset: { "description" => ["safe old", "<script>alert(1)</script>"] })
+      end
+
+      it "HTML-escapes inputs before passing to Differ" do
+        allow(Differ).to receive(:diff_by_word).and_return(
+          double("diff", format_as: double("formatted", html_safe: "formatted diff"))
+        )
+
+        controller.send(:calculate_diff, version)
+
+        expect(Differ).to have_received(:diff_by_word).with(
+          "&lt;script&gt;alert(1)&lt;/script&gt;",
+          "safe old"
+        )
+      end
+    end
   end
 
   private

--- a/spec/requests/admins/descriptions/inks_controller_spec.rb
+++ b/spec/requests/admins/descriptions/inks_controller_spec.rb
@@ -306,6 +306,25 @@ describe Admins::Descriptions::InksController do
         expect(result).to eq([])
       end
     end
+
+    context "with HTML in changeset values (XSS regression)" do
+      let(:version) do
+        double("version", changeset: { "description" => ["safe old", "<script>alert(1)</script>"] })
+      end
+
+      it "HTML-escapes inputs before passing to Differ" do
+        allow(Differ).to receive(:diff_by_word).and_return(
+          double("diff", format_as: double("formatted", html_safe: "formatted diff"))
+        )
+
+        controller.send(:calculate_diffs, version)
+
+        expect(Differ).to have_received(:diff_by_word).with(
+          "&lt;script&gt;alert(1)&lt;/script&gt;",
+          "safe old"
+        )
+      end
+    end
   end
 
   private

--- a/spec/requests/custom_sessions_controller_spec.rb
+++ b/spec/requests/custom_sessions_controller_spec.rb
@@ -39,6 +39,20 @@ describe CustomSessionsController, type: :request do
 
         expect(magic_link_calls).to eq(1)
       end
+
+      it "does not 500 when the email param is missing" do
+        post "/users/sign_in", params: { user: { password: "" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(flash[:notice]).to eq(I18n.t("devise.passwordless.magic_link_sent_paranoid"))
+      end
+
+      it "does not 500 when the email param is blank" do
+        post "/users/sign_in", params: { user: { email: "   " } }
+
+        expect(response).to have_http_status(:ok)
+        expect(flash[:notice]).to eq(I18n.t("devise.passwordless.magic_link_sent_paranoid"))
+      end
     end
   end
 end

--- a/spec/requests/custom_sessions_controller_spec.rb
+++ b/spec/requests/custom_sessions_controller_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe CustomSessionsController, type: :request do
+  describe "POST /users/sign_in" do
+    context "magic-link branch (no password)" do
+      it "shows the paranoid flash when the email matches a user" do
+        user = create(:user)
+
+        post "/users/sign_in", params: { user: { email: user.email } }
+
+        expect(response).to have_http_status(:ok)
+        expect(flash[:notice]).to eq(I18n.t("devise.passwordless.magic_link_sent_paranoid"))
+        expect(flash[:alert]).to be_blank
+      end
+
+      it "shows the same paranoid flash when the email is unknown" do
+        post "/users/sign_in", params: { user: { email: "nobody@example.com" } }
+
+        expect(response).to have_http_status(:ok)
+        expect(flash[:notice]).to eq(I18n.t("devise.passwordless.magic_link_sent_paranoid"))
+        expect(flash[:alert]).to be_blank
+      end
+
+      it "sends a magic link only when the user exists" do
+        existing = create(:user)
+        magic_link_calls = 0
+        original = User.instance_method(:send_magic_link)
+        User.define_method(:send_magic_link) do |*args, **kwargs|
+          magic_link_calls += 1
+          nil
+        end
+
+        begin
+          post "/users/sign_in", params: { user: { email: existing.email } }
+          post "/users/sign_in", params: { user: { email: "nobody@example.com" } }
+        ensure
+          User.define_method(:send_magic_link, original)
+        end
+
+        expect(magic_link_calls).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/requests/histories_controller_spec.rb
+++ b/spec/requests/histories_controller_spec.rb
@@ -134,5 +134,24 @@ describe HistoriesController do
         expect(result).to eq([])
       end
     end
+
+    context "with HTML in changeset values (XSS regression)" do
+      let(:version) do
+        double("version", changeset: { "description" => ["safe old", "<script>alert(1)</script>"] })
+      end
+
+      it "HTML-escapes inputs before passing to Differ" do
+        allow(Differ).to receive(:diff_by_word).and_return(
+          double("diff", format_as: double("formatted", html_safe: "formatted diff"))
+        )
+
+        controller.send(:calculate_diffs, version)
+
+        expect(Differ).to have_received(:diff_by_word).with(
+          "&lt;script&gt;alert(1)&lt;/script&gt;",
+          "safe old"
+        )
+      end
+    end
   end
 end

--- a/spec/requests/histories_controller_spec.rb
+++ b/spec/requests/histories_controller_spec.rb
@@ -153,5 +153,24 @@ describe HistoriesController do
         )
       end
     end
+
+    context "with line_name_is_empty change" do
+      let(:object) { double("object", automatic_line_name: "<line> Iroshizuku") }
+      let(:version) { double("version", changeset: { "line_name_is_empty" => [true, false] }) }
+
+      before { allow(controller).to receive(:object).and_return(object) }
+
+      it "HTML-escapes the automatic_line_name and labels it 'Line Name'" do
+        allow(Differ).to receive(:diff_by_word).and_return(
+          double("diff", format_as: double("formatted", html_safe: "formatted diff"))
+        )
+
+        result = controller.send(:calculate_diffs, version)
+
+        expect(result).to eq([{ label: "Line Name", type: :text, diff: "formatted diff" }])
+        # old_value=true => old_display="", new_value=false => new_display=automatic_line_name
+        expect(Differ).to have_received(:diff_by_word).with("&lt;line&gt; Iroshizuku", "")
+      end
+    end
   end
 end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,98 @@
+require "rails_helper"
+
+describe "Rack::Attack throttles", type: :request do
+  before do
+    # Use a real (memory) cache so throttle counters persist across requests
+    # within a test. The test environment normally uses :null_store / clears
+    # Rails.cache between tests via the global before(:each), so isolation
+    # between examples is already handled.
+    @original_cache = Rack::Attack.cache.store
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.enabled = true
+  end
+
+  after { Rack::Attack.cache.store = @original_cache }
+
+  describe "login throttles on POST /users/sign_in" do
+    it "throttles by IP after 5 attempts in 20 seconds" do
+      6.times do |i|
+        post "/users/sign_in",
+             params: {
+               user: {
+                 email: "ip-victim-#{i}@example.com",
+                 password: "wrong"
+               }
+             },
+             env: {
+               "REMOTE_ADDR" => "203.0.113.1"
+             }
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it "throttles by email regardless of IP" do
+      6.times do |i|
+        post "/users/sign_in",
+             params: {
+               user: {
+                 email: "victim@example.com",
+                 password: "wrong"
+               }
+             },
+             env: {
+               "REMOTE_ADDR" => "203.0.113.#{i + 10}"
+             }
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "password reset throttles on POST /users/password" do
+    it "throttles by email after 3 attempts in 1 hour" do
+      4.times do |i|
+        post "/users/password",
+             params: {
+               user: {
+                 email: "reset-victim@example.com"
+               }
+             },
+             env: {
+               "REMOTE_ADDR" => "203.0.113.#{i + 20}"
+             }
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe "signup throttle on POST /users" do
+    before do
+      stub_request(:post, "https://api.hcaptcha.com/siteverify").to_return(
+        status: 200,
+        body: { success: true }.to_json,
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+    end
+
+    it "throttles by IP after 5 attempts in 1 hour" do
+      6.times do |i|
+        post "/users",
+             params: {
+               user: {
+                 email: "signup-#{i}@example.com",
+                 password: "password123"
+               }
+             },
+             env: {
+               "REMOTE_ADDR" => "203.0.113.50"
+             }
+      end
+
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -4,11 +4,15 @@ describe "Rack::Attack throttles", type: :request do
   before do
     # Per-example cache so throttle counters don't leak between tests.
     @original_cache = Rack::Attack.cache.store
+    @original_enabled = Rack::Attack.enabled
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rack::Attack.enabled = true
   end
 
-  after { Rack::Attack.cache.store = @original_cache }
+  after do
+    Rack::Attack.cache.store = @original_cache
+    Rack::Attack.enabled = @original_enabled
+  end
 
   def statuses(count, &block)
     Array.new(count) do |i|

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -2,10 +2,7 @@ require "rails_helper"
 
 describe "Rack::Attack throttles", type: :request do
   before do
-    # Use a real (memory) cache so throttle counters persist across requests
-    # within a test. The test environment normally uses :null_store / clears
-    # Rails.cache between tests via the global before(:each), so isolation
-    # between examples is already handled.
+    # Per-example cache so throttle counters don't leak between tests.
     @original_cache = Rack::Attack.cache.store
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rack::Attack.enabled = true
@@ -13,57 +10,70 @@ describe "Rack::Attack throttles", type: :request do
 
   after { Rack::Attack.cache.store = @original_cache }
 
-  describe "login throttles on POST /users/sign_in" do
-    it "throttles by IP after 5 attempts in 20 seconds" do
-      6.times do |i|
-        post "/users/sign_in",
-             params: {
-               user: {
-                 email: "ip-victim-#{i}@example.com",
-                 password: "wrong"
-               }
-             },
-             env: {
-               "REMOTE_ADDR" => "203.0.113.1"
-             }
-      end
+  def statuses(count, &block)
+    Array.new(count) do |i|
+      block.call(i)
+      response.status
+    end
+  end
 
-      expect(response).to have_http_status(:too_many_requests)
+  describe "login throttles on POST /users/sign_in" do
+    it "allows the first 5 attempts and throttles the 6th from the same IP" do
+      results =
+        statuses(6) do |i|
+          post "/users/sign_in",
+               params: {
+                 user: {
+                   email: "ip-victim-#{i}@example.com",
+                   password: "wrong"
+                 }
+               },
+               env: {
+                 "REMOTE_ADDR" => "203.0.113.1"
+               }
+        end
+
+      expect(results.first(5)).to all(be < 429)
+      expect(results.last).to eq(429)
     end
 
-    it "throttles by email regardless of IP" do
-      6.times do |i|
-        post "/users/sign_in",
-             params: {
-               user: {
-                 email: "victim@example.com",
-                 password: "wrong"
+    it "allows the first 5 attempts and throttles the 6th for the same email across IPs" do
+      results =
+        statuses(6) do |i|
+          post "/users/sign_in",
+               params: {
+                 user: {
+                   email: "victim@example.com",
+                   password: "wrong"
+                 }
+               },
+               env: {
+                 "REMOTE_ADDR" => "203.0.113.#{i + 10}"
                }
-             },
-             env: {
-               "REMOTE_ADDR" => "203.0.113.#{i + 10}"
-             }
-      end
+        end
 
-      expect(response).to have_http_status(:too_many_requests)
+      expect(results.first(5)).to all(be < 429)
+      expect(results.last).to eq(429)
     end
   end
 
   describe "password reset throttles on POST /users/password" do
-    it "throttles by email after 3 attempts in 1 hour" do
-      4.times do |i|
-        post "/users/password",
-             params: {
-               user: {
-                 email: "reset-victim@example.com"
+    it "allows the first 3 attempts and throttles the 4th for the same email" do
+      results =
+        statuses(4) do |i|
+          post "/users/password",
+               params: {
+                 user: {
+                   email: "reset-victim@example.com"
+                 }
+               },
+               env: {
+                 "REMOTE_ADDR" => "203.0.113.#{i + 20}"
                }
-             },
-             env: {
-               "REMOTE_ADDR" => "203.0.113.#{i + 20}"
-             }
-      end
+        end
 
-      expect(response).to have_http_status(:too_many_requests)
+      expect(results.first(3)).to all(be < 429)
+      expect(results.last).to eq(429)
     end
   end
 
@@ -78,21 +88,23 @@ describe "Rack::Attack throttles", type: :request do
       )
     end
 
-    it "throttles by IP after 5 attempts in 1 hour" do
-      6.times do |i|
-        post "/users",
-             params: {
-               user: {
-                 email: "signup-#{i}@example.com",
-                 password: "password123"
+    it "allows the first 5 attempts and throttles the 6th from the same IP" do
+      results =
+        statuses(6) do |i|
+          post "/users",
+               params: {
+                 user: {
+                   email: "signup-#{i}@example.com",
+                   password: "password123"
+                 }
+               },
+               env: {
+                 "REMOTE_ADDR" => "203.0.113.50"
                }
-             },
-             env: {
-               "REMOTE_ADDR" => "203.0.113.50"
-             }
-      end
+        end
 
-      expect(response).to have_http_status(:too_many_requests)
+      expect(results.first(5)).to all(be < 429)
+      expect(results.last).to eq(429)
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes three of the highest-severity findings from the security audit (see `../SECURITY_AUDIT.md`):

- **H-2 (Stored XSS in description history diffs).** `HistoriesController` and the two admin `Descriptions::*` controllers passed raw user-supplied changeset values to `Differ.format_as(:html)` and marked the result `html_safe`. The differ gem does not HTML-escape text around `<ins>`/`<del>` tags, so any HTML in a brand or ink description rendered live on the public history pages and on the admin description views. Inputs are now `ERB::Util.html_escape`'d before diffing.
- **H-6 / H-7 / M-15 (No brute-force or email-flood protection on Devise endpoints).** Rack::Attack now throttles `POST /users/sign_in`, `POST /users/password`, and `POST /users` keyed on both IP and submitted email. Defaults: 5/20s and 5/60s for sign-in (IP, email), 5/hr and 3/hr for password reset, 5/hr per IP for signup.
- **M-1 (Account enumeration via magic-link).** `CustomSessionsController` previously emitted distinct flashes depending on whether the submitted email belonged to a user. Always shows `:magic_link_sent_paranoid` now. `config.paranoid = true` is enabled in Devise so the recoverable/confirmable flows also stop leaking account existence.

New regression specs cover the escaping fix (XSS regression case), the unified paranoid flash, the conditional `send_magic_link` call, and each Rack::Attack throttle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XSS in diff displays by HTML-escaping diff inputs for descriptions and history fields.
  * Normalized magic-link sign-in flow to always show a single, non-revealing success notice and handle blank/missing emails safely.

* **Security**
  * Enabled paranoid authentication behavior for consistent confirmation/password workflows.
  * Added rate limiting on sign-in, password reset, and sign-up endpoints to mitigate credential-stuffing.

* **Tests**
  * Added request specs covering XSS diffs, magic-link behavior, and the new throttles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->