### PR TITLE
Fix Sidekiq ArgumentError from symbol keys in rejected_suggestions

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -144,7 +144,7 @@ class WidgetsController < ApplicationController
         ink_id = safe_integer(entry["ink_id"])
         pen_id = safe_integer(entry["pen_id"])
         next unless ink_id && pen_id
-        { ink_id: ink_id, pen_id: pen_id }
+        { "ink_id" => ink_id, "pen_id" => pen_id }
       end
   rescue JSON::ParserError
     []

--- a/spec/requests/widgets_spec.rb
+++ b/spec/requests/widgets_spec.rb
@@ -294,7 +294,7 @@ describe WidgetsController do
         get url, params: { rejected_suggestions: payload }
 
         expect(captured[:rejected_suggestions]).to eq(
-          [{ ink_id: 1, pen_id: 2 }, { ink_id: 5, pen_id: 6 }]
+          [{ "ink_id" => 1, "pen_id" => 2 }, { "ink_id" => 5, "pen_id" => 6 }]
         )
       end
 
@@ -324,6 +324,18 @@ describe WidgetsController do
         expect(captured[:rejected_suggestions].length).to eq(
           WidgetsController::MAX_REJECTED_SUGGESTIONS
         )
+      end
+
+      it "enqueues the worker with Sidekiq-safe (string-keyed) args" do
+        payload = [{ "ink_id" => 1, "pen_id" => 2 }].to_json
+
+        expect { get url, params: { rejected_suggestions: payload } }.to change(
+          SchedulePenAndInkSuggestion.jobs,
+          :size
+        ).by(1)
+
+        enqueued_rejected = SchedulePenAndInkSuggestion.jobs.last["args"].last
+        expect(enqueued_rejected).to eq([{ "ink_id" => 1, "pen_id" => 2 }])
       end
     end
   end


### PR DESCRIPTION
PR #3561's `parse_rejected_suggestions` returned `{ ink_id:, pen_id: }` hashes that flowed into `SchedulePenAndInkSuggestion.perform_async`; Sidekiq's `strict_args` rejects symbol keys, so every suggestion enqueue since the merge has raised `ArgumentError` (Honeybadger 131600570) and the job never ran. Switch to string keys — downstream only calls `JSON.generate`, so behavior is unchanged — and add a regression spec that exercises the real enqueue path (the original tests stubbed `RequestPenAndInkSuggestion` and missed it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling consistency for background job processing.

* **Tests**
  * Enhanced test coverage for job queue handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->