### PR TITLE
Fix RubyLLM::BadRequestError from unreachable YouTube thumbnails

### DIFF
--- a/app/agents/youtube_summarizer.rb
+++ b/app/agents/youtube_summarizer.rb
@@ -18,7 +18,7 @@ class YoutubeSummarizer
   end
 
   def perform
-    response = ask(prompt_text, with: source_image.presence)
+    response = ask(prompt_text, with: resolved_image_url)
     agent_log.waiting_for_approval!
     response.content
   end
@@ -50,6 +50,10 @@ class YoutubeSummarizer
   def source_title = source.respond_to?(:title) ? source.title.to_s : ""
   def source_description = source.respond_to?(:description) ? source.description.to_s : ""
   def source_image = source.respond_to?(:image) ? source.image.to_s : ""
+
+  def resolved_image_url
+    ResolveImageUrl.new(source_image).perform
+  end
 
   def source_tags
     if source.respond_to?(:youtube_tags)

--- a/spec/agents/youtube_summarizer_spec.rb
+++ b/spec/agents/youtube_summarizer_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe YoutubeSummarizer do
         "Content-Type" => "application/json"
       }
     )
+    stub_request(:head, %r{https://img\.youtube\.com/vi/.+/maxresdefault\.jpg}).to_return(
+      status: 200,
+      headers: {
+        "Content-Type" => "image/jpeg"
+      }
+    )
   end
 
   subject { described_class.new(parent_agent_log, source) }
@@ -118,6 +124,23 @@ RSpec.describe YoutubeSummarizer do
       content = user_msg["content"]
       text = content.is_a?(Array) ? content.find { |p| p["type"] == "text" }&.[]("text") : content
       text.include?("(none available)")
+    }
+  end
+
+  it "omits the thumbnail when the URL is unreachable" do
+    stub_request(:head, "https://img.youtube.com/vi/abc/maxresdefault.jpg").to_return(status: 404)
+
+    subject.perform
+
+    expect(WebMock).to have_requested(
+      :post,
+      "https://api.openai.com/v1/chat/completions"
+    ).with { |req|
+      body = JSON.parse(req.body)
+      user_msg = body["messages"].find { |m| m["role"] == "user" }
+      content = user_msg["content"]
+      content.is_a?(String) ||
+        (content.is_a?(Array) && content.none? { |p| p["type"] == "image_url" })
     }
   end
 


### PR DESCRIPTION
## Summary

- `YoutubeSummarizer` passed `page_data.image` straight to OpenAI's vision API. YouTube's data API sometimes lists a `maxresdefault.jpg` thumbnail that 404s when fetched, so OpenAI returned 400 and the job kept retrying — Honeybadger fault [131146198](https://app.honeybadger.io/projects/107098/faults/131146198) accumulated 17 notices across several days.
- `ReviewFinder` already wraps the image URL in `ResolveImageUrl` (HEAD + `image/*` content-type check). Reuse the same operation in `YoutubeSummarizer`; if unreachable, `with:` receives `nil` and the attachment is omitted, matching the existing behaviour for web-page summaries.
- Spec stubs the HEAD for the happy path and adds a regression test that verifies the thumbnail is dropped when the URL is unreachable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YouTube summarizer to gracefully handle cases where thumbnail images are unavailable or unreachable, ensuring consistent summarization performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->