### PR TITLE
Security: restrict Admins::StatsController to explicit allowlist

### DIFF
--- a/app/controllers/admins/stats_controller.rb
+++ b/app/controllers/admins/stats_controller.rb
@@ -1,12 +1,37 @@
 class Admins::StatsController < Admins::BaseController
+  # Stat methods that take an Integer-coercible :arg.
+  ARG_STATS = %w[pens_micro_clusters_prio_to_assign_count relevant_pens_micro_clusters_count].freeze
+
+  # Stat methods callable with no argument: everything public on AdminStats
+  # that isn't in ARG_STATS. Anything not in one of these two sets returns 404.
+  NO_ARG_STATS = (AdminStats.instance_methods(false).map(&:to_s) - ARG_STATS).freeze
+
   def show
-    render json: statistic
+    return head :not_found unless stat_allowed?
+
+    result = statistic
+    return if performed?
+
+    render json: result
   end
 
   private
 
+  def stat_name
+    params[:id].to_s
+  end
+
+  def stat_allowed?
+    NO_ARG_STATS.include?(stat_name) || ARG_STATS.include?(stat_name)
+  end
+
   def statistic
-    args = [params[:id], params[:arg]].compact
-    AdminStats.new.send(*args)
+    if ARG_STATS.include?(stat_name) && params[:arg].present?
+      AdminStats.new.public_send(stat_name, Integer(params[:arg]))
+    else
+      AdminStats.new.public_send(stat_name)
+    end
+  rescue ArgumentError, TypeError
+    head :bad_request
   end
 end

--- a/spec/requests/admins/stats_controller_spec.rb
+++ b/spec/requests/admins/stats_controller_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe Admins::StatsController, type: :request do
+  let(:admin) { create(:user, :admin) }
+  let(:regular_user) { create(:user) }
+
+  describe "GET /admins/stats/:id" do
+    context "when not authenticated" do
+      it "redirects to login" do
+        get "/admins/stats/user_count"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as a regular user" do
+      before { sign_in(regular_user) }
+
+      it "is not allowed" do
+        get "/admins/stats/user_count"
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when authenticated as admin" do
+      before { sign_in(admin) }
+
+      it "returns the value for a known no-arg stat" do
+        create(:user)
+        get "/admins/stats/user_count"
+        expect(response).to be_successful
+        expect(JSON.parse(response.body)).to eq(User.active.count)
+      end
+
+      it "returns the value for a known arg-taking stat" do
+        get "/admins/stats/pens_micro_clusters_prio_to_assign_count?arg=2"
+        expect(response).to be_successful
+        expect(response.body).to match(/\A\d+\z/)
+      end
+
+      it "uses the method default when an arg-taking stat is called with no arg" do
+        # The dashboard view calls these stats both with and without arg —
+        # without arg the AdminStats method's default value must apply.
+        get "/admins/stats/pens_micro_clusters_prio_to_assign_count"
+        expect(response).to be_successful
+        expect(response.body).to match(/\A\d+\z/)
+      end
+
+      it "returns 404 for an unknown stat name" do
+        get "/admins/stats/nope_not_a_real_stat"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 for a private/Kernel method (security regression)" do
+        get "/admins/stats/eval", params: { arg: "`whoami`" }
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 404 for a private/Kernel method without arg" do
+        get "/admins/stats/instance_eval"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "returns 400 when arg is not coercible to Integer" do
+        get "/admins/stats/pens_micro_clusters_prio_to_assign_count?arg=notanint"
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes H-8 from the audit. `Admins::StatsController#show` previously called `AdminStats.new.send(params[:id], params[:arg])`, where `Object#send` reaches private methods including Kernel's `eval`, `instance_eval`, `system`, and `exec`. Admin-gated, so an anonymous attacker can't hit it directly — but any GET-CSRF / admin-XSS vector (`<img src=\"/admins/stats/eval?arg=...\">` inside a description) would convert admin browser compromise into RCE in the Rails process.

Replaced the dynamic dispatch with:

- `ARG_STATS` — explicit allowlist of the two `AdminStats` methods that take a single Integer-coercible count.
- `NO_ARG_STATS = AdminStats.instance_methods(false) - ARG_STATS` — everything else on `AdminStats`. `instance_methods(false)` returns only methods defined directly on the class, so the allowlist excludes Kernel/Object inheritance.
- `public_send` instead of `send`. Even if the allowlist were ever loosened the dispatcher can no longer reach private/Kernel methods.
- `Integer(params[:arg])` for `ARG_STATS` calls when an arg is present; fall through to the method's default `count = 1` when it isn't, so the dashboard widgets at `app/views/admins/dashboards/show.html.slim:67,71` that intentionally request the unfiltered count keep working.
- 404 for unknown stat names; 400 for arg coercion failures.