### PR TITLE
Silence RubyLLM deprecation warnings

### DIFF
--- a/app/agents/concerns/ruby_llm_agent.rb
+++ b/app/agents/concerns/ruby_llm_agent.rb
@@ -117,8 +117,8 @@ module RubyLlmAgent
   # interaction so the agent log reflects progress incrementally.
   def register_callbacks(c)
     @tool_call_count = 0
-    c.on_end_message { |message| save_transcript_and_usage(message) }
-    c.on_tool_call do
+    c.after_message { |message| save_transcript_and_usage(message) }
+    c.before_tool_call do
       @tool_call_count += 1
       raise "Max tool calls (#{MAX_TOOL_CALLS}) exceeded" if @tool_call_count > MAX_TOOL_CALLS
       save_transcript

--- a/config/initializers/ruby_llm.rb
+++ b/config/initializers/ruby_llm.rb
@@ -1,3 +1,10 @@
+RubyLLM.configure do |config|
+  # Opt into the new acts_as API. The app uses RubyLLM::Chat directly and no
+  # acts_as_* ActiveRecord models, so this only silences the legacy deprecation
+  # warning without changing behavior. Required before RubyLLM 2.0.
+  config.use_new_acts_as = true
+end
+
 RubyLLM::Tool.prepend(
   Module.new do
     def name


### PR DESCRIPTION
## Summary

The test suite emitted 421 RubyLLM deprecation warnings (all from RubyLLM 1.16.0 preparing for 2.0). This clears them all.

- **`app/agents/concerns/ruby_llm_agent.rb`** — rename deprecated chat callbacks to their 1.7+ equivalents:
  - `on_end_message` → `after_message`
  - `on_tool_call` → `before_tool_call`
  
  The gem maps the legacy names to these exact callbacks internally (same firing timing), so this is behavior-preserving.

- **`config/initializers/ruby_llm.rb`** — set `config.use_new_acts_as = true` to silence the boot-time legacy `acts_as` deprecation. The app uses `RubyLLM::Chat` directly with no `acts_as_*` ActiveRecord models, so the new module changes nothing the app touches.

After: `1525 examples, 0 failures`, zero warnings.