### PR TITLE
Stabilize flaky rack_attack throttle spec by freezing time

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,15 +1,21 @@
 require "rails_helper"
 
 describe "Rack::Attack throttles", type: :request do
+  include ActiveSupport::Testing::TimeHelpers
+
   before do
     # Per-example cache so throttle counters don't leak between tests.
     @original_cache = Rack::Attack.cache.store
     @original_enabled = Rack::Attack.enabled
     Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     Rack::Attack.enabled = true
+    # Freeze time so a burst of requests can't straddle a Rack::Attack
+    # period boundary and reset the counter mid-test.
+    freeze_time
   end
 
   after do
+    travel_back
     Rack::Attack.cache.store = @original_cache
     Rack::Attack.enabled = @original_enabled
   end


### PR DESCRIPTION
Rack::Attack uses wall-clock-aligned time windows (`limit: 60, period: 60.seconds`), so a 60-request burst that straddled a period boundary saw the counter reset mid-test and the final request escape throttling — Rails then returned 406 (no `Accept` header on the JSON-only route) instead of the expected 429. Both `/api/*` throttle examples flaked intermittently in CI (most recently in #3564). Wrap the spec in `freeze_time` so every burst lands inside a single period.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of throttling test specifications with enhanced time management during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->