### PR TITLE
Fix InkClusterer skipping runs after admin cluster changes

### DIFF
--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -278,13 +278,12 @@ class InkClusterer
     return true if micro_cluster.ignored?
     return true if micro_cluster.macro_cluster_id.present?
 
+    # Only an in-flight run (waiting for approval) should block a new run. The
+    # ignored?/macro_cluster_id checks above already cover resolved states, and
+    # APPROVED logs must not block re-clustering triggered by admin actions
+    # (deleting a macro cluster, unignoring or unassigning a micro cluster).
     latest =
-      micro_cluster
-        .agent_logs
-        .ink_clusterer
-        .where(state: [AgentLog::APPROVED, AgentLog::WAITING_FOR_APPROVAL])
-        .order(updated_at: :desc)
-        .first
+      micro_cluster.agent_logs.ink_clusterer.waiting_for_approval.order(updated_at: :desc).first
     return false unless latest
 
     micro_cluster.collected_inks.where("updated_at > ?", latest.updated_at).none?

--- a/app/controllers/admins/macro_clusters_controller.rb
+++ b/app/controllers/admins/macro_clusters_controller.rb
@@ -32,18 +32,9 @@ class Admins::MacroClustersController < Admins::BaseController
 
   def destroy
     cluster = MacroCluster.find(params[:id])
-    micro_cluster_ids = []
-    cluster.micro_clusters.each do |micro_cluster|
-      micro_cluster.agent_logs.create!(
-        name: "InkClusterer",
-        state: AgentLog::APPROVED,
-        transcript: [],
-        extra_data: {
-          action: "create_new_cluster"
-        }
-      )
-      micro_cluster_ids << micro_cluster.id
-    end
+    # Capture the ids before destroy nullifies the association so the freed
+    # micro clusters can be re-clustered from scratch.
+    micro_cluster_ids = cluster.micro_clusters.pluck(:id)
     cluster.destroy!
     micro_cluster_ids.each { |micro_cluster_id| UpdateMicroCluster.perform_async(micro_cluster_id) }
     head :ok

--- a/app/controllers/admins/micro_clusters_controller.rb
+++ b/app/controllers/admins/micro_clusters_controller.rb
@@ -32,7 +32,6 @@ class Admins::MicroClustersController < Admins::BaseController
   def update
     cluster = MicroCluster.find(params[:id])
     cluster.update!(update_params)
-    UpdateMicroCluster.perform_async(cluster.id)
     if cluster.previous_changes["ignored"] == [true, false]
       # Record the undone "ignore" as rejected so the clusterer is told not to
       # ignore this ink again, without blocking the re-clustering run.
@@ -45,6 +44,8 @@ class Admins::MicroClustersController < Admins::BaseController
         }
       )
     end
+    # Enqueue after the guidance log is persisted so the clusterer run sees it.
+    UpdateMicroCluster.perform_async(cluster.id)
     if request.referrer == ignored_admins_micro_clusters_url
       redirect_to ignored_admins_micro_clusters_url
     else
@@ -56,7 +57,6 @@ class Admins::MicroClustersController < Admins::BaseController
     cluster = MicroCluster.find(params[:id])
     previous_macro_cluster_id = cluster.macro_cluster_id
     cluster.update!(macro_cluster_id: nil)
-    UpdateMicroCluster.perform_async(cluster.id)
     # Record the undone assignment as rejected so the clusterer is told not to
     # reassign to the same macro cluster, without blocking the re-clustering run.
     cluster.agent_logs.create!(
@@ -68,6 +68,8 @@ class Admins::MicroClustersController < Admins::BaseController
         cluster_id: previous_macro_cluster_id
       }
     )
+    # Enqueue after the guidance log is persisted so the clusterer run sees it.
+    UpdateMicroCluster.perform_async(cluster.id)
     head :ok
   end
 

--- a/app/controllers/admins/micro_clusters_controller.rb
+++ b/app/controllers/admins/micro_clusters_controller.rb
@@ -34,9 +34,11 @@ class Admins::MicroClustersController < Admins::BaseController
     cluster.update!(update_params)
     UpdateMicroCluster.perform_async(cluster.id)
     if cluster.previous_changes["ignored"] == [true, false]
+      # Record the undone "ignore" as rejected so the clusterer is told not to
+      # ignore this ink again, without blocking the re-clustering run.
       cluster.agent_logs.create!(
         name: "InkClusterer",
-        state: AgentLog::APPROVED,
+        state: AgentLog::REJECTED,
         transcript: [],
         extra_data: {
           action: "ignore_ink"
@@ -52,16 +54,18 @@ class Admins::MicroClustersController < Admins::BaseController
 
   def unassign
     cluster = MicroCluster.find(params[:id])
+    previous_macro_cluster_id = cluster.macro_cluster_id
     cluster.update!(macro_cluster_id: nil)
     UpdateMicroCluster.perform_async(cluster.id)
-    # Fake entry, to avoid generating the same outcome in the clustering agent again
+    # Record the undone assignment as rejected so the clusterer is told not to
+    # reassign to the same macro cluster, without blocking the re-clustering run.
     cluster.agent_logs.create!(
       name: "InkClusterer",
-      state: AgentLog::APPROVED,
+      state: AgentLog::REJECTED,
       transcript: [],
       extra_data: {
         action: "assign_to_cluster",
-        cluster_id: cluster.id
+        cluster_id: previous_macro_cluster_id
       }
     )
     head :ok

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -388,7 +388,15 @@ RSpec.describe InkClusterer do
         expect(RunInkClustererAgent.jobs.size).to eq(0)
       end
 
-      it "skips when a prior APPROVED log exists and no collected_ink updated after" do
+      it "re-runs when only a prior APPROVED log exists (no in-flight run)" do
+        stub_request(:post, "https://api.openai.com/v1/chat/completions").to_return(
+          status: 200,
+          body: assign_to_cluster_response.to_json,
+          headers: {
+            "Content-Type" => "application/json"
+          }
+        )
+
         AgentLog.create!(
           name: "InkClusterer",
           owner: micro_cluster,
@@ -398,13 +406,16 @@ RSpec.describe InkClusterer do
             "action" => "hand_over_to_human"
           }
         )
-        # Make sure the inks predate the log
+        # Make sure the inks predate the log and are outside the debounce window.
         collected_ink_1.update_columns(updated_at: 1.hour.ago)
         collected_ink_2.update_columns(updated_at: 1.hour.ago)
 
-        expect { subject.perform }.not_to change { AgentLog.count }
-        expect(WebMock).not_to have_requested(:post, "https://api.openai.com/v1/chat/completions")
-        expect(RunInkClustererAgent.jobs.size).to eq(0)
+        subject.perform
+
+        expect(WebMock).to have_requested(
+          :post,
+          "https://api.openai.com/v1/chat/completions"
+        ).at_least_once
       end
 
       it "skips when a WAITING_FOR_APPROVAL log exists" do

--- a/spec/requests/admins/macro_clusters_controller_spec.rb
+++ b/spec/requests/admins/macro_clusters_controller_spec.rb
@@ -354,6 +354,19 @@ describe Admins::MacroClustersController do
           expect(response).to be_successful
         end.to change { MacroCluster.count }.by(-1)
       end
+
+      it "re-clusters the freed micro clusters without blocking the run" do
+        micro_cluster = create(:micro_cluster, macro_cluster:)
+
+        expect do
+          delete "/admins/macro_clusters/#{macro_cluster.id}"
+          expect(response).to be_successful
+        end.to change { UpdateMicroCluster.jobs.count }.by(1)
+
+        expect(UpdateMicroCluster.jobs.last["args"]).to eq([micro_cluster.id])
+        expect(micro_cluster.reload.macro_cluster_id).to be_nil
+        expect(micro_cluster.agent_logs.ink_clusterer.where(state: AgentLog::APPROVED)).to be_empty
+      end
     end
   end
 end

--- a/spec/requests/admins/micro_clusters_controller_spec.rb
+++ b/spec/requests/admins/micro_clusters_controller_spec.rb
@@ -130,6 +130,27 @@ describe Admins::MicroClustersController do
         expect(response).to be_successful
         expect(micro_cluster.reload.macro_cluster).to eq(macro_cluster)
       end
+
+      it "records a rejected ignore log and schedules a run when unignoring" do
+        micro_cluster.update!(ignored: true)
+
+        expect do
+          put "/admins/micro_clusters/#{micro_cluster.id}",
+              params: {
+                "data" => {
+                  "id" => micro_cluster.id.to_s,
+                  "type" => "micro_cluster",
+                  "attributes" => {
+                    "ignored" => false
+                  }
+                }
+              }
+        end.to change { UpdateMicroCluster.jobs.count }.by(1)
+
+        log = micro_cluster.agent_logs.ink_clusterer.last
+        expect(log.state).to eq(AgentLog::REJECTED)
+        expect(log.extra_data["action"]).to eq("ignore_ink")
+      end
     end
   end
 
@@ -153,6 +174,15 @@ describe Admins::MicroClustersController do
       end.to change { UpdateMicroCluster.jobs.count }.from(0).to(1)
       job = UpdateMicroCluster.jobs.first
       expect(job["args"]).to eq([micro_cluster.id])
+    end
+
+    it "records the undone assignment as a rejected log" do
+      delete "/admins/micro_clusters/#{micro_cluster.id}/unassign"
+
+      log = micro_cluster.agent_logs.ink_clusterer.last
+      expect(log.state).to eq(AgentLog::REJECTED)
+      expect(log.extra_data["action"]).to eq("assign_to_cluster")
+      expect(log.extra_data["cluster_id"]).to eq(macro_cluster.id)
     end
   end
 end


### PR DESCRIPTION
## Problem

After recent changes to avoid duplicate ink-clustering LLM runs, runs stopped triggering on several admin actions:

- Deleting a macro cluster (`admins/macro_clusters#destroy`)
- Unignoring an ink (`admins/micro_clusters#update`)
- Unassigning a micro cluster (`admins/micro_clusters#unassign`)
- Sometimes under normal circumstances too

## Root cause

`InkClusterer#already_resolved?` skipped a run when the latest **APPROVED**-or-WAITING `InkClusterer` log post-dated every `CollectedInk` update. Two ways this misfired:

1. **Synthetic admin logs.** Each of the three admin actions created an APPROVED `InkClusterer` log without touching any `CollectedInk`. The guard then saw a fresh approval with no newer ink activity and skipped the run those actions were meant to trigger.
2. **Stale real APPROVED logs.** A micro cluster previously clustered keeps its old APPROVED `assign_to_cluster` log. Deleting its macro sets `macro_cluster_id` to nil but leaves that log, which still post-dates the inks — so the guard skipped.

Separately, commit `ab35f397` narrowed `processed_tries` (the "don't repeat this outcome" prompt guidance) to **rejected** logs only, which silently broke the synthetic APPROVED logs' original purpose of steering the LLM.

## Changes

- **`app/agents/ink_clusterer.rb`** — guard keys only on `WAITING_FOR_APPROVAL` (a genuine in-flight run). The `ignored?` / `macro_cluster_id` early returns already cover resolved states, so duplicate-run protection is preserved.
- **`admins/macro_clusters_controller.rb#destroy`** — drop the synthetic `create_new_cluster` log; freed micro clusters (`dependent: :nullify`) re-cluster from scratch.
- **`admins/micro_clusters_controller.rb#update`** (unignore) — synthetic `ignore_ink` log is now `REJECTED`, so it feeds `processed_tries` ("don't ignore again") instead of blocking the run.
- **`admins/micro_clusters_controller.rb#unassign`** — synthetic `assign_to_cluster` log is now `REJECTED`, and records the real previous macro cluster id instead of the micro cluster's own id (was a bug).

No locking (redlock) added: the reported issue is over-blocking, not double-runs. The pre-existing concurrency race (two jobs reaching the LLM before either writes a log) is separate and unchanged.

## Tests

- Repurposed the guard spec: a prior APPROVED-only log now re-runs.
- Added macro-delete re-cluster spec, and unignore / unassign rejected-log specs.

Full RSpec suite (1525 examples) and linters pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed clustering behavior to allow re-clustering after a previous clustering was approved
  * Improved tracking when admins unignore or unassign micro clusters

* **Improvements**
  * Enhanced macro cluster deletion with automatic re-clustering of freed micro clusters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->