### PR TITLE
Clean up frontend test console noise

### DIFF
--- a/app/javascript/src/admin/components/clustering/MacroClusterRow.spec.jsx
+++ b/app/javascript/src/admin/components/clustering/MacroClusterRow.spec.jsx
@@ -16,10 +16,14 @@ jest.mock("react-scroll-into-view-if-needed", () => {
 });
 
 jest.mock("./EntriesList", () => ({
+  // The real EntriesList renders <tr> rows; mock it with valid table markup so
+  // it doesn't trigger invalid-nesting warnings inside the surrounding <tbody>.
   EntriesList: ({ entries }) => (
-    <div data-testid="entries-list" data-entries-count={entries.length}>
-      Entries List
-    </div>
+    <tr>
+      <td data-testid="entries-list" data-entries-count={entries.length}>
+        Entries List
+      </td>
+    </tr>
   )
 }));
 
@@ -172,7 +176,7 @@ describe("MacroClusterRow", () => {
       renderWithContext({ selected: true });
 
       const rows = screen.getAllByRole("row");
-      expect(rows).toHaveLength(2); // Main row + expanded row
+      expect(rows).toHaveLength(3); // Main row + expanded row + EntriesList row
       expect(screen.getByTestId("entries-list")).toBeInTheDocument();
     });
   });
@@ -189,7 +193,7 @@ describe("MacroClusterRow", () => {
 
       // Click to show
       await user.click(scrollComponent);
-      expect(screen.getAllByRole("row")).toHaveLength(2);
+      expect(screen.getAllByRole("row")).toHaveLength(3);
       expect(screen.getByTestId("entries-list")).toBeInTheDocument();
 
       // Click to hide
@@ -205,7 +209,7 @@ describe("MacroClusterRow", () => {
 
       // Click to show
       await user.click(brandCell);
-      expect(screen.getAllByRole("row")).toHaveLength(2);
+      expect(screen.getAllByRole("row")).toHaveLength(3);
 
       // Click to hide
       await user.click(brandCell);

--- a/app/javascript/src/admin/graphs/__tests__/AgentUsage.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/AgentUsage.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { AgentUsage } from "../AgentUsage";

--- a/app/javascript/src/admin/graphs/__tests__/Agents.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/Agents.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import HighchartsReact from "highcharts-react-official";
 import * as fetchModule from "../../../fetch";

--- a/app/javascript/src/admin/graphs/__tests__/BotSignUps.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/BotSignUps.spec.jsx
@@ -1,6 +1,3 @@
-/* eslint-env jest */
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { BotSignUps } from "../BotSignUps";

--- a/app/javascript/src/admin/graphs/__tests__/CollectedInks.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CollectedInks.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { CollectedInks } from "../CollectedInks";

--- a/app/javascript/src/admin/graphs/__tests__/CollectedPens.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CollectedPens.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { CollectedPens } from "../CollectedPens";

--- a/app/javascript/src/admin/graphs/__tests__/CurrentlyInked.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/CurrentlyInked.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { CurrentlyInked } from "../CurrentlyInked";

--- a/app/javascript/src/admin/graphs/__tests__/SignUps.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/SignUps.spec.jsx
@@ -1,6 +1,3 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-/* eslint-env jest */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
 import { SignUps } from "../SignUps";

--- a/app/javascript/src/admin/graphs/__tests__/Spam.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/Spam.spec.jsx
@@ -1,18 +1,19 @@
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
-import { UsageRecords } from "../UsageRecords";
+import { Spam } from "../Spam";
 
 jest.mock("highcharts", () => ({}));
 
-// Mock HighchartsReact to just render a div with its props for inspection
+// Mock HighchartsReact to just render a div with the options as JSON for inspection
 jest.mock("highcharts-react-official", () => {
   const MockHighchartsReact = (props) => (
     <div data-testid="highcharts-mock">{JSON.stringify(props.options)}</div>
   );
   MockHighchartsReact.displayName = "MockHighchartsReact";
-  return MockHighchartsReact;
+  return {
+    __esModule: true,
+    default: MockHighchartsReact
+  };
 });
 
 // Mock Spinner
@@ -31,10 +32,15 @@ afterAll(() => {
   delete global.navigator.locks;
 });
 
-describe("UsageRecords", () => {
+describe("Spam", () => {
   const mockData = [
-    [1717200000000, 8],
-    [1717286400000, 12]
+    {
+      name: "Spam Accounts",
+      data: [
+        [1714608000000, 1],
+        [1714694400000, 2]
+      ]
+    }
   ];
 
   beforeEach(() => {
@@ -64,14 +70,14 @@ describe("UsageRecords", () => {
         })
     );
 
-    render(<UsageRecords />);
+    render(<Spam />);
     expect(screen.getByTestId("spinner")).toBeInTheDocument();
     // Wait for spinner to disappear
     await waitFor(() => expect(screen.queryByTestId("spinner")).not.toBeInTheDocument());
   });
 
   it("fetches data and renders HighchartsReact with correct options", async () => {
-    render(<UsageRecords />);
+    render(<Spam />);
     // Wait for chart to appear
     const chart = await screen.findByTestId("highcharts-mock");
     expect(chart).toBeInTheDocument();
@@ -79,10 +85,9 @@ describe("UsageRecords", () => {
     // Parse the options passed to HighchartsReact
     const options = JSON.parse(chart.textContent);
     expect(options.chart.type).toBe("spline");
-    expect(options.series[0].data).toEqual(mockData);
-    expect(options.series[0].name).toBe("Usage Records");
-    expect(options.title.text).toMatch(/Usage records per day/i);
+    expect(options.series).toEqual(mockData);
+    expect(options.title.text).toMatch(/Spam accounts/i);
     expect(options.xAxis.type).toBe("datetime");
-    expect(options.legend.enabled).toBe(false);
+    expect(options.legend.enabled).toBe(true);
   });
 });

--- a/app/javascript/src/admin/graphs/__tests__/UsageRecords.spec.jsx
+++ b/app/javascript/src/admin/graphs/__tests__/UsageRecords.spec.jsx
@@ -1,23 +1,16 @@
-/* eslint-env jest */
-/* eslint-env jest */
-/* global jest, describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, global */
-/* eslint-env jest */
 import { render, screen, waitFor } from "@testing-library/react";
 import * as fetchModule from "../../../fetch";
-import { Spam } from "../Spam";
+import { UsageRecords } from "../UsageRecords";
 
 jest.mock("highcharts", () => ({}));
 
-// Mock HighchartsReact to just render a div with the options as JSON for inspection
+// Mock HighchartsReact to just render a div with its props for inspection
 jest.mock("highcharts-react-official", () => {
   const MockHighchartsReact = (props) => (
     <div data-testid="highcharts-mock">{JSON.stringify(props.options)}</div>
   );
   MockHighchartsReact.displayName = "MockHighchartsReact";
-  return {
-    __esModule: true,
-    default: MockHighchartsReact
-  };
+  return MockHighchartsReact;
 });
 
 // Mock Spinner
@@ -36,15 +29,10 @@ afterAll(() => {
   delete global.navigator.locks;
 });
 
-describe("Spam", () => {
+describe("UsageRecords", () => {
   const mockData = [
-    {
-      name: "Spam Accounts",
-      data: [
-        [1714608000000, 1],
-        [1714694400000, 2]
-      ]
-    }
+    [1717200000000, 8],
+    [1717286400000, 12]
   ];
 
   beforeEach(() => {
@@ -74,14 +62,14 @@ describe("Spam", () => {
         })
     );
 
-    render(<Spam />);
+    render(<UsageRecords />);
     expect(screen.getByTestId("spinner")).toBeInTheDocument();
     // Wait for spinner to disappear
     await waitFor(() => expect(screen.queryByTestId("spinner")).not.toBeInTheDocument());
   });
 
   it("fetches data and renders HighchartsReact with correct options", async () => {
-    render(<Spam />);
+    render(<UsageRecords />);
     // Wait for chart to appear
     const chart = await screen.findByTestId("highcharts-mock");
     expect(chart).toBeInTheDocument();
@@ -89,9 +77,10 @@ describe("Spam", () => {
     // Parse the options passed to HighchartsReact
     const options = JSON.parse(chart.textContent);
     expect(options.chart.type).toBe("spline");
-    expect(options.series).toEqual(mockData);
-    expect(options.title.text).toMatch(/Spam accounts/i);
+    expect(options.series[0].data).toEqual(mockData);
+    expect(options.series[0].name).toBe("Usage Records");
+    expect(options.title.text).toMatch(/Usage records per day/i);
     expect(options.xAxis.type).toBe("datetime");
-    expect(options.legend.enabled).toBe(true);
+    expect(options.legend.enabled).toBe(false);
   });
 });

--- a/app/javascript/src/collected_inks/CollectedInks.spec.jsx
+++ b/app/javascript/src/collected_inks/CollectedInks.spec.jsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
+import { accountHandlers } from "../../../../spec/javascript/support/accountHandlers";
 import { CollectedInks, storageKeyLayout } from "./CollectedInks";
 
 const setup = (jsx, options) => {
@@ -98,7 +99,8 @@ describe("<CollectedInks />", () => {
           ]
         })
       )
-    )
+    ),
+    ...accountHandlers
   );
 
   beforeAll(() => {

--- a/app/javascript/src/collected_pens/CollectedPens.spec.jsx
+++ b/app/javascript/src/collected_pens/CollectedPens.spec.jsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
+import { accountHandlers } from "../../../../spec/javascript/support/accountHandlers";
 import { CollectedPens, storageKeyLayout } from "./CollectedPens";
 
 const setup = (jsx, options) => {
@@ -31,7 +32,8 @@ describe("<CollectedPens />", () => {
         }
       ];
       return res(ctx.json({ data, meta }));
-    })
+    }),
+    ...accountHandlers
   );
 
   beforeAll(() => server.listen());

--- a/app/javascript/src/currently_inked/CurrentlyInked.spec.jsx
+++ b/app/javascript/src/currently_inked/CurrentlyInked.spec.jsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
+import { accountHandlers } from "../../../../spec/javascript/support/accountHandlers";
 import { CurrentlyInked, storageKeyLayout } from "./CurrentlyInked";
 
 const setup = (jsx, options) => {
@@ -213,7 +214,8 @@ describe("<CurrentlyInked />", () => {
           }
         })
       )
-    )
+    ),
+    ...accountHandlers
   );
 
   beforeAll(() => {

--- a/spec/javascript/src/review-submission/app.spec.jsx
+++ b/spec/javascript/src/review-submission/app.spec.jsx
@@ -3,10 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { rest } from "msw";
 import { setupServer } from "msw/node";
 import { App } from "review-submission/app";
+import { accountHandlers } from "../../support/accountHandlers";
 
 describe("ReviewSubmission App", () => {
   const submitUrl = "/brands/1/inks/2/ink_review_submissions";
-  const server = setupServer();
+  const server = setupServer(...accountHandlers);
 
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());

--- a/spec/javascript/support/accountHandlers.js
+++ b/spec/javascript/support/accountHandlers.js
@@ -1,0 +1,14 @@
+import { rest } from "msw";
+
+// Components that use the useHiddenFields hook fire a background
+// `GET /account` (and a `PUT /account` when migrating local preferences to
+// the server). Component suites that don't exercise preference syncing can
+// register these no-op handlers to silence MSW "unhandled request" warnings.
+const accountResponse = {
+  data: { id: "1", type: "user", attributes: { name: "Test", preferences: {} } }
+};
+
+export const accountHandlers = [
+  rest.get("/account", (req, res, ctx) => res(ctx.json(accountResponse))),
+  rest.put("/account", (req, res, ctx) => res(ctx.json(accountResponse)))
+];

--- a/spec/javascript/support/setup.js
+++ b/spec/javascript/support/setup.js
@@ -1,2 +1,30 @@
 import "@testing-library/jest-dom";
 import "regenerator-runtime/runtime";
+
+// jsdom does not implement the canvas API; chart components call getContext.
+// Stub it so suites that render charts don't emit "Not implemented:
+// HTMLCanvasElement.prototype.getContext" errors.
+HTMLCanvasElement.prototype.getContext = () => null;
+
+// jsdom cannot navigate. Components redirect via window.location.href on a 401
+// (e.g. the background /account sync in useHiddenFields when unauthenticated),
+// which jsdom reports as an "Not implemented: navigation" error on
+// console.error. window.location and its href setter are both non-configurable
+// so the assignment can't be stubbed; instead drop only this known, benign
+// jsdom message and let every other console.error through. The error object
+// originates in jsdom's realm, so match on its message rather than instanceof.
+const originalConsoleError = console.error;
+console.error = (...args) => {
+  const message = String(args[0]?.message ?? args[0] ?? "");
+  if (message.includes("Not implemented: navigation")) return;
+  originalConsoleError(...args);
+};
+
+// The same background /account sync logs retry messages via console.log when
+// the request fails (no server in unit tests). Drop those benign debug logs.
+const originalConsoleLog = console.log;
+console.log = (...args) => {
+  const message = String(args[0] ?? "");
+  if (message.startsWith("Retrying")) return;
+  originalConsoleLog(...args);
+};


### PR DESCRIPTION
## Summary

Silences benign, environment-only noise in the Jest suite and fixes the one real issue behind it. All 657 tests still pass; lint is clean (only pre-existing `react-hooks/incompatible-library` warnings remain).

## Changes

- **`spec/javascript/support/setup.js`**: stub canvas `getContext`, and filter the jsdom `"Not implemented: navigation"` error plus the `fetch.js` retry logs. These all come from `useHiddenFields`' background `GET /account` sync; `window.location` and its `href` setter are non-configurable in jsdom so the assignment itself can't be stubbed.
- **`spec/javascript/support/accountHandlers.js`** (new): shared MSW `/account` handlers, registered in the four suites that render `useHiddenFields` components — removes `[MSW] unhandled request` warnings.
- **`MacroClusterRow.spec.jsx`**: the `EntriesList` mock rendered a `<div>` inside `<tbody>` (invalid HTML — the real component renders `<tr>`s), producing a React nesting warning. Mock now uses valid table markup; row-count assertions updated accordingly.
- **ESLint deprecation**: replaced the deprecated `/* eslint-env jest */` comments (errors as of ESLint v10) with jest globals in the flat config.
- **Filename consistency**: renamed the nine `admin/graphs` `*.test.jsx` files to `*.spec.jsx` to match the project-wide `.spec` convention.