### PR TITLE
Add Claude Code PR reviewer GitHub Action

### DIFF
--- a/.github/actions/claude-review/action.yml
+++ b/.github/actions/claude-review/action.yml
@@ -1,0 +1,223 @@
+name: Claude Code Review
+description: >
+  Run Claude Code as a PR reviewer using a prompt assembled from
+  prompts/*.md. Generic guidance lives in prompts/base.md and
+  prompts/review-checks.md; the fixed Ruby/Rails and React toolset
+  fragments under prompts/tools/ are always appended.
+
+inputs:
+  claude_code_oauth_token:
+    description: >
+      Claude Code OAuth token. EMPTY on fork PRs (secrets are not
+      exposed to fork-triggered workflows); the guard step skips the
+      review cleanly in that case.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Decide whether to skip review
+      id: guard
+      shell: bash
+      env:
+        OAUTH: ${{ inputs.claude_code_oauth_token }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      run: |
+        set -euo pipefail
+        reason=""
+        if [ -z "$OAUTH" ]; then
+          # No token: either a fork PR (secrets withheld by GitHub) or
+          # the CLAUDE_CODE_OAUTH_TOKEN secret is unset. Skip cleanly —
+          # there is nothing to authenticate with, and this must not
+          # fail-red on every external-contributor PR.
+          reason="no Claude token (fork PR or unconfigured secret)"
+        elif [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+          reason="PR authored by dependabot[bot]"
+        fi
+        if [ -n "$reason" ]; then
+          echo "Skipping review: $reason"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Pre-fetch PR context
+      if: steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        GH_TOKEN: ${{ github.token }}
+        DEST: ${{ github.workspace }}/.pr-context
+      run: |
+        set -euo pipefail
+        mkdir -p "$DEST"
+        gh pr view "$PR_NUMBER" \
+          --repo "$REPO" \
+          --json title,body,number,headRefOid,baseRefName,headRefName,additions,deletions,changedFiles,author,isDraft,labels,files \
+          > "$DEST/meta.json"
+        # --paginate writes each page as its own JSON array,
+        # which is not valid JSON. Slurp pages and `add` to
+        # merge them into one flat array.
+        gh api "repos/$REPO/pulls/$PR_NUMBER/comments" --paginate \
+          | jq -s 'add // []' > "$DEST/inline-comments.json"
+        gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+          | jq -s 'add // []' > "$DEST/issue-comments.json"
+        # checkout@v6 with fetch-depth: 0 already fetched all
+        # history; the explicit fetch is a safety net for repos
+        # configured with a different depth.
+        git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true
+        # Three-dot diff: head vs. merge-base(base, head). Matches
+        # GitHub's "Files changed" tab. Two-dot would fold in any
+        # base-branch commits made after the PR branched off,
+        # producing false positives on code the PR didn't touch.
+        git diff "$BASE_SHA...$HEAD_SHA" > "$DEST/diff.patch"
+        git diff --stat "$BASE_SHA...$HEAD_SHA" > "$DEST/diff-stat.txt"
+        # Filtered code-only diff: excludes generated/lockfile noise
+        # that bloats every subagent's cache_read without adding
+        # review signal. Subagents default to this; full diff stays
+        # at diff.patch for the rare case (e.g. correctness on a
+        # schema change) where the excluded paths matter.
+        #
+        # The `glob` magic is mandatory for `**/...` patterns. In
+        # default pathspec magic, `**` is two `*`s and matches at
+        # least one path component, so `:(exclude)**/yarn.lock`
+        # silently fails on a root-level `yarn.lock`. `:(exclude,glob)`
+        # switches to gitignore-style globbing where `**/` collapses
+        # to "any depth, including zero".
+        git diff "$BASE_SHA...$HEAD_SHA" -- . \
+          ':(exclude,glob)**/*.lock' \
+          ':(exclude,glob)**/yarn.lock' \
+          ':(exclude,glob)**/package-lock.json' \
+          ':(exclude,glob)**/db/structure.sql' \
+          ':(exclude,glob)**/db/schema.rb' \
+          ':(exclude,glob)**/app/assets/builds/**' \
+          ':(exclude,glob)**/*.snap' \
+          ':(exclude,glob)**/__snapshots__/**' \
+          ':(exclude,glob)**/*.min.js' \
+          ':(exclude,glob)**/*.min.css' \
+          > "$DEST/diff-code.patch"
+        printf '%s' "$BASE_SHA" > "$DEST/base-sha"
+        printf '%s' "$HEAD_SHA" > "$DEST/head-sha"
+
+    - name: Assemble prompt
+      id: assemble
+      if: steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+        {
+          echo "prompt<<PROMPT_EOF"
+          # Inline REVIEW.md (if present) at the top so subagents
+          # do not each re-read it from disk on every run. The
+          # inlined copy is canonical; the on-disk file is not read
+          # by the reviewer.
+          if [ -s "$GITHUB_WORKSPACE/REVIEW.md" ]; then
+            echo "# Repository review rules (inlined from REVIEW.md)"
+            echo
+            echo "These rules are the highest-priority review guidance and override the default checks below. Apply them in every subagent and in the verification pass. Do not Read REVIEW.md from disk — this inlined copy is canonical."
+            echo
+            cat "$GITHUB_WORKSPACE/REVIEW.md"
+            echo
+            echo "---"
+            echo
+          fi
+          envsubst '$PR_NUMBER $REPO $BASE_SHA $HEAD_SHA' < "$ACTION_PATH/prompts/base.md"
+          echo
+          envsubst '$PR_NUMBER $REPO $BASE_SHA $HEAD_SHA' < "$ACTION_PATH/prompts/review-checks.md"
+          echo
+          envsubst '$PR_NUMBER $REPO $BASE_SHA $HEAD_SHA' < "$ACTION_PATH/prompts/blocked-tools-comment.md"
+          # Fixed toolset for this repo: Ruby/Rails + React frontend.
+          echo
+          envsubst '$PR_NUMBER $REPO $BASE_SHA $HEAD_SHA' < "$ACTION_PATH/prompts/tools/ruby.md"
+          echo
+          envsubst '$PR_NUMBER $REPO $BASE_SHA $HEAD_SHA' < "$ACTION_PATH/prompts/tools/frontend.md"
+          echo "PROMPT_EOF"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Stage review helper
+      if: steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        DEST: ${{ github.workspace }}/.claude-review-post
+      run: |
+        set -euo pipefail
+        cp "$ACTION_PATH/scripts/post-review.sh" "$DEST"
+        chmod +x "$DEST"
+
+    - uses: anthropics/claude-code-action@806af32823ef69c8ef357086c573a902af641307 # v1
+      id: claude
+      if: steps.guard.outputs.skip != 'true'
+      with:
+        claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
+        github_token: ${{ github.token }}
+        prompt: ${{ steps.assemble.outputs.prompt }}
+        claude_args: |
+          --model opus
+          --allowedTools "Bash(gh:*),Bash(git fetch:*),Bash(git log:*),Bash(git show:*),Bash(git blame:*),Bash(git diff:*),Bash(git ls-files:*),Bash(git ls-tree:*),Bash(git cat-file:*),Bash(git status),Bash(grep:*),Bash(head:*),Bash(tail:*),Bash(ls:*),Bash(cat:*),Bash(wc:*),Bash(./.claude-review-post:*),Task,Agent"
+          --append-system-prompt "Repo-specific review rules are inlined at the top of the review prompt under the 'Repository review rules' section. Apply them in every subagent and validation pass — they override default rules. Findings that violate the inlined skip rules must not be reported. Do not Read REVIEW.md from disk; the inlined copy is canonical."
+
+    - name: Remove staged review helper
+      if: always() && steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        DEST: ${{ github.workspace }}/.claude-review-post
+      run: rm -f "$DEST"
+
+    - name: Remove pre-fetched PR context
+      if: always() && steps.guard.outputs.skip != 'true'
+      shell: bash
+      env:
+        DEST: ${{ github.workspace }}/.pr-context
+      run: rm -rf "$DEST"
+
+    - name: Upload Claude execution log
+      if: always() && steps.guard.outputs.skip != 'true' && steps.claude.outputs.execution_file != ''
+      uses: actions/upload-artifact@v4
+      with:
+        name: claude-execution-log
+        path: ${{ steps.claude.outputs.execution_file }}
+        if-no-files-found: ignore
+        retention-days: 30
+
+    - name: Render reviewer transcript to step summary
+      if: always() && steps.guard.outputs.skip != 'true' && steps.claude.outputs.execution_file != ''
+      shell: bash
+      env:
+        EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+      run: |
+        set -euo pipefail
+        {
+          echo "## Claude reviewer transcript"
+          echo
+          jq -r '
+            (.[] | select(.type == "result")) as $r
+            | "**Duration:** \(($r.duration_ms / 1000) | floor)s  ·  **Turns:** \($r.num_turns)  ·  **Cost:** $\($r.total_cost_usd)  ·  **Error:** \($r.is_error)"
+          ' "$EXECUTION_FILE"
+          echo
+          echo "### Turns"
+          echo
+          jq -r '
+            .[]
+            | select(.type == "assistant")
+            | .message.content[]?
+            | if .type == "text" then
+                "**assistant:**\n\n" + .text + "\n"
+              elif .type == "tool_use" then
+                "**tool_use** `" + .name + "`:\n\n```json\n" + (.input | tojson) + "\n```\n"
+              else empty end
+          ' "$EXECUTION_FILE"
+          echo
+          echo "### Final result"
+          echo
+          jq -r '(.[] | select(.type == "result")).result' "$EXECUTION_FILE"
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/claude-review/prompts/base.md
+++ b/.github/actions/claude-review/prompts/base.md
@@ -1,0 +1,370 @@
+Repo-specific review rules are inlined above under the
+"Repository review rules" section. Treat them as the highest-
+priority review guidance — they override the default review
+checks and apply to every finding. Do not Read `REVIEW.md`
+from disk; the inlined copy is canonical.
+
+## Process — follow this exactly
+
+The main thread has exactly three phases. Do not interleave
+them. Source-file reads (`Read` on `app/...`, any path in the
+diff) and `git show <sha>:<path>` are reserved for **Phase 3**
+only — never in Phase 1 or 2.
+
+### Phase 1 — bootstrap (exactly 1 tool call, then stop)
+
+Make exactly this one `Read` call and nothing else:
+
+1. `Read` `.pr-context/meta.json`
+
+Then **stop and immediately produce the Phase 2 fan-out
+message**. Do not read `diff.patch` or `diff-code.patch`,
+do not read `diff-stat.txt`, do not read `REVIEW.md` (it is already
+inlined above), do not read any source file, do not run
+`ls`, `find`, `git ls-files`, or any other reconnaissance
+command, do not emit a "now I will dispatch the subagents"
+preamble. The subagents will gather what they need.
+`meta.json.additions` and `meta.json.deletions` are read
+here **solely** so you can apply the `consistency` gate in
+Phase 2 by mental arithmetic — not as an invitation to
+explore the diff yourself.
+
+### Phase 2 — fan-out (exactly 1 message)
+
+**Your VERY NEXT message MUST contain ONLY `Agent`
+tool_use blocks. Nothing else.** No `Read`, no `Bash`, no
+text reasoning between them, no preamble, no "let me think
+about which checks apply" narration. The fan-out message
+comes immediately after Phase 1 — do not insert any other
+tool calls between Phase 1 reads and the fan-out message.
+
+The block count is decided by **mental arithmetic only** on
+the numbers already on disk from Phase 1 (`meta.json`
+fields `.additions`, `.deletions`). Do not Read or Bash
+anything new to make this decision. Do not "double-check"
+by reading `diff.patch` or `diff-code.patch`:
+
+- **Default: 7 `Agent` blocks** — one per check below
+  (`test-coverage`, `pr-meta`, `consistency`, `clean-code`,
+  `correctness`, `simplification`, `efficiency`).
+- **Drop the `consistency` block (→ 6 blocks)** iff
+  `additions + deletions ≤ 100`. LOC only — file count is
+  not part of the gate. If the LOC value is unknown,
+  ambiguous, or borderline (within 10 of the threshold),
+  dispatch `consistency` — erring toward an extra subagent
+  is cheaper than a missed-coverage regression.
+
+No other checks are gated. Use `subagent_type:
+"general-purpose"` for each block. Run them all in a
+single message so the API parallelises.
+
+**Per-check model tier.** Each block MUST set an explicit
+`model` parameter — the tier is chosen to match the task
+shape, not inherited from the main thread. The `Agent`
+tool's `model` enum only accepts the tier shorthand
+(`haiku` / `sonnet` / `opus`), which resolves at runtime
+to the latest pinned ID for that tier. Do NOT pass full
+`claude-*-N` model IDs here — they will fail validation
+and force a costly retry. Use exactly these values:
+
+- `haiku` — `pr-meta`. Reads only `meta.json` and
+  `diff-stat.txt`; pure text classification, no code
+  reasoning.
+- `sonnet` — `test-coverage`, `simplification`,
+  `efficiency`, `clean-code`. File-to-test mapping, local
+  mechanical pattern recognition, SOLID/readability
+  critique against the rubric.
+- `opus` — `consistency`, `correctness`. Cross-file
+  judgment, novel-pattern-vs-prior-art sweeps, subtle bug
+  hunting, contract reasoning.
+
+Do not omit the `model` parameter.
+
+Pattern — default (7 blocks, large diff):
+
+    <single message>
+      Agent(check=test-coverage,   model=sonnet, ...)
+      Agent(check=pr-meta,         model=haiku,  ...)
+      Agent(check=consistency,     model=opus,   ...)
+      Agent(check=clean-code,      model=sonnet, ...)
+      Agent(check=correctness,     model=opus,   ...)
+      Agent(check=simplification,  model=sonnet, ...)
+      Agent(check=efficiency,      model=sonnet, ...)
+    </single message>
+
+Pattern — gated small diff (6 blocks, `consistency` dropped):
+
+    <single message>
+      Agent(check=test-coverage,   model=sonnet, ...)
+      Agent(check=pr-meta,         model=haiku,  ...)
+      Agent(check=clean-code,      model=sonnet, ...)
+      Agent(check=correctness,     model=opus,   ...)
+      Agent(check=simplification,  model=sonnet, ...)
+      Agent(check=efficiency,      model=sonnet, ...)
+    </single message>
+
+These two patterns are the **only** valid fan-out shapes.
+A message with 0, 1, 2, 3, 4, 5 blocks (other than the
+gated 6), with anything-but-`Agent` between blocks, or with
+a `model` value that does not match the "Per-check model
+tier" table at the start of this Phase 2 section is a
+regression of the fan-out and must not happen.
+
+If you feel an urge to `Read` a file or run a `Bash` command
+before dispatching, **resist it** — that urge is the failure
+mode this prompt exists to prevent. The subagents `Read` their
+own files; pre-reading on the main thread is wasted serial
+work that drops the whole reason we fan out. Each subagent
+runs in its own turn with its own context window — it has
+plenty of room to fetch the diff, blame, related files,
+prior patterns, etc.
+
+### Phase 3 — consolidate and verify (after subagents return)
+
+Only after every subagent has returned do you:
+
+1. Build the suppression set from `.pr-context/inline-comments.json`
+   and `.pr-context/issue-comments.json` (rules below).
+2. Run the dedupe + verification pass below. This is the
+   first and only point where you may `Read` a source file
+   on the main thread — and only to verify a specific
+   subagent finding's cited `file:line`. Do not open files
+   that no subagent flagged. Do not re-do the review.
+3. Post comments per the rules below, or stay silent.
+
+## Pre-fetched PR context
+
+The workflow has already gathered the data you'd otherwise
+fetch via `gh` and `git diff`. **Read these files** instead of
+re-running those commands:
+
+- `.pr-context/meta.json` — PR title, body, head/base SHAs,
+  additions/deletions, changed-file count, author, labels.
+- `.pr-context/diff-code.patch` — **default diff for every
+  subagent.** Same three-dot diff as `diff.patch` with
+  generated/lockfile paths excluded (`*.lock` covers
+  `yarn.lock`, `Gemfile.lock`, etc.; plus `package-lock.json`,
+  `db/structure.sql`, `db/schema.rb`, `app/assets/builds/`,
+  `*.snap`, `__snapshots__/`, `*.min.js`, `*.min.css`). Read
+  this in preference to `diff.patch` — the excluded paths
+  add no review signal and inflate cache_read on every
+  subagent.
+- `.pr-context/diff.patch` — unfiltered diff. Only read
+  when a check genuinely needs the excluded paths
+  (e.g. `correctness` reviewing a `db/structure.sql` change,
+  `consistency` cross-referencing a lockfile bump). Default
+  to `diff-code.patch`.
+- `.pr-context/diff-stat.txt` — diff stat (unfiltered).
+- `.pr-context/inline-comments.json` — prior inline review
+  comments (from `repos/<repo>/pulls/<pr>/comments`), with
+  `path`, `line`, `body`, `user.login`, `author_association`,
+  `commit_id`, `in_reply_to_id`.
+- `.pr-context/issue-comments.json` — prior PR-level (issue)
+  comments, with `user.login`, `author_association`, `body`.
+- `.pr-context/base-sha`, `.pr-context/head-sha` — the SHAs
+  the diff was computed against ($BASE_SHA, $HEAD_SHA also
+  inlined into this prompt).
+
+Repo: `$REPO` · Base SHA: `$BASE_SHA` · Head SHA: `$HEAD_SHA`
+
+Do NOT re-run `gh pr view`, `gh pr view --comments`,
+`gh api .../comments`, or `git diff $BASE_SHA...$HEAD_SHA` to
+re-fetch this data — it's on disk. Extra `git`/`gh` calls are
+only needed when a subagent needs to inspect a specific
+revision or file beyond what's in the diff.
+
+`diff-code.patch`, `diff.patch`, and `diff-stat.txt` use the
+three-dot form (`$BASE_SHA...$HEAD_SHA`, head vs. merge-base)
+to match GitHub's "Files changed" tab. If you re-run
+`git diff` yourself for any reason, use three dots, not two.
+
+## Suppression set
+
+Build the suppression set from `.pr-context/inline-comments.json`
+and `.pr-context/issue-comments.json`:
+
+- Any inline review comment posted by `claude[bot]` or
+  `claude` whose file path + line + root cause matches a new
+  finding → drop the new finding unless the underlying code
+  at that location has changed since the original comment's
+  `commit_id`.
+- Any inline comment that has a reply from a repo member
+  (`author_association` MEMBER / OWNER / COLLABORATOR) is
+  "addressed": the author has accepted, rejected, or
+  discussed it. Do not re-post the same finding regardless
+  of whether the code changed. The human reply is the source
+  of truth — the reviewer runs on every push to the PR, so
+  treat any prior member response as the final word on that
+  finding.
+- Any "Reviewer tools blocked during this run" comment
+  already on the PR → if the set of blocked tools this run
+  is a subset of (or equal to) the already-posted one, skip
+  the new tools-blocked comment.
+
+## Finding shape
+
+Each finding returned by a subagent must include:
+
+- `file`, `line`, `summary` (one sentence)
+- `severity`: one of `important` (🔴 — bug that should be
+  fixed before merge), `nit` (🟡 — minor, worth fixing but
+  not blocking), or `pre-existing` (🟣 — bug present in the
+  code but not introduced by this PR)
+- `evidence`: a `file:line` citation in the source or a
+  concrete diff hunk that proves the claim, not an inference
+  from naming.
+
+## Verification pass
+
+This is Phase 3 (see Process section). It runs only after
+all subagents have returned and never before. Within this
+phase, source-file `Read`s and `git show`s are allowed but
+strictly scoped to verifying a subagent's cited `file:line`
+— do NOT use this phase to re-do the review, audit files no
+subagent flagged, or "double-check" by reading the whole
+diff yourself.
+
+Steps:
+
+1. Deduplicate findings that point at the same file + line
+   - root cause (subagents may overlap on simplification vs.
+     consistency, etc.). Keep the highest-severity wording.
+2. For each remaining finding, re-read **only** the cited
+   `file:line` with a **±50-line** window via the `Read`
+   tool's `offset`/`limit` (e.g. cited line 200 → read
+   `offset: 150, limit: 100`). Do not re-read the whole
+   file, do not open files no subagent flagged, and do not
+   re-Read the same window twice in this pass — if you
+   already verified a finding at `path:N`, trust your
+   earlier read. Confirm the claim holds against actual
+   behavior. Drop findings whose evidence does not check
+   out — false positives cost the author a round trip and
+   erode trust in the reviewer. Log dropped findings in
+   the step summary with the reason.
+3. Apply the skip rules from the inlined "Repository review
+   rules" section (at the top of this prompt) and the
+   suppression set. Findings dropped by suppression should
+   be listed in the step summary (so we can audit the
+   filter) but not posted to the PR.
+
+When posting inline comments, prefix the body with the
+severity marker: `🔴 Important:`, `🟡 Nit:`, or
+`🟣 Pre-existing:`. Severity must match Anthropic's
+definitions above so PR authors get the same calibration as
+the `/code-review` skill / Code Review managed service.
+
+If, after dedupe + verification + suppression + the inlined
+Repository-review-rules skip rules, there are zero findings
+to report, post NOTHING
+to the PR. Do not post
+a top-level "no findings", "all clear", "automated review —
+no blocking findings", or any other status/summary comment.
+Silence means success. The step summary and execution log
+already record what ran; the PR stays clean. This rule does
+not affect the separate blocked-tools comment described
+below, which has its own posting condition.
+
+## Shell command constraints
+
+**The allowlist matches single bare commands, not shell
+constructs.** This is the #1 source of wasted retries in past
+runs — internalize it before issuing any Bash call.
+
+- Run ONE command per `Bash` call. **No** pipes (`|`),
+  command chaining (`;`, `&&`, `||`), output redirection
+  (`>`, `>>`, `<`), command substitution (`$(...)`,
+  backticks), or `cd`. If you need a piped pipeline, split
+  it across multiple Bash calls and process the
+  intermediate output yourself.
+- **No `git -C <path>` and no `git -c <key>=<value>`.** The
+  allowlist is prefix-matched, so `git -C ...` does not
+  match `Bash(git diff:*)` and is rejected. `git -c` is
+  forbidden because it can override `core.sshCommand` to
+  exec arbitrary shell. The workflow checkout is your cwd
+  — run bare git commands directly (`git diff <range>`).
+- Allowlisted single-purpose filters are available so you
+  don't need to pipe: `grep`, `head`, `tail`, `ls`, `cat`.
+  Use them in their own Bash call against the pre-fetched
+  `.pr-context/*` files or against a path on disk.
+  Example: instead of `git diff <range> | grep <file>`,
+  run `grep '<file>' .pr-context/diff-code.patch` in its own
+  call, or use `git diff --name-only <range>` and scan the
+  output in the next turn. For JSON parsing, use
+  `gh api --jq '...'` (allowlisted via `gh:*`) on the gh
+  side, or use the `Read` tool on `.pr-context/*.json` and
+  process the structure in your own context.
+- `awk`, `sed`, `find`, `xargs`, `jq` are NOT allowlisted.
+  Each has a primitive that defeats the "single read-only
+  filter" property: `awk`/`sed` exec arbitrary shell
+  (`system()`, `-e`, `-i`), `find`/`xargs` exec arbitrary
+  commands (`-exec`, by-design), and `jq -n env` dumps
+  every environment variable — including the Claude auth
+  token and `GITHUB_TOKEN` — as JSON in a single bare
+  command that passes prefix-match allowlisting. Use the
+  allowlisted filters above instead.
+- Do NOT use the `Write` or `Edit` tools and do not stage
+  JSON or other payloads to disk to feed `gh api --input`.
+  The `Write` tool is intentionally not allowlisted: it has
+  no path-scoping syntax, so granting it would permit writes
+  anywhere the runner can reach (`$GITHUB_ENV`,
+  `$GITHUB_OUTPUT`, working tree, dotfiles) and weaken the
+  blast radius of any PR-content prompt injection. Do not
+  log `Write` rejections in the blocked-tools list — this
+  is expected and not a gap to be filled.
+- For a multi-comment inline review, use the staged helper
+  `./.claude-review-post`, which is allowlisted and built for
+  this purpose. It takes structured args, JSON-encodes them
+  via `jq`, and POSTs a single `repos/<repo>/pulls/<pr>/reviews`
+  request internally — no Write, no stdin pipe, no shell
+  constructs visible to the allowlist. Invocation:
+
+      ./.claude-review-post <repo> <pr> <commit_sha> <event> \
+        <path> <line> <body> [<path> <line> <body>] ...
+
+  where `<event>` is one of `COMMENT`, `APPROVE`, or
+  `REQUEST_CHANGES`, and triples of `<path> <line> <body>`
+  repeat for each inline comment. The repo slug is `$REPO`
+  and the PR head SHA is `$HEAD_SHA` (both inlined above);
+  the head SHA is also on disk at `.pr-context/head-sha`.
+  Do not run `git remote get-url`, `gh repo view`, or
+  `gh pr view ... headRefOid` to re-fetch them.
+  Comment bodies are passed as positional args, so any
+  content from the PR (diff snippets, etc.) is safe to
+  include verbatim — `jq --args` JSON-encodes it, nothing
+  is interpreted as shell. The helper is the preferred path
+  for any review with more than one inline comment.
+
+- For single inline comments or simple top-level comments,
+  `gh api -f key=value` flags and `gh pr comment --body '...'`
+  arguments are still fine. Do not use `gh api -F key=@-`
+  or `-F key=@file` — `@-` reads stdin (needs a pipe or
+  `<` redirect, both banned above) and `@file` would require
+  staging via `Write`.
+- When the body contains backticks (e.g. the verbatim
+  blocked-tools-comment template, which uses Markdown code
+  spans), wrap the `--body` value in **single quotes**, not
+  double quotes. Backticks inside double-quoted shell
+  arguments are command substitution and the allowlist
+  rejects them; inside single quotes they are literal and
+  pass through unchanged. If the body itself contains a
+  single quote, splice it with `'\''` (close, escaped quote,
+  reopen).
+  Do not strip backticks, swap them for unicode look-alikes,
+  or indent-escape them; those mangle the rendered Markdown
+  and the blocked-tools-comment template must post verbatim.
+
+While the review runs, keep a list of every tool call that
+was rejected with a "requires approval" / "permission denied"
+/ "command not allowed" response, recording the tool name
+and the exact command or arguments that were blocked.
+Before recording a rejection, first retry the same intent
+as a single bare command per the constraints above; only
+log it as blocked if the simplified single-command form
+was also rejected.
+
+After the review completes (regardless of whether findings
+were posted), if that list is non-empty, post ONE additional
+PR comment via `gh pr comment $PR_NUMBER --body ...` using
+the exact body template in the "Blocked-tools PR comment"
+section below. If the list is empty, do not post this
+comment.

--- a/.github/actions/claude-review/prompts/blocked-tools-comment.md
+++ b/.github/actions/claude-review/prompts/blocked-tools-comment.md
@@ -1,0 +1,28 @@
+# Blocked-tools PR comment
+
+Use this body verbatim when posting the blocked-tools comment,
+substituting the actual `<tool name>` / `<blocked command/args>`
+entries:
+
+> **Reviewer tools blocked during this run**
+>
+> The reviewer attempted these tools but the CI permission
+> gate rejected them, so it had to work around the gap:
+>
+> - `<tool name>`: `<blocked command/args>`
+> - ...
+>
+> If a maintainer's security review of these calls says they're
+> safe, add them to the `--allowedTools` list in
+> `.github/actions/claude-review/action.yml` so future reviews
+> don't have to improvise.
+>
+> ⚠️ Do **not** blanket-allow `Bash` or use
+> `--dangerously-skip-permissions`. The reviewer reads PR
+> content (diff, commit messages, comments) as input, so a
+> malicious PR can prompt-inject the reviewer into running
+> shell. With broad permissions that means the Claude auth
+> token, `GITHUB_TOKEN`, and anything else in the job env can
+> be exfiltrated via `curl` / `wget` / etc. Allowlist
+> specific tools and narrow command patterns (e.g.
+> `Bash(gh pr view:*)`) instead.

--- a/.github/actions/claude-review/prompts/review-checks.md
+++ b/.github/actions/claude-review/prompts/review-checks.md
@@ -1,0 +1,141 @@
+# Required review checks
+
+Required review checks. Each check is independent — run them in
+parallel as subagents per the dispatch instructions in
+`base.md`. The inlined "Repository review rules" section at
+the top of this prompt may add to, replace, or remove items
+from this list; if that section defines its own check list,
+follow it instead. Otherwise run every applicable check
+below.
+
+Some checks are **gated** — they self-skip when the diff is
+too small or otherwise not a candidate. The main thread
+reads `.pr-context/meta.json` in Phase 1 specifically so it
+can apply these gates before fan-out. A gated-out check is
+**not dispatched at all** in Phase 2 (no Agent block, no
+wasted turn). Each gated check states its skip condition in
+its own definition below.
+
+1. test-coverage — Verify every behavioral change in the diff
+   is covered by a new or updated test. Walk each non-test
+   file in the diff and check that the corresponding test
+   file (per the repo's test layout conventions — Ruby specs
+   under `spec/` mirroring `app/`, Jest specs as `*.spec.js(x)`
+   under `spec/javascript/` mirroring `app/javascript/src/`)
+   exercises the new code path. Pure refactors with no
+   behavior change are exempt. Report each uncovered change as
+   one finding pinned to the production file:line that lacks
+   coverage.
+
+2. pr-meta — Combined PR-description + PR-size check. Read
+   `.pr-context/meta.json` (`.title`, `.body`, `.additions`,
+   `.deletions`, `.changedFiles`) and `.pr-context/diff-stat.txt`.
+   Do NOT Read any source file in this check — meta.json and
+   diff-stat are sufficient. Run two sub-checks and report at
+   most one finding per sub-check (so 0–2 findings total,
+   all PR-level, none pinned to a file):
+
+   (a) Description quality. Verify the body explains WHY
+   the change is being made, not just what changed. If
+   the description is missing or only restates the diff,
+   surface one PR-level finding asking for the
+   motivation/context. This is an open-source project —
+   do NOT require a linked issue or ticket; a `#123`
+   GitHub issue reference is welcome where one plausibly
+   exists, but its absence is not a finding. Trivial
+   chores (typo fixes, dependency bumps, internal
+   tooling) may have a terse description — use judgement.
+   Do not re-run `gh pr view`; the data is in `meta.json`.
+
+   (b) PR size and seams. If the diff is large or spans
+   multiple unrelated concerns, surface one PR-level
+   finding proposing a split along logical seams (e.g.
+   refactor vs. feature, independent modules, prep
+   commits vs. behavior change, test scaffolding vs.
+   production code) — name the files/commits in each
+   smaller PR and the seam. Cohesive small changes and
+   pure mechanical sweeps (renames, formatting) are
+   exempt — use judgement.
+
+3. consistency — **Gated: skip when `additions + deletions ≤
+100`.** Small diffs rarely introduce genuinely novel
+   patterns and consistency findings on them are mostly
+   noise. File count is irrelevant — a 50-LOC change spread
+   across 10 files is still too small to warrant a consistency
+   sweep. When the gate passes, reject novel
+   patterns where an existing pattern in the repo already
+   solves the same problem. For each new abstraction, helper,
+   service/operation object, query style, error-handling
+   shape, React hook, or naming choice introduced by the diff,
+   grep the codebase for prior art and flag any divergence.
+   Report each as a finding on the new code with a pointer to
+   the existing pattern (file:line) to follow instead.
+
+4. clean-code — Enforce SOLID principles and top-down
+   readability. Each new or modified function/method should
+   read as a short sequence of well-named steps at one level
+   of abstraction, with complexity hidden behind those names.
+   Flag: functions doing more than one thing (SRP), modules
+   that can't be extended without modification (OCP), leaky
+   abstractions or wrong-level mixing (LSP/ISP), hard-wired
+   dependencies that should be injected (DIP), and any top-
+   level function where a reader has to hold low-level detail
+   in their head to follow the flow. Report each as a finding
+   pinned to the offending file:line with a concrete
+   refactor: which steps to extract, what to name them, or
+   which dependency to invert. Note: this repo's CLAUDE.md
+   states existing code quality varies — judge new/changed
+   code on its own merits, do not excuse it because nearby
+   legacy code is worse.
+
+5. correctness — Hunt for bugs that would break production.
+   Walk every changed line and ask: does this match the
+   author's intent and the surrounding contract? Flag nil /
+   null / undefined access on paths that weren't there before,
+   off-by-one and boundary errors, inverted conditions,
+   missing or wrong error handling (the repo convention is to
+   rescue specific errors only, never bare `rescue`), race
+   conditions and concurrent-mutation hazards, missing
+   transaction or lock scope, N+1-induced incorrectness,
+   regressions against the pre-PR behavior at the same call
+   sites, contract violations (callers expect X, the new code
+   returns Y), broken invariants on data the rest of the
+   system already relies on, and security issues (SQL/HTML
+   injection, unscoped queries, mass-assignment, secrets in
+   logs, auth bypass). Report each as one finding pinned to
+   the file:line with a short description of the failure mode
+   and a minimal reproducer or counter-example when possible.
+   Mark severity `important` for behavior-breaking bugs, `nit`
+   for narrow edge cases that are unlikely to fire, and
+   `pre-existing` for bugs the diff did not introduce but
+   exposed.
+
+6. simplification — Flag unnecessary complexity the diff
+   adds. Look for: redundant or derivable state (values
+   recomputed or stored that could be derived from existing
+   ones), copy-paste with slight variation (extract a
+   parameterized helper), deep nesting that could be
+   flattened with early returns or guard clauses, dead code
+   left behind by the change (unused vars, unreachable
+   branches, commented-out blocks), redundant conditionals,
+   and abstractions introduced for a single caller. For each
+   finding, name the simpler form that does the same job and
+   pin it to file:line. This check is distinct from
+   clean-code (SOLID): it targets local mechanical
+   simplifications, not architectural shape.
+
+7. efficiency — Flag wasted work the diff introduces.
+   Look for: redundant computation inside loops (hoist
+   invariants), repeated I/O that could be batched or
+   cached, N+1 query patterns (a recurring Rails hazard —
+   check for missing `includes`/`preload`), independent
+   operations run sequentially that could run in parallel,
+   blocking work added to request/hot paths that belongs in
+   a background job (Sidekiq), eager loading of data the
+   caller does not use, and unnecessary re-renders in React
+   (missing memoization on hot paths, new object/array
+   literals passed as props each render). For each finding,
+   name the cheaper alternative and pin it to file:line.
+   Do not flag micro-optimizations on cold paths — the bar
+   is "wasted work the diff introduces", not theoretical
+   speedups.

--- a/.github/actions/claude-review/prompts/tools/frontend.md
+++ b/.github/actions/claude-review/prompts/tools/frontend.md
@@ -1,0 +1,31 @@
+# Frontend toolset guidance
+
+React components and hooks live in `app/javascript/src/`,
+bundled by Webpack into `app/assets/builds/` (generated — never
+review the builds output; it is excluded from `diff-code.patch`).
+Tests are Jest, named `*.spec.js(x)`, under `spec/javascript/`
+mirroring the source tree. No Node toolchain runs in this
+workflow — review from source and the diff, do not try to run
+`yarn`, `jest`, `eslint`, or `prettier`.
+
+## Conventions to enforce (from CLAUDE.md)
+
+- **PascalCase** for components, **camelCase** for
+  variables/functions.
+- **React Hooks rules are enforced** (eslint-plugin-react-hooks).
+  Flag: hooks called conditionally or in loops, missing/incorrect
+  dependency arrays on `useEffect`/`useMemo`/`useCallback`,
+  state derived in an effect that should be computed during
+  render, and effects that should be event handlers.
+- **No unused vars** (ESLint). Flag dead imports/locals the
+  diff introduces.
+
+## Formatting is owned by Prettier — do NOT flag style nits
+
+Prettier config: **100-char width, semicolons, double quotes,
+no trailing commas, `arrowParens: always`**. Quote style,
+semicolons, line width, trailing commas, and arrow-paren style
+are auto-fixed by the formatter and lint-staged on commit — do
+**not** raise findings about them. Likewise Ruby is formatted by
+the Prettier Ruby plugin. Focus on logic, correctness, hook
+usage, and structure, not anything a formatter rewrites.

--- a/.github/actions/claude-review/prompts/tools/ruby.md
+++ b/.github/actions/claude-review/prompts/tools/ruby.md
@@ -1,0 +1,43 @@
+# Ruby / Rails toolset guidance
+
+This repo is a Ruby on Rails app (server-rendered Slim views +
+JSON API) with React for the inks/pens UI. No Ruby runtime is
+installed in this workflow and Bundler is **not** on the
+allowlist — review from source and the diff, do not try to run
+`bundle`, `rails`, `rspec`, or `rubocop`.
+
+## Conventions to enforce (from CLAUDE.md)
+
+- **snake_case** methods/variables, **CamelCase** classes/modules.
+- **Rescue specific errors only** — flag bare `rescue` /
+  `rescue StandardError` that swallows everything.
+- **Prefer `attr_accessor`/`attr_reader` with `self.x =` in
+  constructors** over bare `@x` instance variables. Flag new
+  classes that reach for raw ivars where an accessor reads
+  cleaner.
+- DB schema is **`structure.sql`** (SQL format), not
+  `schema.rb`. It is generated from migrations — never review
+  edits to it as hand-written code; check the migration
+  instead.
+- Service/business logic lives in `app/operations/`,
+  background work in `app/jobs/` (ActiveJob) and
+  `app/workers/` (Sidekiq), AI agents in `app/agents/`.
+- **New AI agents must use the `RubyLlmAgent` concern, not
+  raix** (raix agents are legacy, being migrated). Flag a new
+  agent built on raix. RubyLLM inner-class tools **must
+  override `def name`** — the auto-generated name includes the
+  module prefix, so a missing `name` override is a bug.
+
+## Reading gem source
+
+To inspect the source of a gem this repo depends on:
+
+1. Read `Gemfile.lock` via the `Read` tool to find the gem's
+   version (rubygems-sourced) or revision (GIT-sourced).
+2. For GIT-sourced gems pinned to a SHA, fetch individual
+   files via `gh api repos/<org>/<repo>/contents/<path>?ref=<sha>`
+   (the response includes base64-encoded content).
+3. For public rubygems with no readily-available GitHub
+   source, note in the finding that external gem source was
+   not inspected. Do not list this as a blocked tool in the
+   trailing comment.

--- a/.github/actions/claude-review/scripts/post-review.sh
+++ b/.github/actions/claude-review/scripts/post-review.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# Submit a batched PR review with multiple inline comments via a single
+# call to GitHub's "Create a review for a pull request" endpoint.
+#
+# The Claude reviewer cannot do this directly because the API needs a
+# JSON body with a comments[] array, and the two ways to deliver it
+# (`gh api --input <file>` and `gh api --input -` via stdin) both
+# require either the `Write` tool (not allowlisted: it has no path
+# scoping) or shell constructs like pipes / `<` redirection (banned
+# by the allowlist policy in prompts/base.md).
+#
+# This helper is the narrow, audited bridge: a single bash entry point
+# that takes structured args, JSON-encodes everything via `jq --arg /
+# --args` so payload content is never interpreted as shell, and pipes
+# the result to `gh api --input -` internally.
+#
+# Usage:
+#   ./.claude-review-post <repo> <pr> <commit_sha> <event> \
+#     [<path> <line> <body>] ...
+#
+# Arguments:
+#   <repo>        owner/name, e.g. urbanhafner/fountainpencompanion
+#   <pr>          pull request number
+#   <commit_sha>  head SHA of the PR (must be a hex string)
+#   <event>       one of: COMMENT, APPROVE, REQUEST_CHANGES
+#   <path> <line> <body>   zero or more inline-comment triples
+#
+# Notes:
+#   - All input validation rejects unexpected characters before any
+#     downstream call. Repo names are restricted to [A-Za-z0-9._/-],
+#     PR numbers must be digits, and the commit SHA must be hex.
+#   - The `gh` CLI uses the runner's GITHUB_TOKEN; this script does
+#     not handle auth.
+
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+  echo "usage: $0 <repo> <pr> <commit_sha> <event> [<path> <line> <body>]..." >&2
+  exit 2
+fi
+
+repo=$1
+pr=$2
+commit=$3
+event=$4
+shift 4
+
+case "$repo" in
+  ''|*[!A-Za-z0-9._/-]*)
+    echo "bad repo: $repo" >&2; exit 2;;
+esac
+
+case "$pr" in
+  ''|*[!0-9]*)
+    echo "bad pr: $pr" >&2; exit 2;;
+esac
+
+case "$commit" in
+  ''|*[!A-Fa-f0-9]*)
+    echo "bad commit_sha: $commit" >&2; exit 2;;
+esac
+
+case "$event" in
+  COMMENT|APPROVE|REQUEST_CHANGES) ;;
+  *)
+    echo "bad event: $event (must be COMMENT, APPROVE, or REQUEST_CHANGES)" >&2
+    exit 2;;
+esac
+
+remaining=$#
+if [ $((remaining % 3)) -ne 0 ]; then
+  echo "comment args must come in (path, line, body) triples; got $remaining trailing args" >&2
+  exit 2
+fi
+
+i=0
+for arg in "$@"; do
+  if [ $((i % 3)) -eq 1 ]; then
+    case "$arg" in
+      ''|*[!0-9]*)
+        echo "bad line value at comment $((i / 3 + 1)): '$arg' (must be a positive integer)" >&2
+        exit 2;;
+    esac
+  fi
+  i=$((i + 1))
+done
+
+comments=$(
+  jq -n --args '
+    [ $ARGS.positional as $a
+      | range(0; ($a | length); 3) as $i
+      | { path: $a[$i], line: ($a[$i+1] | tonumber), side: "RIGHT", body: $a[$i+2] }
+    ]
+  ' -- "$@"
+)
+
+jq -n \
+  --arg commit "$commit" \
+  --arg event "$event" \
+  --argjson comments "$comments" \
+  '{commit_id: $commit, event: $event, comments: $comments}' \
+| gh api \
+    "repos/$repo/pulls/$pr/reviews" \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    --input -

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,49 @@
+name: Claude Code Review
+
+# Claude reviews pull requests and posts inline findings.
+#
+# SECURITY MODEL (this repo is open source):
+#   - Trigger is `pull_request`, NOT `pull_request_target`. GitHub does
+#     not expose repository secrets to workflows triggered by a PR from
+#     a fork, so `secrets.CLAUDE_CODE_OAUTH_TOKEN` is EMPTY on fork PRs.
+#     The guard step below detects the empty token and skips cleanly
+#     (green), so external-contributor PRs are simply not reviewed —
+#     there is no path for a fork to obtain the token. This is the
+#     deliberate trade-off: no token exposure, no fork reviews.
+#   - The reviewer never checks out or executes PR head code; it works
+#     off the diff/metadata fetched via the `gh`/`git` read-only tools.
+#   - Claude runs with a hardened, read-only tool allowlist (see
+#     .github/actions/claude-review/action.yml). It can post review
+#     comments via GITHUB_TOKEN (pull-requests: write) but cannot push
+#     code, write files, or run arbitrary shell.
+#
+# SETUP (one-time, by a maintainer):
+#   1. Generate a token:  claude setup-token
+#   2. Add it as a repository secret named CLAUDE_CODE_OAUTH_TOKEN
+#      (Settings -> Secrets and variables -> Actions).
+#   The token is tied to a personal Claude subscription — treat it like
+#   a password.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/claude-review
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,48 @@
+# Repository review rules — Fountain Pen Companion
+
+These rules apply in addition to the default review checks and are the
+highest-priority guidance for this repo. When a default check would
+produce a finding that contradicts a rule here, the rule here wins —
+suppress the finding (and log the suppression in the step summary).
+
+## Intentional designs — do NOT flag these as bugs
+
+- **Wiki-style community editing.** Brand and ink descriptions can be
+  edited by **any authenticated user** by design — this is intentional
+  wiki-style collaborative editing, not a broken authorization check.
+  Do not raise authz/IDOR/"missing permission check" findings against
+  description-editing paths on this basis.
+
+- **Agents auto-publishing to live.** AI agents (e.g. `ReviewApprover`)
+  auto-publishing ink reviews to the live site is an **accepted,
+  intentional risk**. Do not flag it as a missing human-in-the-loop or
+  unsafe-automation finding.
+
+## Skip / scope rules
+
+- **`db/structure.sql`** is the generated SQL schema dump, not
+  hand-written code. It is excluded from `diff-code.patch`. Never
+  review it as source — if schema behavior matters, review the
+  migration under `db/migrate/` instead.
+
+- **`app/assets/builds/`** is Webpack output (generated). Never review
+  it; excluded from `diff-code.patch`.
+
+- **Formatter-owned style.** Prettier (JS + Ruby via the Prettier Ruby
+  plugin) and ESLint run via lint-staged on commit. Do NOT raise
+  findings about quote style, semicolons, line width (100), trailing
+  commas, arrow-paren style, or import ordering — the formatter owns
+  these and lint-staged enforces them.
+
+- **No issue/ticket requirement.** This is an open-source project. Do
+  not require PR descriptions to link an issue or ticket. A `#123`
+  GitHub issue reference is welcome but its absence is never a finding.
+
+## Calibration
+
+- CLAUDE.md notes existing code quality varies and that older code is
+  often poorly tested. Judge new and changed code on its own merits and
+  hold it to the "well-structured and thoroughly tested" bar — do not
+  excuse a weak new addition because nearby legacy code is worse, and
+  do not demand that a PR fix unrelated pre-existing problems (flag
+  those as `pre-existing` at most).


### PR DESCRIPTION
Runs Claude Code as an automated PR reviewer. Fans out per-check subagents (test-coverage, pr-meta, consistency, clean-code, correctness, simplification, efficiency), verifies each finding against the cited `file:line`, then posts inline comments — or stays silent when there's nothing to report.

## Why

Get fast, consistent first-pass review on every PR without standing up a third-party SaaS reviewer. Design is ported from an internal reviewer action and made fully self-contained so it works in this open-source repo with no external action dependency beyond `anthropics/claude-code-action`.

## Security model (this is the important part for an OSS repo)

- **Trigger is `pull_request`, NOT `pull_request_target`.** GitHub withholds repository secrets from fork-triggered workflows, so `CLAUDE_CODE_OAUTH_TOKEN` is empty on fork PRs. The guard step detects the empty token and skips cleanly (green run). Net trade-off: **external/fork PRs are not reviewed**, in exchange for **zero token-exposure / pwn-request risk**.
- The reviewer **never checks out or executes PR head code** — it works only off the diff/metadata fetched via read-only `gh`/`git`.
- **Hardened read-only tool allowlist** (`gh`/`git`/`grep`/`cat`/etc. — no `Write`/`awk`/`sed`/`jq`/pipes) to limit prompt-injection blast radius.
- Posts via the built-in `GITHUB_TOKEN` (`pull-requests: write`), no PAT.
- Third-party action **pinned to a commit SHA** (`806af32` = v1), not a floating tag.

## Behavior

- Skips PRs authored by `dependabot[bot]`.
- Fixed Ruby/Rails + React toolset (no configurable inputs).
- Repo-specific review rules live in `REVIEW.md` at the repo root (inlined into the prompt) — including the intentional designs (wiki-style community editing, agent auto-publish) so they aren't false-flagged.

## Setup required before it runs

A maintainer must run `claude setup-token` and add the result as the repository secret `CLAUDE_CODE_OAUTH_TOKEN` (Settings → Secrets and variables → Actions). The token is tied to a personal Claude subscription — treat it like a password. Until the secret is set, every run skips cleanly.