### PR TITLE
Filter empty micro clusters from ink clusterer review queue

### DIFF
--- a/app/agents/check_ink_clustering/base.rb
+++ b/app/agents/check_ink_clustering/base.rb
@@ -34,18 +34,7 @@ class CheckInkClustering::Base
       update_micro_cluster_agent_log!
       execute_decision!
     else
-      agent_log.update(
-        extra_data: {
-          "action" => "reject",
-          "explanation_of_decision" =>
-            "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
-        }
-      )
-      agent_log.approve_by_agent!
-      update_micro_cluster_agent_log!
-      # The micro cluster lost its inks between clustering and review. Reject the
-      # parent log outright so it never reaches a human reviewer.
-      micro_cluster_agent_log.reject!
+      reject_empty_micro_cluster!
     end
   end
 
@@ -54,6 +43,24 @@ class CheckInkClustering::Base
   private
 
   attr_accessor :micro_cluster_agent_log
+
+  EMPTY_MICRO_CLUSTER_EXPLANATION =
+    "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
+
+  # The micro cluster lost its inks between clustering and review. Record the
+  # reason on the child log, annotate the parent, then reject the parent log
+  # outright so it never reaches a human reviewer.
+  def reject_empty_micro_cluster!
+    agent_log.update(
+      extra_data: {
+        "action" => "reject",
+        "explanation_of_decision" => EMPTY_MICRO_CLUSTER_EXPLANATION
+      }
+    )
+    agent_log.approve_by_agent!
+    update_micro_cluster_agent_log!
+    micro_cluster_agent_log.reject!
+  end
 
   def base_tools
     [

--- a/app/agents/check_ink_clustering/base.rb
+++ b/app/agents/check_ink_clustering/base.rb
@@ -42,6 +42,10 @@ class CheckInkClustering::Base
         }
       )
       agent_log.approve_by_agent!
+      update_micro_cluster_agent_log!
+      # The micro cluster lost its inks between clustering and review. Reject the
+      # parent log outright so it never reaches a human reviewer.
+      micro_cluster_agent_log.reject!
     end
   end
 

--- a/app/agents/check_ink_clustering/human.rb
+++ b/app/agents/check_ink_clustering/human.rb
@@ -48,17 +48,7 @@ class CheckInkClustering::Human < CheckInkClustering::Base
       agent_log.waiting_for_approval!
       micro_cluster_agent_log.approve!
     else
-      agent_log.update(
-        extra_data: {
-          "action" => "reject",
-          "explanation_of_decision" =>
-            "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
-        }
-      )
-      # Match Base#perform: mark the child log done, then reject the parent log
-      # outright so it never reaches a human reviewer.
-      agent_log.approve_by_agent!
-      micro_cluster_agent_log.reject!
+      reject_empty_micro_cluster!
     end
   end
 

--- a/app/agents/check_ink_clustering/human.rb
+++ b/app/agents/check_ink_clustering/human.rb
@@ -45,6 +45,8 @@ class CheckInkClustering::Human < CheckInkClustering::Base
     if micro_cluster.collected_inks.present?
       prompt = [clustering_explanation, micro_cluster_data].compact.join("\n\n")
       ask(prompt)
+      agent_log.waiting_for_approval!
+      micro_cluster_agent_log.approve!
     else
       agent_log.update(
         extra_data: {
@@ -53,9 +55,11 @@ class CheckInkClustering::Human < CheckInkClustering::Base
             "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
         }
       )
+      agent_log.waiting_for_approval!
+      # The micro cluster lost its inks between clustering and review. Reject the
+      # parent log outright so it never reaches a human reviewer.
+      micro_cluster_agent_log.reject!
     end
-    agent_log.waiting_for_approval!
-    micro_cluster_agent_log.approve!
   end
 
   private

--- a/app/agents/check_ink_clustering/human.rb
+++ b/app/agents/check_ink_clustering/human.rb
@@ -55,9 +55,9 @@ class CheckInkClustering::Human < CheckInkClustering::Base
             "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
         }
       )
-      agent_log.waiting_for_approval!
-      # The micro cluster lost its inks between clustering and review. Reject the
-      # parent log outright so it never reaches a human reviewer.
+      # Match Base#perform: mark the child log done, then reject the parent log
+      # outright so it never reaches a human reviewer.
+      agent_log.approve_by_agent!
       micro_cluster_agent_log.reject!
     end
   end

--- a/app/agents/ink_clusterer.rb
+++ b/app/agents/ink_clusterer.rb
@@ -198,7 +198,9 @@ class InkClusterer
               "The micro cluster has no inks in it. It is not possible to cluster an empty micro cluster."
           )
       )
-      agent_log.approve_by_agent!
+      # Empty micro clusters can't be clustered and shouldn't reach a human
+      # reviewer, so reject the log outright.
+      agent_log.reject!
     end
   end
 

--- a/app/controllers/admins/agents/ink_clusterer_controller.rb
+++ b/app/controllers/admins/agents/ink_clusterer_controller.rb
@@ -73,6 +73,7 @@ class Admins::Agents::InkClustererController < Admins::BaseController
       .ink_clusterer
       .where(state: [AgentLog::WAITING_FOR_APPROVAL, AgentLog::PROCESSING])
       .or(AgentLog.ink_clusterer.agent_processed)
+      .with_collected_inks
       .order(:id)
   end
 

--- a/app/models/admin_stats.rb
+++ b/app/models/admin_stats.rb
@@ -12,7 +12,12 @@ class AdminStats
   end
 
   def micro_cluster_agent_review_count
-    AgentLog.ink_clusterer.waiting_for_approval.or(AgentLog.ink_clusterer.agent_processed).count
+    AgentLog
+      .ink_clusterer
+      .waiting_for_approval
+      .or(AgentLog.ink_clusterer.agent_processed)
+      .with_collected_inks
+      .count
   end
 
   def pens_model_micro_clusters_to_assign_count

--- a/app/models/agent_log.rb
+++ b/app/models/agent_log.rb
@@ -13,6 +13,17 @@ class AgentLog < ApplicationRecord
 
   scope :ink_clusterer, -> { where(name: "InkClusterer") }
 
+  # Only logs whose owning micro cluster still has collected inks. Empty micro
+  # clusters don't show up anywhere in the app, so their review logs should be
+  # hidden from the review queue. Relies on ink_clusterer logs always owning a
+  # MicroCluster (owner_id -> micro_clusters.id).
+  scope :with_collected_inks,
+        -> do
+          where(
+            "EXISTS (SELECT 1 FROM collected_inks WHERE collected_inks.micro_cluster_id = agent_logs.owner_id)"
+          )
+        end
+
   scope :processing, -> { where(state: PROCESSING) }
   scope :waiting_for_approval, -> { where(state: WAITING_FOR_APPROVAL) }
   scope :approved, -> { where(state: APPROVED) }

--- a/app/models/agent_log.rb
+++ b/app/models/agent_log.rb
@@ -15,12 +15,12 @@ class AgentLog < ApplicationRecord
 
   # Only logs whose owning micro cluster still has collected inks. Empty micro
   # clusters don't show up anywhere in the app, so their review logs should be
-  # hidden from the review queue. Relies on ink_clusterer logs always owning a
-  # MicroCluster (owner_id -> micro_clusters.id).
+  # hidden from the review queue. The owner_type guard keeps the scope correct
+  # for any owner, not just the InkClusterer (MicroCluster-owned) callers.
   scope :with_collected_inks,
         -> do
           where(
-            "EXISTS (SELECT 1 FROM collected_inks WHERE collected_inks.micro_cluster_id = agent_logs.owner_id)"
+            "agent_logs.owner_type = 'MicroCluster' AND EXISTS (SELECT 1 FROM collected_inks WHERE collected_inks.micro_cluster_id = agent_logs.owner_id)"
           )
         end
 

--- a/spec/agents/check_ink_clustering/assign_spec.rb
+++ b/spec/agents/check_ink_clustering/assign_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe CheckInkClustering::Assign do
 
       subject { described_class.new(empty_agent_log.id) }
 
-      it "auto-approves empty micro cluster without calling OpenAI" do
+      it "rejects the parent log for an empty micro cluster without calling OpenAI" do
         subject.perform
 
         expect(WebMock).not_to have_requested(:post, openai_url)
@@ -295,6 +295,10 @@ RSpec.describe CheckInkClustering::Assign do
         expect(agent_log.extra_data["action"]).to eq("reject")
         expect(agent_log.extra_data["explanation_of_decision"]).to include("no inks in it")
         expect(agent_log.state).to eq("approved")
+
+        empty_agent_log.reload
+        expect(empty_agent_log.state).to eq("rejected")
+        expect(empty_agent_log.agent_approved).to be false
       end
     end
 

--- a/spec/agents/check_ink_clustering/create_spec.rb
+++ b/spec/agents/check_ink_clustering/create_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe CheckInkClustering::Create do
 
       subject { described_class.new(empty_agent_log.id) }
 
-      it "auto-approves empty micro cluster without calling OpenAI" do
+      it "rejects the parent log for an empty micro cluster without calling OpenAI" do
         subject.perform
 
         expect(WebMock).not_to have_requested(:post, openai_url)
@@ -265,6 +265,10 @@ RSpec.describe CheckInkClustering::Create do
         expect(agent_log.extra_data["action"]).to eq("reject")
         expect(agent_log.extra_data["explanation_of_decision"]).to include("no inks in it")
         expect(agent_log.state).to eq("approved")
+
+        empty_agent_log.reload
+        expect(empty_agent_log.state).to eq("rejected")
+        expect(empty_agent_log.agent_approved).to be false
       end
     end
 

--- a/spec/agents/check_ink_clustering/human_spec.rb
+++ b/spec/agents/check_ink_clustering/human_spec.rb
@@ -176,9 +176,12 @@ RSpec.describe CheckInkClustering::Human do
         expect(agent_log.extra_data["explanation_of_decision"]).to include("no inks in it")
       end
 
-      it "still approves the micro cluster agent log" do
-        expect_any_instance_of(AgentLog).to receive(:approve!)
+      it "rejects the micro cluster agent log so it never reaches a reviewer" do
         subject.perform
+
+        empty_agent_log.reload
+        expect(empty_agent_log.state).to eq("rejected")
+        expect(empty_agent_log.agent_approved).to be false
       end
     end
 

--- a/spec/agents/check_ink_clustering/ignore_spec.rb
+++ b/spec/agents/check_ink_clustering/ignore_spec.rb
@@ -245,7 +245,7 @@ RSpec.describe CheckInkClustering::Ignore do
 
       subject { described_class.new(empty_agent_log.id) }
 
-      it "auto-approves empty micro cluster without calling OpenAI" do
+      it "rejects the parent log for an empty micro cluster without calling OpenAI" do
         subject.perform
 
         expect(WebMock).not_to have_requested(:post, openai_url)
@@ -254,6 +254,10 @@ RSpec.describe CheckInkClustering::Ignore do
         expect(agent_log.extra_data["action"]).to eq("reject")
         expect(agent_log.extra_data["explanation_of_decision"]).to include("no inks in it")
         expect(agent_log.state).to eq("approved")
+
+        empty_agent_log.reload
+        expect(empty_agent_log.state).to eq("rejected")
+        expect(empty_agent_log.agent_approved).to be false
       end
     end
 

--- a/spec/agents/ink_clusterer_spec.rb
+++ b/spec/agents/ink_clusterer_spec.rb
@@ -226,8 +226,8 @@ RSpec.describe InkClusterer do
 
         expect(subject.agent_log.extra_data["action"]).to eq("reject")
         expect(subject.agent_log.extra_data["explanation_of_decision"]).to include("no inks in it")
-        expect(subject.agent_log.state).to eq("approved")
-        expect(subject.agent_log.agent_approved).to be true
+        expect(subject.agent_log.state).to eq("rejected")
+        expect(subject.agent_log.agent_approved).to be false
       end
 
       it "does not make OpenAI request for empty cluster" do

--- a/spec/models/admin_stats_spec.rb
+++ b/spec/models/admin_stats_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe AdminStats do
+  describe "#micro_cluster_agent_review_count" do
+    it "ignores logs whose micro cluster has no collected inks" do
+      ink = create(:collected_ink)
+      with_inks = create(:micro_cluster)
+      with_inks.collected_inks = [ink]
+      empty = create(:micro_cluster)
+
+      AgentLog.create!(
+        name: "InkClusterer",
+        owner: with_inks,
+        transcript: [],
+        state: AgentLog::WAITING_FOR_APPROVAL
+      )
+      AgentLog.create!(
+        name: "InkClusterer",
+        owner: empty,
+        transcript: [],
+        state: AgentLog::WAITING_FOR_APPROVAL
+      )
+
+      expect(described_class.new.micro_cluster_agent_review_count).to eq(1)
+    end
+  end
+end

--- a/spec/requests/admins/agents/ink_clusterer_controller_spec.rb
+++ b/spec/requests/admins/agents/ink_clusterer_controller_spec.rb
@@ -16,6 +16,34 @@ describe Admins::Agents::InkClustererController do
         get "/admins/agents/ink_clusterer"
         expect(response).to be_successful
       end
+
+      it "hides logs whose micro cluster has no collected inks" do
+        ink = create(:collected_ink)
+        with_inks = create(:micro_cluster)
+        with_inks.collected_inks = [ink]
+        empty = create(:micro_cluster)
+
+        shown =
+          AgentLog.create!(
+            name: "InkClusterer",
+            owner: with_inks,
+            transcript: [],
+            state: AgentLog::WAITING_FOR_APPROVAL
+          )
+        hidden =
+          AgentLog.create!(
+            name: "InkClusterer",
+            owner: empty,
+            transcript: [],
+            state: AgentLog::WAITING_FOR_APPROVAL
+          )
+
+        get "/admins/agents/ink_clusterer"
+
+        expect(controller.view_assigns["queue_length"]).to eq(1)
+        expect(controller.view_assigns["agent_logs"]).to include(shown)
+        expect(controller.view_assigns["agent_logs"]).not_to include(hidden)
+      end
     end
   end
 


### PR DESCRIPTION
Empty micro clusters don't surface anywhere in the app, so their review logs shouldn't waste a human reviewer's time. This hides logs whose micro cluster has no collected inks from both the review list and the dashboard count (no status change), and additionally rejects the log outright when the agent hits the "no inks" error during the clustering run or its follow-up review so it never reaches a reviewer.