### PR TITLE
Security: per-IP + per-token-id API throttles + page-size caps

### DIFF
--- a/app/models/collected_ink.rb
+++ b/app/models/collected_ink.rb
@@ -4,6 +4,9 @@ class CollectedInk < ApplicationRecord
   include Archivable
   include PgSearch::Model
 
+  paginates_per 100
+  max_paginates_per 100
+
   KINDS = %w[bottle sample cartridge swab]
 
   validates :kind, inclusion: { in: KINDS, allow_blank: true }

--- a/app/models/macro_cluster.rb
+++ b/app/models/macro_cluster.rb
@@ -52,6 +52,7 @@ class MacroCluster < ApplicationRecord
   after_commit :enqueue_update, if: :saved_change_to_color?
 
   paginates_per 100
+  max_paginates_per 100
 
   scope :unassigned, -> { where(brand_cluster_id: nil) }
   scope :without_description, -> { where(description: "") }

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 Kaminari.configure do |config|
   # config.default_per_page = 25
-  # config.max_per_page = nil
+  # Global ceiling on `page[size]` (the user-supplied per-page value).
+  # Per-model `max_paginates_per` overrides this for tighter caps.
+  config.max_per_page = 500
   # config.window = 4
   # config.outer_window = 0
   # config.left = 0

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,33 @@
-# Throttle API requests by authorization token
-Rack::Attack.throttle("api requests", limit: 15, period: 30) do |request|
-  request.env["HTTP_AUTHORIZATION"] if request.env["HTTP_AUTHORIZATION"].present?
+# Throttle API requests. Two complementary rules:
+#
+# - Per-IP throttle on every /api/* request, so rotating bearer tokens
+#   (or sending garbage tokens) cannot evade the throttle by handing
+#   each request a fresh bucket key. This catches CPU-amplified DoS
+#   that forces a bcrypt-compare on every garbage token.
+# - Per-token-id throttle so a single legitimate user with a valid
+#   token still hits a per-token ceiling regardless of source IP. Keyed
+#   on the *id* portion of the token (everything before the first
+#   ".") rather than the full Authorization header, because the secret
+#   half is high-entropy and attackers could rotate it freely.
+
+def fpc_api_token_id(request)
+  auth = request.env["HTTP_AUTHORIZATION"].to_s
+  return nil if auth.empty?
+
+  # Token-authenticator format: `Token token="<id>.<secret>"` (or with
+  # the `Bearer` scheme, or no scheme at all). Pull out the value, then
+  # take the id half.
+  raw = auth[/token=("?)([^"\s,]+)\1/i, 2] || auth.sub(/\ABearer\s+/i, "").strip
+  id, _secret = raw.to_s.split(".", 2)
+  id.presence
+end
+
+Rack::Attack.throttle("api/ip", limit: 60, period: 60.seconds) do |request|
+  request.ip if request.path.starts_with?("/api/")
+end
+
+Rack::Attack.throttle("api/token-id", limit: 15, period: 30.seconds) do |request|
+  fpc_api_token_id(request) if request.path.starts_with?("/api/")
 end
 
 # Brute-force / credential-stuffing protection on Devise endpoints.

--- a/spec/requests/api/v1/collected_inks_spec.rb
+++ b/spec/requests/api/v1/collected_inks_spec.rb
@@ -50,6 +50,24 @@ describe Api::V1::CollectedInksController do
         )
       end
 
+      it "caps page[size] at CollectedInk.max_paginates_per" do
+        # max_paginates_per is 100. Even when the client requests a huge
+        # size, the response must not exceed it.
+        150.times { create(:collected_ink, user: user) }
+
+        get "/api/v1/collected_inks",
+            params: {
+              page: {
+                size: 10_000
+              }
+            },
+            headers: {
+              "ACCEPT" => "application/json"
+            }
+
+        expect(json[:data].size).to be <= CollectedInk.max_per_page
+      end
+
       it "allows supports pagination" do
         create(:collected_ink, user: user, brand_name: "Aurora", ink_name: "Black")
         create(:collected_ink, user: user, brand_name: "Waldmann", ink_name: "Blue")

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -111,4 +111,39 @@ describe "Rack::Attack throttles", type: :request do
       expect(results.last).to eq(429)
     end
   end
+
+  describe "API token throttles" do
+    it "throttles /api/* requests by IP when the Authorization header changes per request" do
+      # Rotate a fake bearer token on every request. The old per-header
+      # throttle would have given each value its own bucket; the new
+      # per-IP /api/* throttle catches this pattern.
+      results =
+        statuses(61) do |i|
+          get "/api/v1/collected_inks",
+              env: {
+                "REMOTE_ADDR" => "203.0.113.77",
+                "HTTP_AUTHORIZATION" => %(Token token="garbage-#{i}.secret")
+              }
+        end
+
+      expect(results.first(60)).to all(be < 429)
+      expect(results.last).to eq(429)
+    end
+
+    it "throttles /api/* by token id across rotating secrets" do
+      # Same token id with rotating secret halves should hit the
+      # per-token-id throttle even from different IPs.
+      results =
+        statuses(16) do |i|
+          get "/api/v1/collected_inks",
+              env: {
+                "REMOTE_ADDR" => "203.0.113.#{100 + i}",
+                "HTTP_AUTHORIZATION" => %(Token token="same-id.secret-#{i}")
+              }
+        end
+
+      expect(results.first(15)).to all(be < 429)
+      expect(results.last).to eq(429)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Closes M-10 and M-11 from the audit.

**M-10.** The old "api requests" throttle keyed on the full `Authorization` header, so a rotated bearer value got a fresh bucket every request and bypassed the cap entirely. Each garbage token still cost the server a bcrypt-compare in `AuthenticationToken.authenticate_by` — a CPU-amplified DoS the throttle didn't slow. Replace it with two rules:

- **`api/ip`** — 60 req/60 s on every `/api/*` request, keyed on the source IP. Catches rotating-token DoS regardless of header value.
- **`api/token-id`** — 15 req/30 s keyed on the *id* half of the token (everything before the first `.`). The high-entropy secret half can no longer be rotated to evade the per-token cap. Same bucketing granularity as before for legitimate clients (one bucket per token).

**M-11.** Add `max_paginates_per 100` to `CollectedInk` and `MacroCluster`. Both were previously uncapped, letting an authenticated client demand `?page[size]=1000000` and force a full table scan plus eager-load and JSONAPI serialize. `CollectedPen` and `CurrentlyInked` already had explicit caps; this finishes the set. Also set a global `Kaminari.config.max_per_page = 500` as a defense-in-depth ceiling for any future paginated model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * API rate limiting now differentiates between requests by source IP and by token identifier for granular traffic control.
  * API pagination requests are now capped at a maximum of 500 items per page, with per-endpoint refinements available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->