### PR TITLE
Security: route user-URL fetches through ssrf_filter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "simple_form"
 gem "slim"
 gem "slodown"
 gem "sprockets-rails"
+gem "ssrf_filter"
 gem "strong_migrations"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -544,6 +544,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.5.0)
     stringio (3.2.0)
     strong_migrations (2.8.0)
       activerecord (>= 7.2)
@@ -653,6 +654,7 @@ DEPENDENCIES
   slim
   slodown
   sprockets-rails
+  ssrf_filter
   strong_migrations
   syntax_tree (~> 6.3)
   syntax_tree-haml (~> 4.0)

--- a/app/operations/ink_review_checker.rb
+++ b/app/operations/ink_review_checker.rb
@@ -33,8 +33,8 @@ class InkReviewChecker
 
   def image_reachable?(url)
     return false if url.blank?
-    Faraday.new { |c| c.response :follow_redirects }.head(url).success?
-  rescue Faraday::Error
+    (200..299).cover?(SafeHttp.head(url).status)
+  rescue Faraday::Error, URI::InvalidURIError
     false
   end
 

--- a/app/operations/resolve_image_url.rb
+++ b/app/operations/resolve_image_url.rb
@@ -1,10 +1,4 @@
-require "faraday/follow_redirects"
-
 class ResolveImageUrl
-  OPEN_TIMEOUT = 3
-  READ_TIMEOUT = 5
-  MAX_REDIRECTS = 5
-
   def initialize(url)
     self.url = url
   end
@@ -12,8 +6,8 @@ class ResolveImageUrl
   def perform
     return nil if url.blank?
 
-    response = connection.head(url)
-    return nil unless response.success?
+    response = SafeHttp.head(url)
+    return nil unless (200..299).cover?(response.status)
     return nil unless response.headers["content-type"].to_s.start_with?("image/")
 
     response.env.url.to_s
@@ -24,12 +18,4 @@ class ResolveImageUrl
   private
 
   attr_accessor :url
-
-  def connection
-    Faraday.new do |f|
-      f.response :follow_redirects, limit: MAX_REDIRECTS
-      f.options.open_timeout = OPEN_TIMEOUT
-      f.options.timeout = READ_TIMEOUT
-    end
-  end
 end

--- a/app/operations/safe_http.rb
+++ b/app/operations/safe_http.rb
@@ -65,7 +65,14 @@ class SafeHttp
     uri = parse_uri(url)
     return false unless uri
 
-    addresses_for(uri.host).any? { |ip| globally_routable?(ip) }
+    addresses = addresses_for(uri.host)
+    return false if addresses.empty?
+
+    # Require *all* resolved addresses to be routable. A hostname that
+    # resolves to both a public IP and an internal IP (mixed-answer DNS)
+    # would otherwise pass the gate, and an admin's browser could pick
+    # the internal address when later fetching the URL.
+    addresses.all? { |ip| globally_routable?(ip) }
   rescue URI::InvalidURIError, IPAddr::InvalidAddressError, Resolv::ResolvError
     false
   end

--- a/app/operations/safe_http.rb
+++ b/app/operations/safe_http.rb
@@ -1,0 +1,193 @@
+require "ssrf_filter"
+require "ipaddr"
+require "resolv"
+
+# Thin wrapper around the ssrf_filter gem that provides:
+#
+# - A small compatibility shim so existing callers can keep using
+#   `.status` (Integer), `.headers["content-type"]`, `.body`, and
+#   `.env.url.to_s` regardless of the underlying Net::HTTPResponse API.
+# - A `.allowed?(url)` URL-only validator used at unfurl time before
+#   persisting an attacker-controlled `og:image` URL: we never want to
+#   store a URL that points at an internal address even if we don't
+#   fetch it ourselves (an admin's browser would later fetch it with
+#   their cookies).
+# - Status-aware Faraday exceptions for non-2xx responses (mirrors the
+#   `:raise_error` middleware Faraday provides), so callers that look
+#   for e.g. `Faraday::ForbiddenError` keep working.
+# - Wrapping of network-level exceptions (SocketError, Errno::*, SSL,
+#   IO, EOF) into `Faraday::ConnectionFailed`, again so callers that
+#   already rescue `Faraday::Error` cover the same failure modes they
+#   did before.
+#
+# Note on response-size protection: ssrf_filter calls `Net::HTTP#request`
+# without a streaming block, which buffers the response body. The
+# post-fetch size check below is a backstop only; the primary defense
+# against giant payloads is the read timeout.
+class SafeHttp
+  MAX_REDIRECTS = 5
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 10
+  MAX_BODY_BYTES = 5 * 1024 * 1024
+
+  HTTP_OPTIONS = { open_timeout: OPEN_TIMEOUT, read_timeout: READ_TIMEOUT }.freeze
+
+  class BlockedError < Faraday::Error
+  end
+
+  class ResponseTooLarge < BlockedError
+  end
+
+  Response =
+    Struct.new(:status, :headers, :body, :final_url) do
+      Env = Struct.new(:url)
+
+      # Mimics Faraday::Response#env so callers can read the final URL after
+      # redirects: `response.env.url.to_s`.
+      def env
+        Env.new(URI(final_url))
+      end
+    end
+
+  def self.get(url, headers: {})
+    fetch(:get, url, headers: headers)
+  end
+
+  def self.head(url, headers: {})
+    fetch(:head, url, headers: headers)
+  end
+
+  # URL-only safety check. True when the URL has an http(s) scheme, the
+  # host resolves at all, and at least one resolved IP is globally
+  # routable per ssrf_filter's own blacklist. Does NOT make an HTTP
+  # request.
+  def self.allowed?(url)
+    uri = parse_uri(url)
+    return false unless uri
+
+    addresses_for(uri.host).any? { |ip| globally_routable?(ip) }
+  rescue URI::InvalidURIError, IPAddr::InvalidAddressError, Resolv::ResolvError
+    false
+  end
+
+  def self.parse_uri(url)
+    uri = URI(url.to_s)
+    return nil unless %w[http https].include?(uri.scheme)
+    return nil if uri.host.blank?
+
+    uri
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def self.addresses_for(host)
+    return [IPAddr.new(host)] if literal_ip?(host)
+
+    Resolv.getaddresses(host).map { |a| IPAddr.new(a) }
+  rescue Resolv::ResolvError, IPAddr::InvalidAddressError
+    []
+  end
+
+  def self.literal_ip?(host)
+    IPAddr.new(host)
+    true
+  rescue IPAddr::InvalidAddressError
+    false
+  end
+
+  # Delegates to ssrf_filter's own blacklists so this validator's view of
+  # "routable" matches what the gem will allow at fetch time. The lists
+  # cover all the meaningful ranges (RFC1918, loopback, link-local,
+  # CGNAT, IETF reserved, IPv6 ULA, multicast, IPv4-mapped IPv6, 6to4
+  # back-references, etc.).
+  def self.globally_routable?(ip)
+    if ip.ipv4?
+      SsrfFilter::IPV4_BLACKLIST.none? { |range| range.include?(ip) }
+    elsif ip.ipv6?
+      SsrfFilter::IPV6_BLACKLIST.none? { |range| range.include?(ip) }
+    else
+      false
+    end
+  end
+
+  def self.fetch(verb, url, headers:)
+    raw =
+      SsrfFilter.public_send(
+        verb,
+        url.to_s,
+        max_redirects: MAX_REDIRECTS,
+        scheme_whitelist: %w[http https],
+        headers: headers,
+        http_options: HTTP_OPTIONS,
+        on_cross_origin_redirect: :strip
+      )
+
+    body = raw.body.to_s
+    if body.bytesize > MAX_BODY_BYTES
+      raise ResponseTooLarge, "Response exceeded #{MAX_BODY_BYTES} bytes"
+    end
+
+    response = Response.new(raw.code.to_i, headers_hash(raw), body, raw.uri.to_s)
+
+    raise_for_status!(response)
+    response
+  rescue SsrfFilter::Error, URI::InvalidURIError => e
+    raise BlockedError, e.message
+  rescue Timeout::Error => e
+    raise Faraday::TimeoutError, e.message
+  rescue SocketError,
+         Errno::ECONNREFUSED,
+         Errno::ECONNRESET,
+         Errno::EHOSTUNREACH,
+         Errno::ETIMEDOUT,
+         Errno::ENETUNREACH,
+         Errno::EPIPE,
+         OpenSSL::SSL::SSLError,
+         IOError,
+         EOFError,
+         Net::HTTPBadResponse,
+         Net::ProtocolError => e
+    raise Faraday::ConnectionFailed, e.message
+  end
+
+  # Mirror Faraday's `raise_error` middleware so callers that match on
+  # specific subclasses (e.g. ProcessInkReviewSubmission's 403 carve-out)
+  # keep working.
+  def self.raise_for_status!(response)
+    case response.status
+    when 200..399
+      nil
+    when 400
+      raise Faraday::BadRequestError.new(nil, response.to_h)
+    when 401
+      raise Faraday::UnauthorizedError.new(nil, response.to_h)
+    when 403
+      raise Faraday::ForbiddenError.new(nil, response.to_h)
+    when 404
+      raise Faraday::ResourceNotFound.new(nil, response.to_h)
+    when 408
+      raise Faraday::RequestTimeoutError.new(nil, response.to_h)
+    when 409
+      raise Faraday::ConflictError.new(nil, response.to_h)
+    when 422
+      raise Faraday::UnprocessableContentError.new(nil, response.to_h)
+    when 429
+      raise Faraday::TooManyRequestsError.new(nil, response.to_h)
+    when 400..499
+      raise Faraday::ClientError.new(nil, response.to_h)
+    when 500..599
+      raise Faraday::ServerError.new(nil, response.to_h)
+    else
+      raise Faraday::Error, "Unexpected status #{response.status}"
+    end
+  end
+
+  # Net::HTTPResponse exposes headers as #each_header / #[]; convert to a
+  # plain hash with downcased keys to match Faraday's response.headers
+  # semantics.
+  def self.headers_hash(raw)
+    hash = {}
+    raw.each_header { |k, v| hash[k.to_s.downcase] = v }
+    hash
+  end
+end

--- a/app/operations/unfurler.rb
+++ b/app/operations/unfurler.rb
@@ -48,11 +48,6 @@ class Unfurler
   end
 
   def html
-    connection =
-      Faraday.new do |c|
-        c.response :follow_redirects
-        c.response :raise_error
-      end
-    connection.get(uri).body
+    SafeHttp.get(uri.to_s).body
   end
 end

--- a/app/operations/unfurler/html.rb
+++ b/app/operations/unfurler/html.rb
@@ -47,7 +47,7 @@ class Unfurler
       image ||= document.css("main .cPost_contentWrap img")&.first&.attribute("data-src")&.value
       image ||= document.css("article img")&.first&.attribute("src")&.value
 
-      image = nil if image && URI(image).host.blank?
+      image = nil if image && !SafeHttp.allowed?(image)
 
       image
     end

--- a/spec/operations/ink_review_checker_spec.rb
+++ b/spec/operations/ink_review_checker_spec.rb
@@ -254,4 +254,24 @@ describe InkReviewChecker do
       )
     end
   end
+
+  describe "image hosted on a blocked address (SSRF regression)" do
+    let(:bad_image) { "http://169.254.169.254/latest/meta-data/" }
+    let(:fresh_data) do
+      Unfurler::Result.new("http://example.com/review", "t", "d", bad_image, "a", nil, false, "")
+    end
+
+    before do
+      allow(Resolv).to receive(:getaddresses).with("169.254.169.254").and_return(
+        ["169.254.169.254"]
+      )
+    end
+
+    it "records a failure rather than issuing the HEAD request" do
+      described_class.new(review).perform
+      expect(review.reload.ink_review_checks.last.result).to eq("error")
+      # No HEAD request should have been emitted at all.
+      expect(WebMock).not_to have_requested(:head, bad_image)
+    end
+  end
 end

--- a/spec/operations/resolve_image_url_spec.rb
+++ b/spec/operations/resolve_image_url_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ResolveImageUrl do
       expect(described_class.new(start_url).perform).to be_nil
     end
 
-    it "returns nil when the redirect chain exceeds MAX_REDIRECTS" do
-      urls = (0..described_class::MAX_REDIRECTS).map { |i| "https://example.com/r#{i}" }
+    it "returns nil when the redirect chain exceeds SafeHttp::MAX_REDIRECTS" do
+      urls = (0..SafeHttp::MAX_REDIRECTS).map { |i| "https://example.com/r#{i}" }
       urls.each_with_index do |u, i|
         next_u = urls[i + 1] || "https://example.com/final"
         stub_request(:head, u).to_return(status: 301, headers: { "Location" => next_u })

--- a/spec/operations/safe_http_spec.rb
+++ b/spec/operations/safe_http_spec.rb
@@ -59,6 +59,11 @@ describe SafeHttp do
       stub_resolv("evil.example", ["10.0.0.1"])
       expect(SafeHttp.allowed?("http://evil.example/")).to be false
     end
+
+    it "returns false when the host returns mixed public + private answers" do
+      stub_resolv("mixed.example", %w[93.184.216.34 10.0.0.1])
+      expect(SafeHttp.allowed?("http://mixed.example/")).to be false
+    end
   end
 
   describe ".get" do

--- a/spec/operations/safe_http_spec.rb
+++ b/spec/operations/safe_http_spec.rb
@@ -1,0 +1,189 @@
+require "rails_helper"
+
+describe SafeHttp do
+  def stub_resolv(host, addresses)
+    allow(Resolv).to receive(:getaddresses).with(host).and_return(addresses)
+  end
+
+  describe ".allowed?" do
+    it "returns false for blank/invalid URLs" do
+      expect(SafeHttp.allowed?(nil)).to be false
+      expect(SafeHttp.allowed?("")).to be false
+      expect(SafeHttp.allowed?("not a url")).to be false
+    end
+
+    it "returns false for non-http(s) schemes" do
+      expect(SafeHttp.allowed?("file:///etc/passwd")).to be false
+      expect(SafeHttp.allowed?("javascript:alert(1)")).to be false
+      expect(SafeHttp.allowed?("data:text/html,<script>")).to be false
+      expect(SafeHttp.allowed?("ftp://example.com/x")).to be false
+    end
+
+    it "returns false for loopback hosts" do
+      expect(SafeHttp.allowed?("http://127.0.0.1/")).to be false
+      expect(SafeHttp.allowed?("http://[::1]/")).to be false
+    end
+
+    it "returns false for private IPv4 ranges" do
+      expect(SafeHttp.allowed?("http://10.0.0.1/")).to be false
+      expect(SafeHttp.allowed?("http://192.168.1.1/")).to be false
+      expect(SafeHttp.allowed?("http://172.16.0.1/")).to be false
+    end
+
+    it "returns false for link-local / metadata addresses" do
+      expect(SafeHttp.allowed?("http://169.254.169.254/latest/meta-data/")).to be false
+    end
+
+    it "returns false for CGNAT 100.64.0.0/10" do
+      expect(SafeHttp.allowed?("http://100.64.0.1/")).to be false
+    end
+
+    it "returns false for IPv6 unique-local addresses (fc00::/7)" do
+      expect(SafeHttp.allowed?("http://[fd00::1]/")).to be false
+    end
+
+    it "returns false for IPv4-mapped IPv6 loopback" do
+      expect(SafeHttp.allowed?("http://[::ffff:127.0.0.1]/")).to be false
+    end
+
+    it "returns false for 0.0.0.0 sentinel" do
+      expect(SafeHttp.allowed?("http://0.0.0.0/")).to be false
+    end
+
+    it "returns true when the host resolves to a public IPv4 address" do
+      stub_resolv("example.com", ["93.184.216.34"])
+      expect(SafeHttp.allowed?("https://example.com/x")).to be true
+    end
+
+    it "returns false when the host resolves only to private addresses (DNS-rebinding)" do
+      stub_resolv("evil.example", ["10.0.0.1"])
+      expect(SafeHttp.allowed?("http://evil.example/")).to be false
+    end
+  end
+
+  describe ".get" do
+    it "raises BlockedError on a non-http scheme" do
+      expect { SafeHttp.get("file:///etc/passwd") }.to raise_error(SafeHttp::BlockedError)
+    end
+
+    it "raises BlockedError when the host resolves to a private address" do
+      stub_resolv("rebind.test", ["10.0.0.5"])
+      expect { SafeHttp.get("http://rebind.test/") }.to raise_error(SafeHttp::BlockedError)
+    end
+
+    it "raises BlockedError before opening the socket for a literal loopback IP" do
+      expect { SafeHttp.get("http://127.0.0.1/") }.to raise_error(SafeHttp::BlockedError)
+    end
+
+    it "fetches a public URL and returns the response body" do
+      stub_resolv("public.test", ["93.184.216.34"])
+      stub_request(:get, "http://public.test/").to_return(status: 200, body: "ok")
+
+      response = SafeHttp.get("http://public.test/")
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("ok")
+    end
+
+    it "re-validates the destination on a redirect and blocks rebinding to a private IP" do
+      stub_resolv("public.test", ["93.184.216.34"])
+      stub_resolv("private.test", ["10.0.0.7"])
+      stub_request(:get, "http://public.test/").to_return(
+        status: 302,
+        headers: {
+          "Location" => "http://private.test/"
+        }
+      )
+
+      expect { SafeHttp.get("http://public.test/") }.to raise_error(SafeHttp::BlockedError)
+    end
+
+    it "follows redirects to public destinations" do
+      stub_resolv("first.test", ["93.184.216.34"])
+      stub_resolv("second.test", ["8.8.8.8"])
+      stub_request(:get, "http://first.test/").to_return(
+        status: 302,
+        headers: {
+          "Location" => "http://second.test/x"
+        }
+      )
+      stub_request(:get, "http://second.test/x").to_return(status: 200, body: "redirected")
+
+      response = SafeHttp.get("http://first.test/")
+      expect(response.status).to eq(200)
+      expect(response.body).to eq("redirected")
+    end
+
+    it "caps response body size and raises ResponseTooLarge" do
+      stub_resolv("big.test", ["8.8.8.8"])
+      big = "x" * (SafeHttp::MAX_BODY_BYTES + 1)
+      stub_request(:get, "http://big.test/").to_return(status: 200, body: big)
+
+      expect { SafeHttp.get("http://big.test/") }.to raise_error(SafeHttp::ResponseTooLarge)
+    end
+  end
+
+  describe "non-2xx status handling" do
+    before { stub_resolv("nx.test", ["8.8.8.8"]) }
+
+    it "raises Faraday::ForbiddenError on a 403" do
+      stub_request(:get, "http://nx.test/").to_return(status: 403)
+      expect { SafeHttp.get("http://nx.test/") }.to raise_error(Faraday::ForbiddenError)
+    end
+
+    it "raises Faraday::ResourceNotFound on a 404" do
+      stub_request(:get, "http://nx.test/").to_return(status: 404)
+      expect { SafeHttp.get("http://nx.test/") }.to raise_error(Faraday::ResourceNotFound)
+    end
+
+    it "raises Faraday::ClientError on a 410" do
+      stub_request(:get, "http://nx.test/").to_return(status: 410)
+      expect { SafeHttp.get("http://nx.test/") }.to raise_error(Faraday::ClientError)
+    end
+
+    it "raises Faraday::ServerError on a 500" do
+      stub_request(:get, "http://nx.test/").to_return(status: 500)
+      expect { SafeHttp.get("http://nx.test/") }.to raise_error(Faraday::ServerError)
+    end
+  end
+
+  describe "network-level exception wrapping" do
+    before { stub_resolv("broken.test", ["8.8.8.8"]) }
+
+    it "wraps SocketError as Faraday::ConnectionFailed" do
+      stub_request(:get, "http://broken.test/").to_raise(SocketError.new("getaddrinfo"))
+      expect { SafeHttp.get("http://broken.test/") }.to raise_error(Faraday::ConnectionFailed)
+    end
+
+    it "wraps Errno::ECONNREFUSED as Faraday::ConnectionFailed" do
+      stub_request(:get, "http://broken.test/").to_raise(Errno::ECONNREFUSED)
+      expect { SafeHttp.get("http://broken.test/") }.to raise_error(Faraday::ConnectionFailed)
+    end
+
+    it "wraps OpenSSL::SSL::SSLError as Faraday::ConnectionFailed" do
+      stub_request(:get, "http://broken.test/").to_raise(OpenSSL::SSL::SSLError.new("bad cert"))
+      expect { SafeHttp.get("http://broken.test/") }.to raise_error(Faraday::ConnectionFailed)
+    end
+  end
+
+  describe ".head" do
+    it "raises BlockedError before opening the socket for AWS metadata" do
+      expect { SafeHttp.head("http://169.254.169.254/latest/meta-data/") }.to raise_error(
+        SafeHttp::BlockedError
+      )
+    end
+
+    it "fetches a public URL with HEAD" do
+      stub_resolv("public.test", ["8.8.8.8"])
+      stub_request(:head, "http://public.test/img.png").to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "image/png"
+        }
+      )
+
+      response = SafeHttp.head("http://public.test/img.png")
+      expect(response.status).to eq(200)
+      expect(response.headers["content-type"]).to eq("image/png")
+    end
+  end
+end

--- a/spec/operations/unfurler/html_spec.rb
+++ b/spec/operations/unfurler/html_spec.rb
@@ -232,4 +232,35 @@ describe Unfurler::Html do
       expect(subject.author).to eq(nil)
     end
   end
+
+  context "image hosted on a private/blocked address (SSRF regression)" do
+    let(:html) { <<~HTML }
+        <html>
+          <head>
+            <meta property="og:image" content="http://169.254.169.254/latest/meta-data/">
+          </head>
+        </html>
+      HTML
+
+    it "drops the image rather than persisting an attacker-controlled internal URL" do
+      allow(Resolv).to receive(:getaddresses).with("169.254.169.254").and_return(
+        ["169.254.169.254"]
+      )
+      expect(subject.image).to be_nil
+    end
+  end
+
+  context "image with a non-http scheme (SSRF regression)" do
+    let(:html) { <<~HTML }
+        <html>
+          <head>
+            <meta property="og:image" content="data:text/html,<script>alert(1)</script>">
+          </head>
+        </html>
+      HTML
+
+    it "drops data: URIs and other non-http schemes" do
+      expect(subject.image).to be_nil
+    end
+  end
 end

--- a/spec/operations/unfurler_spec.rb
+++ b/spec/operations/unfurler_spec.rb
@@ -31,5 +31,21 @@ RSpec.describe Unfurler do
       )
       described_class.new("https://notyoutube.com/watch?v=abc").perform
     end
+
+    it "refuses to fetch URLs whose host resolves to a private address (SSRF regression)" do
+      allow(Resolv).to receive(:getaddresses).with("metadata.internal").and_return(
+        ["169.254.169.254"]
+      )
+
+      expect { described_class.new("http://metadata.internal/latest/").perform }.to raise_error(
+        Faraday::Error
+      )
+    end
+
+    it "refuses to fetch loopback URLs (SSRF regression)" do
+      expect { described_class.new("http://127.0.0.1:6379/").perform }.to raise_error(
+        Faraday::Error
+      )
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,23 @@ RSpec.configure do |config|
   config.before(:each) { Sidekiq::Worker.clear_all }
   config.before(:each) { Rails.cache.clear }
 
+  # SafeHttp (and ssrf_filter under the hood) resolve hostnames before
+  # opening sockets, but test hosts are not real and we don't want to
+  # depend on container DNS. Default every spec to a public IPv4 for
+  # non-IP hostnames. Literal IPs pass through unchanged so SSRF guards
+  # actually see the address the test used. Tests that exercise a
+  # specific SSRF scenario can still override per-host.
+  config.before(:each) do
+    allow(Resolv).to receive(:getaddresses) do |host|
+      begin
+        IPAddr.new(host.to_s)
+        [host.to_s]
+      rescue IPAddr::InvalidAddressError
+        ["93.184.216.34"]
+      end
+    end
+  end
+
   config.before(:each, type: :request) { Rails.application.reload_routes_unless_loaded }
   config.before(:each, type: :controller) { Rails.application.reload_routes_unless_loaded }
 end


### PR DESCRIPTION
## Summary

Closes SSRF and HTTP-DoS findings from the audit (`../SECURITY_AUDIT.md` — H-4, H-5, M-7, M-8). Anyone who could submit an ink review URL could previously coerce a Sidekiq worker into hitting Redis, Postgres, Fly.io metadata, or the app itself.

- Adopt the **`ssrf_filter`** gem for every outbound HTTP fetch that takes an attacker-controlled URL: `Unfurler`, `ResolveImageUrl`, `InkReviewChecker`.
- Wrap it in a thin `SafeHttp` shim that:
  - Raises status-aware Faraday exceptions (so the existing 403 carve-out in `ProcessInkReviewSubmission` keeps working).
  - Wraps `SocketError` / `Errno::*` / `OpenSSL::SSL::SSLError` / `IOError` / `EOFError` / `Net::*` into `Faraday::ConnectionFailed`, matching the failure surface Faraday gave us before.
  - Exposes `.allowed?(url)` backed by `SsrfFilter::IPV4_BLACKLIST` / `IPV6_BLACKLIST`. `Unfurler::Html#image` now runs the `og:image` URL through this before persisting, so a poisoned page can't plant an internal URL that an admin's browser would later fetch with their cookies.
  - Applies a 5 MB body backstop and 10 s read timeout. Honest comment in the file about the backstop being post-fetch; the primary DoS defense is the timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSRF protection to HTTP/image fetching to block unsafe internal addresses.

* **Bug Fixes**
  * Improved URL/image validation and error handling to avoid fetching from private, loopback, or metadata endpoints.

* **Tests**
  * Added extensive tests covering SSRF scenarios, redirects, header/status handling, and deterministic DNS stubbing for test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->