### PR TITLE
Optimize Dockerfile: jemalloc in prod + cache-friendly gem install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,23 +16,24 @@ WORKDIR /app
 
 ENV BUNDLE_PATH="/usr/local/bundle"
 
-# Install packages needed to run the app
+# Install packages needed to run the app. These live in `base` so both the
+# `common-build`/`dev` and the slim `prod` runtime stages inherit them.
 RUN apt-get update -qq && \
-  apt-get install --no-install-recommends -y libyaml-dev && \
+  apt-get install --no-install-recommends -y libyaml-dev libjemalloc2 && \
   rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Set up jemalloc for better memory management (runtime concern, so it lives in base)
+RUN ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
+ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
+ENV MALLOC_CONF="dirty_decay_ms:1000,narenas:2,background_thread:true"
 
 # The development stage is used to run the app locally as serves as the base for building the version
 # that will contain the data for prod.
 FROM base AS common-build
 # Install base packages
 RUN apt-get update -qq && \
-  apt-get install --no-install-recommends -y curl libjemalloc2 libvips lsb-release gnupg2 && \
+  apt-get install --no-install-recommends -y curl libvips lsb-release gnupg2 && \
   rm -rf /var/lib/apt/lists /var/cache/apt/archives
-
-# Set up jemalloc for better memory management
-RUN ln -s /usr/lib/*-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2
-ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
-ENV MALLOC_CONF="dirty_decay_ms:1000,narenas:2,background_thread:true"
 
 # Install Postgres 17, so that schema dumping works
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
@@ -81,10 +82,9 @@ CMD ["bundle exec puma"]
 
 FROM common-build AS prod-build
 
-# Copy application code
-COPY . .
-
-# Bundle but without dev and test groups
+# Bundle but without dev and test groups. Gemfile/Gemfile.lock are already present
+# from common-build, so installing gems BEFORE copying the app keeps this layer cached
+# across deploys that don't touch the Gemfile.
 ENV RAILS_ENV="production" \
   BUNDLE_DEPLOYMENT="1" \
   BUNDLE_WITHOUT="development:test"
@@ -93,6 +93,9 @@ RUN rm -rf "${BUNDLE_PATH}" && \
   bundle install && \
   rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
   bundle exec bootsnap precompile --gemfile
+
+# Copy application code
+COPY . .
 
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/


### PR DESCRIPTION
## Summary

Two Dockerfile optimizations to the multi-stage build, both targeting the prod path that Fly builds via `flyctl deploy --remote-only`.

### 1. jemalloc now actually runs in production

jemalloc (the `libjemalloc.so.2` symlink + `LD_PRELOAD`/`MALLOC_CONF` env) lived in the `common-build` stage. But the final `prod` stage is `FROM base`, not `FROM common-build` — correct, since common-build carries build tooling we don't want in the slim runtime image. The side effect: **prod ran without jemalloc** despite the setup, even though a long-running runtime is exactly where it helps.

Fix: jemalloc is a runtime concern, so it moves into `base` — the shared ancestor of both `common-build`/`dev` and `prod`. Now:
- dev still gets jemalloc (via common-build)
- prod gets it directly from base (the missing piece)
- no build tooling leaks into the slim prod image

Verified in the built prod image: `/proc/self/maps` shows jemalloc loaded.

### 2. Gem install layer stays cached across deploys

`prod-build` did `COPY . .` *before* `bundle install`, so every code change busted the gem-install layer and reinstalled all gems on each deploy. `Gemfile`/`Gemfile.lock` are already present from `common-build`, so installing gems before copying the app keeps that layer cached across deploys that don't touch the Gemfile.

`libvips` is left in `common-build` (build-time only; the app uses no `image_processing`/vips at runtime).