### PR TITLE
Security: HCaptcha fail-closed on signup (M-9)

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  # hCaptcha is checked BEFORE Devise builds the resource. On failure we
+  # render the form with a base error and never call super, so no User
+  # row is persisted. Previously the controller persisted a "bot"-flagged
+  # row on failed captchas; that left the unique email index occupied
+  # and let an attacker squat any victim's address without ever solving
+  # a captcha (audit finding M-9).
   def create
+    unless hcaptcha_passed?
+      self.resource = resource_class.new(sign_up_params)
+      resource.errors.add(:base, I18n.t("devise.failure.failed_captcha"))
+      clean_up_passwords resource
+      respond_with(resource) and return
+    end
+
     super do |resource|
       resource.update(
         sign_up_user_agent: request.headers["User-Agent"],
@@ -12,25 +25,32 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   private
 
-  def sign_up_params
-    data = super
-    check_captcha!(data)
-    data
+  def hcaptcha_passed?
+    return false if params["h-captcha-response"].blank?
+
+    response =
+      hcaptcha_connection.post("/siteverify") do |req|
+        req.body = {
+          secret: ENV["HCAPTCHA_SECRET"],
+          response: params["h-captcha-response"],
+          remoteip: request.remote_ip
+        }
+      end
+
+    response.body.is_a?(Hash) && response.body["success"] == true
+  rescue Faraday::Error, JSON::ParserError
+    # Fail closed — if hCaptcha is unreachable or returns garbage we
+    # treat it as a failed challenge rather than silently letting the
+    # registration through.
+    false
   end
 
-  def check_captcha!(data)
-    conn =
-      Faraday.new("https://api.hcaptcha.com/") do |c|
-        c.request :url_encoded
-        c.response :json
-      end
-    response =
-      conn.post("/siteverify") do |req|
-        req.body = { secret: ENV["HCAPTCHA_SECRET"], response: params["h-captcha-response"] }
-      end
-
-    return if response.body["success"]
-    data["bot"] = true
-    data["bot_reason"] = "failed-captcha(#{response.body["error-codes"].join(",")})"
+  def hcaptcha_connection
+    Faraday.new("https://api.hcaptcha.com/") do |c|
+      c.request :url_encoded
+      c.response :json
+      c.options.open_timeout = 5
+      c.options.timeout = 10
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,8 +67,14 @@ class User < ApplicationRecord
     super
   end
 
+  # Recovery path for users wrongly flagged by the sign_up_ip_24h_timeframe
+  # heuristic. Their initial confirmation email is suppressed by
+  # `check_if_we_should_skip_confirmation`, but Devise's resend_confirmation
+  # endpoint still delivers — so if a real human clicks the link we clear
+  # the bot flag and the matching reason rather than leaving them in the
+  # bot bucket forever.
   def after_confirmation
-    update_attribute(:bot, false)
+    update_columns(bot: false, bot_reason: nil)
   end
 
   def unread

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
       magic_link_invalid: "Invalid or expired login link."
+      failed_captcha: "We could not verify the captcha. Please try again."
     mailer:
       confirmation_instructions:
         subject: "[fountainpencompanion.com] Confirmation instructions"

--- a/spec/requests/registration_spec.rb
+++ b/spec/requests/registration_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 describe "sign up" do
-  context "normal user" do
-    let(:user_params) do
-      { email: "user@example.com", password: "password", password_confirmation: "password" }
-    end
+  let(:user_params) do
+    { email: "user@example.com", password: "password", password_confirmation: "password" }
+  end
 
+  let(:full_params) { { :user => user_params, "h-captcha-response" => "valid-token" } }
+
+  context "captcha passes" do
     before do
       stub_request(:post, "https://api.hcaptcha.com/siteverify").to_return(
         status: 200,
@@ -15,50 +17,91 @@ describe "sign up" do
         }
       )
     end
-    it "creates a user" do
-      expect do
-        post "/users", params: { user: user_params }
-        expect(response).to be_redirect
-      end.to change { User.where(bot: false).count }.by(1)
+
+    it "creates a non-bot user" do
+      expect { post "/users", params: full_params }.to change { User.where(bot: false).count }.by(1)
+      expect(response).to be_redirect
     end
 
     it "sends the confirmation email" do
       expect do
-        post "/users", params: { user: user_params }
-        expect(response).to be_redirect
+        post "/users", params: full_params
         Sidekiq::Worker.drain_all
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    it "sends the request IP to hCaptcha" do
+      post "/users", params: full_params, env: { "REMOTE_ADDR" => "203.0.113.55" }
+
+      expect(WebMock).to have_requested(:post, "https://api.hcaptcha.com/siteverify").with(
+        body: hash_including("remoteip" => "203.0.113.55")
+      )
+    end
   end
 
-  context "bot user" do
-    let(:user_params) do
-      { email: "user@example.com", password: "password", password_confirmation: "password" }
-    end
-
+  context "captcha fails (hCaptcha returns success: false)" do
     before do
       stub_request(:post, "https://api.hcaptcha.com/siteverify").to_return(
         status: 200,
-        body: { success: false, "error-codes": %w[not good] }.to_json,
+        body: { success: false, "error-codes": %w[invalid-input-response] }.to_json,
         headers: {
           "Content-Type" => "application/json"
         }
       )
     end
 
-    it "creates a bot user" do
-      expect do
-        post "/users", params: { user: user_params }
-        expect(response).to be_redirect
-      end.to change { User.where(bot: true).count }.by(1)
+    it "does not create any user" do
+      expect { post "/users", params: full_params }.not_to(change { User.count })
     end
 
-    it "does not send an email" do
+    it "re-renders the signup form with a base error" do
+      post "/users", params: full_params
+      expect(response.body).to include("captcha")
+    end
+
+    it "does not send any email" do
       expect do
-        post "/users", params: { user: user_params }
-        expect(response).to be_redirect
+        post "/users", params: full_params
         Sidekiq::Worker.drain_all
-      end.to_not(change { ActionMailer::Base.deliveries.count })
+      end.not_to(change { ActionMailer::Base.deliveries.count })
+    end
+  end
+
+  context "captcha token missing entirely" do
+    it "does not create a user and does not call hCaptcha" do
+      stub = stub_request(:post, "https://api.hcaptcha.com/siteverify")
+
+      expect { post "/users", params: { user: user_params } }.not_to(change { User.count })
+
+      expect(stub).not_to have_been_requested
+    end
+  end
+
+  context "hCaptcha service is unreachable (fail-closed)" do
+    before do
+      stub_request(:post, "https://api.hcaptcha.com/siteverify").to_raise(
+        Faraday::ConnectionFailed.new("network down")
+      )
+    end
+
+    it "treats the network error as a captcha failure and does not create a user" do
+      expect { post "/users", params: full_params }.not_to(change { User.count })
+    end
+  end
+
+  context "hCaptcha returns malformed body (fail-closed)" do
+    before do
+      stub_request(:post, "https://api.hcaptcha.com/siteverify").to_return(
+        status: 200,
+        body: "not json",
+        headers: {
+          "Content-Type" => "application/json"
+        }
+      )
+    end
+
+    it "treats the parse error as a captcha failure and does not create a user" do
+      expect { post "/users", params: full_params }.not_to(change { User.count })
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes M-9 from the audit.

Captcha failure used to persist a bot-flagged User row with the confirmation email suppressed. The unique email index was still occupied — any authenticated attacker could squat arbitrary email addresses without ever solving a captcha.

- Restructure `Users::RegistrationsController#create` to check the captcha **before** Devise builds the resource. On failure render \`:new\` with a base error and never call \`super\`. No User row is persisted.
- Wrap the Faraday siteverify call in a rescue. If hCaptcha is unreachable or returns garbage, fail closed (treat as captcha failure) rather than crashing the request and silently letting the registration through.
- Send `remoteip` to siteverify so a solved token can't be replayed from a different source.
- Keep the `User#after_confirmation` recovery callback that clears the bot flag, but switch from `update_attribute(:bot, false)` to `update_columns(bot: false, bot_reason: nil)` — same recovery semantics, no validation-bypass on a single column, and clears the stale `bot_reason` at the same time. Users wrongly flagged by the `sign_up_ip_24h_timeframe` heuristic can still self-recover by requesting Devise resend the confirmation email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  - Refactored signup CAPTCHA verification for improved reliability and earlier validation in the registration process
  - Enhanced error handling for verification timeouts and connection failures
  - Improved user messaging when CAPTCHA validation fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->