### PR TITLE
Serialize ink clustering with a throttle instead of a capsule

### DIFF
--- a/app/workers/run_ink_clusterer_agent.rb
+++ b/app/workers/run_ink_clusterer_agent.rb
@@ -1,7 +1,9 @@
 class RunInkClustererAgent
   include Sidekiq::Worker
+  include Sidekiq::Throttled::Worker
 
-  sidekiq_options queue: "agents-ink-clusterer"
+  sidekiq_throttle concurrency: { limit: 1 }
+  sidekiq_options queue: "agents"
 
   def perform(klass, *)
     klass.constantize.new(*).perform

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -16,12 +16,3 @@ Sidekiq.configure_server do |config|
     cap.queues = %w[leaderboards]
   end
 end
-
-# Separate capsule for the ink clustering as concurrency, especially during an
-# import leads to weird behaviour
-Sidekiq.configure_server do |config|
-  config.capsule("ink-clusterer") do |cap|
-    cap.concurrency = 1
-    cap.queues = %w[agents-ink-clusterer]
-  end
-end


### PR DESCRIPTION
## What

Replace the dedicated `ink-clusterer` Sidekiq capsule with a `sidekiq-throttled` concurrency limit of 1 on `RunInkClustererAgent`.

- `RunInkClustererAgent` now includes `Sidekiq::Throttled::Worker` with `sidekiq_throttle concurrency: { limit: 1 }` and runs on the normal `agents` queue.
- Removed the `ink-clusterer` capsule (and its dedicated `agents-ink-clusterer` queue) from `config/initializers/sidekiq.rb`.

## Why

The "only one clustering job at a time" guarantee was previously achieved with an extra queue plus a capsule running in isolation, which was awkward to set up and reason about. A per-class concurrency throttle expresses the same intent directly, on the standard `agents` queue.

## Behaviour

- Still serialized: all clustering routes through `RunInkClustererAgent` (`InkClusterer` + `CheckInkClustering::*`), so `limit: 1` keeps it to one job at a time. Excess jobs are requeued with a short cooldown rather than reserving a dedicated thread.
- `RunAgent` is untouched, so `ReviewApprover` and `InkBrandClusterer` keep their concurrency limit of 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated background job processing configuration with improved resource management for ink clustering tasks.
  * Reorganized task queue configuration for better system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->