### PR TITLE
Add automatic Patreon patron sync (Option A)

### DIFF
--- a/app/controllers/admins/patreon_controller.rb
+++ b/app/controllers/admins/patreon_controller.rb
@@ -1,0 +1,32 @@
+# Reconciliation view for the automatic patron sync (Option A). Fetches the
+# live list of active Patreon members and shows, for each, whether it matched
+# an FPC user. Unmatched members are the ones an admin needs to handle by hand
+# (usually a different email on each side, until the user links their account).
+class Admins::PatreonController < Admins::BaseController
+  def show
+    @configured = ENV["PATREON_CAMPAIGN_ID"].present? && PatreonCredential.configured?
+    return unless @configured
+
+    members = client.members(ENV["PATREON_CAMPAIGN_ID"]).select(&:active?)
+    rows = members.map { |member| [member, match_user(member)] }
+    @matched, @unmatched = rows.partition { |(_member, user)| user }
+  rescue Faraday::Error => e
+    @error = e.message
+  end
+
+  private
+
+  def match_user(member)
+    if member.user_id.present?
+      user = User.find_by(patreon_user_id: member.user_id)
+      return user if user
+    end
+    return if member.email.blank?
+
+    User.where("lower(email) = ?", member.email.downcase).first
+  end
+
+  def client
+    @client ||= PatreonClient.new(PatreonCredential.access_token!)
+  end
+end

--- a/app/controllers/admins/patreon_controller.rb
+++ b/app/controllers/admins/patreon_controller.rb
@@ -8,23 +8,13 @@ class Admins::PatreonController < Admins::BaseController
     return unless @configured
 
     members = client.members(ENV["PATREON_CAMPAIGN_ID"]).select(&:active?)
-    rows = members.map { |member| [member, match_user(member)] }
+    rows = User.match_patreon_members(members).to_a
     @matched, @unmatched = rows.partition { |(_member, user)| user }
   rescue Faraday::Error => e
     @error = e.message
   end
 
   private
-
-  def match_user(member)
-    if member.user_id.present?
-      user = User.find_by(patreon_user_id: member.user_id)
-      return user if user
-    end
-    return if member.email.blank?
-
-    User.where("lower(email) = ?", member.email.downcase).first
-  end
 
   def client
     @client ||= PatreonClient.new(PatreonCredential.access_token!)

--- a/app/controllers/admins/users_controller.rb
+++ b/app/controllers/admins/users_controller.rb
@@ -27,7 +27,12 @@ class Admins::UsersController < Admins::BaseController
   end
 
   def update
-    if @user.update(update_params)
+    @user.assign_attributes(update_params)
+    # Pin the patron flag as admin-owned only when the admin actually changes
+    # it, so the Patreon sync leaves it alone. Saving an unrelated field does
+    # not claim ownership.
+    @user.patron_source = "manual" if @user.patron_changed?
+    if @user.save
       redirect_to admins_user_path(@user)
     else
       render :show

--- a/app/models/patreon_credential.rb
+++ b/app/models/patreon_credential.rb
@@ -1,0 +1,46 @@
+# Stores the creator-level OAuth tokens used to read the campaign's member
+# list (Option A — automatic patron sync by matching email/Patreon user id).
+#
+# Patreon access tokens are short-lived and refresh tokens rotate on every
+# refresh, so the tokens cannot live in ENV — they must be persisted and
+# updated in place. There is only ever one row.
+#
+# Seed it once (values from the Patreon developer portal) via the console:
+#
+#   PatreonCredential.create!(
+#     access_token: "...",
+#     refresh_token: "...",
+#     expires_at: 1.month.from_now
+#   )
+class PatreonCredential < ApplicationRecord
+  # Refresh a little before the token actually expires to avoid racing the
+  # boundary mid-request.
+  EXPIRY_LEEWAY = 5.minutes
+
+  def self.access_token!
+    cred = current
+    cred.refresh! if cred.expired?
+    cred.access_token
+  end
+
+  def self.current
+    first || raise("No Patreon credential configured")
+  end
+
+  def self.configured?
+    exists?
+  end
+
+  def expired?
+    expires_at.nil? || expires_at <= EXPIRY_LEEWAY.from_now
+  end
+
+  def refresh!
+    data = PatreonClient.refresh_token(refresh_token)
+    update!(
+      access_token: data[:access_token],
+      refresh_token: data[:refresh_token],
+      expires_at: data[:expires_in].to_i.seconds.from_now
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,19 @@ class User < ApplicationRecord
     where(admin: true)
   end
 
+  # Maps each Patreon member to the matching user (or nil), preferring a
+  # linked patreon_user_id over a case-insensitive email match. Bulk-loads in
+  # two queries so callers iterating many members avoid N+1s.
+  def self.match_patreon_members(members)
+    ids = members.filter_map(&:user_id).uniq
+    emails = members.filter_map { |member| member.email&.downcase }.uniq
+    by_id = where(patreon_user_id: ids).index_by(&:patreon_user_id)
+    by_email = where("lower(email) IN (?)", emails).index_by { |user| user.email.downcase }
+    members.index_with do |member|
+      (member.user_id && by_id[member.user_id]) || (member.email && by_email[member.email.downcase])
+    end
+  end
+
   def active_for_authentication?
     super and !spam? and deletion_requested_at.nil?
   end

--- a/app/operations/patreon_client.rb
+++ b/app/operations/patreon_client.rb
@@ -8,6 +8,8 @@ class PatreonClient
   TOKEN_URL = "https://www.patreon.com/api/oauth2/token".freeze
   PAGE_SIZE = 1000
   MEMBER_FIELDS = "patron_status,currently_entitled_amount_cents,email".freeze
+  OPEN_TIMEOUT = 5
+  READ_TIMEOUT = 15
 
   # One Patreon member, flattened to the fields the sync cares about.
   Member =
@@ -46,7 +48,11 @@ class PatreonClient
   def self.refresh_token(refresh_token)
     response =
       Faraday
-        .new { |f| f.response :raise_error }
+        .new do |f|
+          f.options.open_timeout = OPEN_TIMEOUT
+          f.options.timeout = READ_TIMEOUT
+          f.response :raise_error
+        end
         .post(
           TOKEN_URL,
           URI.encode_www_form(
@@ -71,6 +77,8 @@ class PatreonClient
     @connection ||=
       Faraday.new(url: API_BASE) do |f|
         f.headers["Authorization"] = "Bearer #{access_token}"
+        f.options.open_timeout = OPEN_TIMEOUT
+        f.options.timeout = READ_TIMEOUT
         f.response :raise_error
       end
   end

--- a/app/operations/patreon_client.rb
+++ b/app/operations/patreon_client.rb
@@ -1,0 +1,101 @@
+# Thin Faraday wrapper around the Patreon v2 API. Used to read the campaign
+# member list for the automatic patron sync and to refresh creator tokens.
+#
+# The Patreon host is fixed and trusted, so (unlike SafeHttp) there is no SSRF
+# concern here — we talk to exactly one known endpoint with a bearer token.
+class PatreonClient
+  API_BASE = "https://www.patreon.com/api/oauth2/v2".freeze
+  TOKEN_URL = "https://www.patreon.com/api/oauth2/token".freeze
+  PAGE_SIZE = 1000
+  MEMBER_FIELDS = "patron_status,currently_entitled_amount_cents,email".freeze
+
+  # One Patreon member, flattened to the fields the sync cares about.
+  Member =
+    Struct.new(:member_id, :user_id, :email, :status, :amount_cents, keyword_init: true) do
+      def active?
+        status == "active_patron" && amount_cents.to_i.positive?
+      end
+    end
+
+  attr_accessor :access_token
+
+  def initialize(access_token)
+    self.access_token = access_token
+  end
+
+  # Returns every member of the campaign, following cursor pagination.
+  def members(campaign_id)
+    results = []
+    seen_cursors = []
+    cursor = nil
+    loop do
+      body = fetch_members_page(campaign_id, cursor)
+      results.concat(parse_members(body))
+      cursor = body.dig("meta", "pagination", "cursors", "next")
+      # Stop on the end of the list, and guard against a misbehaving API that
+      # keeps handing back a cursor we've already followed (which would loop
+      # forever).
+      break if cursor.blank? || seen_cursors.include?(cursor)
+
+      seen_cursors << cursor
+    end
+    results
+  end
+
+  # Exchanges a (rotating) refresh token for a fresh access/refresh token pair.
+  def self.refresh_token(refresh_token)
+    response =
+      Faraday
+        .new { |f| f.response :raise_error }
+        .post(
+          TOKEN_URL,
+          URI.encode_www_form(
+            grant_type: "refresh_token",
+            refresh_token: refresh_token,
+            client_id: ENV.fetch("PATREON_CLIENT_ID"),
+            client_secret: ENV.fetch("PATREON_CLIENT_SECRET")
+          ),
+          "Content-Type" => "application/x-www-form-urlencoded"
+        )
+    data = JSON.parse(response.body)
+    {
+      access_token: data["access_token"],
+      refresh_token: data["refresh_token"],
+      expires_in: data["expires_in"]
+    }
+  end
+
+  private
+
+  def connection
+    @connection ||=
+      Faraday.new(url: API_BASE) do |f|
+        f.headers["Authorization"] = "Bearer #{access_token}"
+        f.response :raise_error
+      end
+  end
+
+  def fetch_members_page(campaign_id, cursor)
+    response =
+      connection.get("campaigns/#{campaign_id}/members") do |req|
+        req.params["include"] = "user"
+        req.params["fields[member]"] = MEMBER_FIELDS
+        req.params["page[count]"] = PAGE_SIZE
+        req.params["page[cursor]"] = cursor if cursor
+      end
+    JSON.parse(response.body)
+  end
+
+  def parse_members(body)
+    Array(body["data"]).map do |member|
+      attributes = member["attributes"] || {}
+      Member.new(
+        member_id: member["id"],
+        user_id: member.dig("relationships", "user", "data", "id"),
+        email: attributes["email"],
+        status: attributes["patron_status"],
+        amount_cents: attributes["currently_entitled_amount_cents"]
+      )
+    end
+  end
+end

--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -1,3 +1,6 @@
+p class="mb-3"
+  = link_to "Patreon reconciliation", admins_patreon_path, class: "btn btn-outline-secondary btn-sm"
+
 table class="table table-striped"
   thead
     th Name

--- a/app/views/admins/patreon/show.html.slim
+++ b/app/views/admins/patreon/show.html.slim
@@ -1,0 +1,53 @@
+- content_for :title, "Patreon reconciliation"
+
+h1 class="mb-4" Patreon reconciliation
+
+- unless @configured
+  div class="alert alert-warning"
+    | Patreon is not configured. Set the
+    code> PATREON_CAMPAIGN_ID
+    | environment variable and seed a
+    code> PatreonCredential
+    | record.
+
+- if @error
+  div class="alert alert-danger" = "Patreon API error: #{@error}"
+
+- if @configured && !@error
+  p class="text-muted"
+    | Active Patreon members are matched to FPC users by linked Patreon account
+      first, then by email. Unmatched members need a manual patron flag or for
+      the user to link their account.
+
+  h2 class="mt-4 mb-3" = "Unmatched (#{@unmatched.size})"
+  - if @unmatched.empty?
+    p class="text-success" Every active member is matched. 🎉
+  - else
+    table class="table table-striped"
+      thead
+        tr
+          th Patreon email
+          th Patreon user id
+          th Pledge (cents)
+      tbody
+        - @unmatched.each do |member, _user|
+          tr
+            td = member.email
+            td = member.user_id
+            td = member.amount_cents
+
+  h2 class="mt-5 mb-3" = "Matched (#{@matched.size})"
+  table class="table table-striped"
+    thead
+      tr
+        th FPC user
+        th Patreon email
+        th Patron?
+        th Source
+    tbody
+      - @matched.each do |member, user|
+        tr
+          td = link_to(user.public_name.presence || user.email, admins_user_path(user))
+          td = member.email
+          td = user.patron? ? "yes" : "no"
+          td = user.patron_source || "—"

--- a/app/views/admins/users/show.html.slim
+++ b/app/views/admins/users/show.html.slim
@@ -10,6 +10,14 @@ div class="row"
       = f.input :patron
       = f.input :auto_approve_ink_reviews
       = f.submit class: "btn btn-success"
+    - if @user.patron_source.present? || @user.patreon_status.present?
+      p class="text-muted mt-2"
+        | Patron source:
+        strong<> #{@user.patron_source || "—"}
+        - if @user.patreon_status.present?
+          |  · Patreon status: #{@user.patreon_status}
+        - if @user.patreon_synced_at.present?
+          |  · synced #{time_ago_in_words(@user.patreon_synced_at)} ago
 
 div class="row"
   div class="col-sm-12"

--- a/app/workers/sync_patreon_patrons.rb
+++ b/app/workers/sync_patreon_patrons.rb
@@ -18,25 +18,25 @@ class SyncPatreonPatrons
     return unless campaign_id.present? && PatreonCredential.configured?
 
     active_members = client.members(campaign_id).select(&:active?)
-    matched_user_ids = grant(active_members)
+    matched_user_ids = grant(User.match_patreon_members(active_members))
     revoke_churned(matched_user_ids)
   end
 
   private
 
-  def grant(active_members)
-    active_members.filter_map do |member|
-      user = match_user(member)
+  def grant(matches)
+    matches.filter_map do |member, user|
       next unless user
 
-      user.update!(
+      attrs = {
         patreon_member_id: member.member_id,
         patreon_user_id: user.patreon_user_id || member.user_id,
         patreon_email: member.email,
         patreon_status: member.status,
         patreon_synced_at: Time.current
-      )
-      user.update!(patron: true, patron_source: "patreon") unless user.patron_source == "manual"
+      }
+      attrs.merge!(patron: true, patron_source: "patreon") unless user.patron_source == "manual"
+      user.update!(attrs)
       user.id
     end
   end
@@ -53,22 +53,6 @@ class SyncPatreonPatrons
           patreon_synced_at: Time.current
         )
       end
-  end
-
-  def match_user(member)
-    by_linked_id(member) || by_email(member)
-  end
-
-  def by_linked_id(member)
-    return if member.user_id.blank?
-
-    User.find_by(patreon_user_id: member.user_id)
-  end
-
-  def by_email(member)
-    return if member.email.blank?
-
-    User.where("lower(email) = ?", member.email.downcase).first
   end
 
   def client

--- a/app/workers/sync_patreon_patrons.rb
+++ b/app/workers/sync_patreon_patrons.rb
@@ -1,0 +1,81 @@
+# Option A: automatically keep the `patron` flag in sync with the Patreon
+# campaign's active members. Runs on a schedule (see sidekiq_schedule.yml).
+#
+# Matching, in priority order:
+#   1. patreon_user_id  — set when the user explicitly linked their account
+#      (Option B). Authoritative; survives email changes on either side.
+#   2. email            — falls back to a case-insensitive email match for
+#      users who haven't linked but use the same address on both sides.
+#
+# Only patrons the sync itself granted (patron_source == "patreon") are ever
+# auto-revoked. Admin-pinned ("manual") and legacy/unmanaged (NULL) patrons
+# are left untouched, so this can never silently strip a manually granted
+# patron who isn't matchable on Patreon.
+class SyncPatreonPatrons
+  include Sidekiq::Worker
+
+  def perform
+    return unless campaign_id.present? && PatreonCredential.configured?
+
+    active_members = client.members(campaign_id).select(&:active?)
+    matched_user_ids = grant(active_members)
+    revoke_churned(matched_user_ids)
+  end
+
+  private
+
+  def grant(active_members)
+    active_members.filter_map do |member|
+      user = match_user(member)
+      next unless user
+
+      user.update!(
+        patreon_member_id: member.member_id,
+        patreon_user_id: user.patreon_user_id || member.user_id,
+        patreon_email: member.email,
+        patreon_status: member.status,
+        patreon_synced_at: Time.current
+      )
+      user.update!(patron: true, patron_source: "patreon") unless user.patron_source == "manual"
+      user.id
+    end
+  end
+
+  # Anyone we previously granted who is no longer an active member.
+  def revoke_churned(matched_user_ids)
+    User
+      .where(patron_source: "patreon", patron: true)
+      .where.not(id: matched_user_ids)
+      .find_each do |user|
+        user.update!(
+          patron: false,
+          patreon_status: "former_patron",
+          patreon_synced_at: Time.current
+        )
+      end
+  end
+
+  def match_user(member)
+    by_linked_id(member) || by_email(member)
+  end
+
+  def by_linked_id(member)
+    return if member.user_id.blank?
+
+    User.find_by(patreon_user_id: member.user_id)
+  end
+
+  def by_email(member)
+    return if member.email.blank?
+
+    User.where("lower(email) = ?", member.email.downcase).first
+  end
+
+  def client
+    @client ||= PatreonClient.new(PatreonCredential.access_token!)
+  end
+
+  def campaign_id
+    ENV["PATREON_CAMPAIGN_ID"]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,7 @@ Rails.application.routes.draw do
 
   namespace :admins do
     resource :dashboard, only: [:show]
+    resource :patreon, only: [:show], controller: "patreon"
     resources :agent_logs, only: [:index]
     namespace :agents do
       resources :ink_clusterer, only: %i[index destroy update]

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -31,3 +31,6 @@ analyze:
 enqueue_ink_review_checks:
   cron: "*/15 * * * *" # Every 15 minutes
   class: EnqueueInkReviewChecks
+sync_patreon_patrons:
+  cron: "0 4 * * *" # Every day at 4am
+  class: SyncPatreonPatrons

--- a/db/migrate/20260625120000_add_patreon_fields_to_users.rb
+++ b/db/migrate/20260625120000_add_patreon_fields_to_users.rb
@@ -1,0 +1,14 @@
+class AddPatreonFieldsToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :patreon_user_id, :string
+    add_column :users, :patreon_member_id, :string
+    add_column :users, :patreon_email, :string
+    add_column :users, :patreon_status, :string
+    # NULL = legacy/unmanaged (never auto-revoked), "manual" = admin pinned
+    # (never auto-managed), "patreon" = granted by the sync (auto-revoked on
+    # churn). Defaults to NULL so existing patrons are never touched by the
+    # sync until they actively match a Patreon membership.
+    add_column :users, :patron_source, :string
+    add_column :users, :patreon_synced_at, :datetime
+  end
+end

--- a/db/migrate/20260625120100_create_patreon_credentials.rb
+++ b/db/migrate/20260625120100_create_patreon_credentials.rb
@@ -1,0 +1,11 @@
+class CreatePatreonCredentials < ActiveRecord::Migration[8.1]
+  def change
+    create_table :patreon_credentials do |t|
+      t.string :access_token, null: false
+      t.string :refresh_token, null: false
+      t.datetime :expires_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260625120200_add_index_to_users_patreon_user_id.rb
+++ b/db/migrate/20260625120200_add_index_to_users_patreon_user_id.rb
@@ -1,0 +1,11 @@
+class AddIndexToUsersPatreonUserId < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :users,
+              :patreon_user_id,
+              unique: true,
+              where: "patreon_user_id IS NOT NULL",
+              algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -749,6 +749,39 @@ ALTER SEQUENCE public.new_ink_names_id_seq OWNED BY public.new_ink_names.id;
 
 
 --
+-- Name: patreon_credentials; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.patreon_credentials (
+    id bigint NOT NULL,
+    access_token character varying NOT NULL,
+    refresh_token character varying NOT NULL,
+    expires_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: patreon_credentials_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.patreon_credentials_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: patreon_credentials_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.patreon_credentials_id_seq OWNED BY public.patreon_credentials.id;
+
+
+--
 -- Name: pen_embeddings; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1063,7 +1096,13 @@ CREATE TABLE public.users (
     spam_reason character varying DEFAULT ''::character varying,
     auto_approve_ink_reviews boolean DEFAULT false,
     deletion_requested_at timestamp(6) without time zone,
-    preferences jsonb DEFAULT '{}'::jsonb NOT NULL
+    preferences jsonb DEFAULT '{}'::jsonb NOT NULL,
+    patreon_user_id character varying,
+    patreon_member_id character varying,
+    patreon_email character varying,
+    patreon_status character varying,
+    patron_source character varying,
+    patreon_synced_at timestamp(6) without time zone
 );
 
 
@@ -1314,6 +1353,13 @@ ALTER TABLE ONLY public.new_ink_names ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: patreon_credentials id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.patreon_credentials ALTER COLUMN id SET DEFAULT nextval('public.patreon_credentials_id_seq'::regclass);
+
+
+--
 -- Name: pen_embeddings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1547,6 +1593,14 @@ ALTER TABLE ONLY public.micro_clusters
 
 ALTER TABLE ONLY public.new_ink_names
     ADD CONSTRAINT new_ink_names_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: patreon_credentials patreon_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.patreon_credentials
+    ADD CONSTRAINT patreon_credentials_pkey PRIMARY KEY (id);
 
 
 --
@@ -2102,6 +2156,13 @@ CREATE UNIQUE INDEX index_users_on_email ON public.users USING btree (email);
 
 
 --
+-- Name: index_users_on_patreon_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_users_on_patreon_user_id ON public.users USING btree (patreon_user_id) WHERE (patreon_user_id IS NOT NULL);
+
+
+--
 -- Name: index_users_on_reset_password_token; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2393,6 +2454,9 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260625120200'),
+('20260625120100'),
+('20260625120000'),
 ('20260522123500'),
 ('20260413083719'),
 ('20260325150042'),

--- a/spec/models/patreon_credential_spec.rb
+++ b/spec/models/patreon_credential_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe PatreonCredential do
+  describe ".configured?" do
+    it "is false when no row exists" do
+      expect(described_class.configured?).to be(false)
+    end
+
+    it "is true once a credential exists" do
+      described_class.create!(access_token: "a", refresh_token: "r", expires_at: 1.day.from_now)
+      expect(described_class.configured?).to be(true)
+    end
+  end
+
+  describe "#expired?" do
+    it "is true when expires_at is nil" do
+      cred = described_class.new(access_token: "a", refresh_token: "r", expires_at: nil)
+      expect(cred).to be_expired
+    end
+
+    it "is true within the leeway window" do
+      cred =
+        described_class.new(access_token: "a", refresh_token: "r", expires_at: 1.minute.from_now)
+      expect(cred).to be_expired
+    end
+
+    it "is false comfortably before expiry" do
+      cred = described_class.new(access_token: "a", refresh_token: "r", expires_at: 1.hour.from_now)
+      expect(cred).not_to be_expired
+    end
+  end
+
+  describe ".access_token!" do
+    it "returns the token when still valid" do
+      described_class.create!(
+        access_token: "valid",
+        refresh_token: "r",
+        expires_at: 1.hour.from_now
+      )
+      expect(described_class.access_token!).to eq("valid")
+    end
+
+    it "refreshes and persists a rotated pair when expired" do
+      cred =
+        described_class.create!(access_token: "old", refresh_token: "old-refresh", expires_at: nil)
+      allow(PatreonClient).to receive(:refresh_token).with("old-refresh").and_return(
+        access_token: "fresh",
+        refresh_token: "fresh-refresh",
+        expires_in: 3600
+      )
+
+      expect(described_class.access_token!).to eq("fresh")
+
+      cred.reload
+      expect(cred.access_token).to eq("fresh")
+      expect(cred.refresh_token).to eq("fresh-refresh")
+      expect(cred.expires_at).to be_within(5.seconds).of(3600.seconds.from_now)
+    end
+
+    it "raises when not configured" do
+      expect { described_class.access_token! }.to raise_error(/No Patreon credential/)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,4 +48,44 @@ describe User do
       expect(user).not_to be_active_for_authentication
     end
   end
+
+  describe ".match_patreon_members" do
+    def member(user_id: nil, email: nil)
+      PatreonClient::Member.new(
+        member_id: "m",
+        user_id: user_id,
+        email: email,
+        status: "active_patron",
+        amount_cents: 500
+      )
+    end
+
+    it "matches by linked patreon_user_id first, even when the email differs" do
+      user = create(:user, email: "fpc@example.com", patreon_user_id: "u1")
+      m = member(user_id: "u1", email: "other@example.com")
+      expect(described_class.match_patreon_members([m])).to eq(m => user)
+    end
+
+    it "falls back to a case-insensitive email match" do
+      user = create(:user, email: "match@example.com")
+      m = member(email: "Match@Example.com")
+      expect(described_class.match_patreon_members([m])).to eq(m => user)
+    end
+
+    it "maps unmatched members to nil" do
+      m = member(user_id: "nope", email: "nobody@example.com")
+      expect(described_class.match_patreon_members([m])).to eq(m => nil)
+    end
+
+    it "resolves a mix of members in one pass" do
+      by_email = create(:user, email: "a@example.com")
+      by_id = create(:user, email: "b@example.com", patreon_user_id: "u2")
+      members = [
+        member(email: "a@example.com"),
+        member(user_id: "u2", email: "x@example.com"),
+        member(email: "missing@example.com")
+      ]
+      expect(described_class.match_patreon_members(members).values).to eq([by_email, by_id, nil])
+    end
+  end
 end

--- a/spec/operations/patreon_client_spec.rb
+++ b/spec/operations/patreon_client_spec.rb
@@ -1,0 +1,177 @@
+require "rails_helper"
+
+describe PatreonClient do
+  let(:campaign_id) { "12345" }
+
+  def member_json(id:, user_id:, email:, status:, amount:)
+    {
+      id: id,
+      type: "member",
+      attributes: {
+        patron_status: status,
+        currently_entitled_amount_cents: amount,
+        email: email
+      },
+      relationships: {
+        user: {
+          data: {
+            id: user_id,
+            type: "user"
+          }
+        }
+      }
+    }
+  end
+
+  describe "#members" do
+    it "returns flattened members from a single page" do
+      stub_request(
+        :get,
+        "https://www.patreon.com/api/oauth2/v2/campaigns/#{campaign_id}/members"
+      ).with(query: hash_including({})).to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "application/json"
+        },
+        body: {
+          data: [
+            member_json(
+              id: "m1",
+              user_id: "u1",
+              email: "a@example.com",
+              status: "active_patron",
+              amount: 500
+            )
+          ],
+          meta: {
+            pagination: {
+              cursors: {
+                next: nil
+              }
+            }
+          }
+        }.to_json
+      )
+
+      members = described_class.new("token").members(campaign_id)
+
+      expect(members.size).to eq(1)
+      member = members.first
+      expect(member.member_id).to eq("m1")
+      expect(member.user_id).to eq("u1")
+      expect(member.email).to eq("a@example.com")
+      expect(member.status).to eq("active_patron")
+      expect(member.amount_cents).to eq(500)
+      expect(member).to be_active
+    end
+
+    it "follows cursor pagination" do
+      base = "https://www.patreon.com/api/oauth2/v2/campaigns/#{campaign_id}/members"
+      json_headers = { "Content-Type" => "application/json" }
+      page1 = {
+        data: [
+          member_json(
+            id: "m1",
+            user_id: "u1",
+            email: "a@example.com",
+            status: "active_patron",
+            amount: 500
+          )
+        ],
+        meta: {
+          pagination: {
+            cursors: {
+              next: "CURSOR2"
+            }
+          }
+        }
+      }
+      page2 = {
+        data: [
+          member_json(
+            id: "m2",
+            user_id: "u2",
+            email: "b@example.com",
+            status: "former_patron",
+            amount: 0
+          )
+        ],
+        meta: {
+          pagination: {
+            cursors: {
+              next: nil
+            }
+          }
+        }
+      }
+
+      # WebMock nests bracketed query params, so matching on a flat
+      # "page[cursor]" key is unreliable. Return the pages in sequence on the
+      # same stub instead.
+      stub_request(:get, base).with(query: hash_including({})).to_return(
+        { status: 200, headers: json_headers, body: page1.to_json },
+        { status: 200, headers: json_headers, body: page2.to_json }
+      )
+
+      members = described_class.new("token").members(campaign_id)
+
+      expect(members.map(&:member_id)).to eq(%w[m1 m2])
+      expect(members.last).not_to be_active
+    end
+
+    it "sends the bearer token" do
+      stub =
+        stub_request(
+          :get,
+          "https://www.patreon.com/api/oauth2/v2/campaigns/#{campaign_id}/members"
+        ).with(
+          query: hash_including({}),
+          headers: {
+            "Authorization" => "Bearer secret-token"
+          }
+        ).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: { data: [], meta: { pagination: { cursors: { next: nil } } } }.to_json
+        )
+
+      described_class.new("secret-token").members(campaign_id)
+
+      expect(stub).to have_been_requested
+    end
+  end
+
+  describe ".refresh_token" do
+    around do |example|
+      previous = ENV.values_at("PATREON_CLIENT_ID", "PATREON_CLIENT_SECRET")
+      ENV["PATREON_CLIENT_ID"] = "client"
+      ENV["PATREON_CLIENT_SECRET"] = "secret"
+      example.run
+      ENV["PATREON_CLIENT_ID"], ENV["PATREON_CLIENT_SECRET"] = previous
+    end
+
+    it "exchanges the refresh token for a new pair" do
+      stub_request(:post, "https://www.patreon.com/api/oauth2/token").to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "application/json"
+        },
+        body: {
+          access_token: "new-access",
+          refresh_token: "new-refresh",
+          expires_in: 2_678_400
+        }.to_json
+      )
+
+      result = described_class.refresh_token("old-refresh")
+
+      expect(result).to eq(
+        access_token: "new-access",
+        refresh_token: "new-refresh",
+        expires_in: 2_678_400
+      )
+    end
+  end
+end

--- a/spec/requests/admins/patreon_controller_spec.rb
+++ b/spec/requests/admins/patreon_controller_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe Admins::PatreonController do
+  let(:admin) { create(:user, :admin) }
+
+  def member(member_id:, user_id: nil, email: nil, amount: 500)
+    PatreonClient::Member.new(
+      member_id: member_id,
+      user_id: user_id,
+      email: email,
+      status: "active_patron",
+      amount_cents: amount
+    )
+  end
+
+  describe "#show" do
+    it "requires authentication" do
+      get "/admins/patreon"
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    context "signed in" do
+      before(:each) { sign_in(admin) }
+
+      around do |example|
+        previous = ENV["PATREON_CAMPAIGN_ID"]
+        example.run
+        ENV["PATREON_CAMPAIGN_ID"] = previous
+      end
+
+      it "renders a not-configured notice when env is missing" do
+        ENV.delete("PATREON_CAMPAIGN_ID")
+
+        get "/admins/patreon"
+
+        expect(response).to be_successful
+        expect(response.body).to include("Patreon is not configured")
+      end
+
+      it "splits members into matched and unmatched" do
+        ENV["PATREON_CAMPAIGN_ID"] = "campaign-1"
+        PatreonCredential.create!(
+          access_token: "t",
+          refresh_token: "r",
+          expires_at: 1.hour.from_now
+        )
+        create(:user, email: "matched@example.com", name: "Matched User")
+        client =
+          instance_double(
+            PatreonClient,
+            members: [
+              member(member_id: "m1", email: "matched@example.com"),
+              member(member_id: "m2", email: "unknown@example.com")
+            ]
+          )
+        allow(PatreonClient).to receive(:new).and_return(client)
+
+        get "/admins/patreon"
+
+        expect(response).to be_successful
+        expect(response.body).to include("matched@example.com")
+        expect(response.body).to include("unknown@example.com")
+        expect(response.body).to include("Matched User")
+      end
+    end
+  end
+end

--- a/spec/requests/admins/users_controller_spec.rb
+++ b/spec/requests/admins/users_controller_spec.rb
@@ -20,6 +20,40 @@ describe Admins::UsersController do
     end
   end
 
+  describe "#update" do
+    let(:user) { create(:user) }
+
+    it "requires authentication" do
+      put "/admins/users/#{user.id}", params: { user: { patron: true } }
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    context "signed in" do
+      before(:each) { sign_in(admin) }
+
+      it "pins the patron flag as manual when the admin changes it" do
+        put "/admins/users/#{user.id}", params: { user: { patron: true } }
+        user.reload
+        expect(user.patron).to be(true)
+        expect(user.patron_source).to eq("manual")
+      end
+
+      it "does not claim ownership when patron is unchanged" do
+        user.update!(patron: true, patron_source: "patreon")
+        put "/admins/users/#{user.id}",
+            params: {
+              user: {
+                patron: true,
+                auto_approve_ink_reviews: true
+              }
+            }
+        user.reload
+        expect(user.auto_approve_ink_reviews).to be(true)
+        expect(user.patron_source).to eq("patreon")
+      end
+    end
+  end
+
   describe "#ink_import" do
     include ActionDispatch::TestProcess
 

--- a/spec/workers/sync_patreon_patrons_spec.rb
+++ b/spec/workers/sync_patreon_patrons_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+describe SyncPatreonPatrons do
+  def member(member_id:, user_id: nil, email: nil, status: "active_patron", amount: 500)
+    PatreonClient::Member.new(
+      member_id: member_id,
+      user_id: user_id,
+      email: email,
+      status: status,
+      amount_cents: amount
+    )
+  end
+
+  def stub_members(members)
+    PatreonCredential.create!(access_token: "t", refresh_token: "r", expires_at: 1.hour.from_now)
+    client = instance_double(PatreonClient, members: members)
+    allow(PatreonClient).to receive(:new).and_return(client)
+  end
+
+  around do |example|
+    previous = ENV["PATREON_CAMPAIGN_ID"]
+    ENV["PATREON_CAMPAIGN_ID"] = "campaign-1"
+    example.run
+    ENV["PATREON_CAMPAIGN_ID"] = previous
+  end
+
+  it "grants patron status by email match" do
+    user = create(:user, email: "match@example.com", patron: false)
+    stub_members([member(member_id: "m1", user_id: "u1", email: "Match@Example.com")])
+
+    described_class.new.perform
+
+    user.reload
+    expect(user.patron).to be(true)
+    expect(user.patron_source).to eq("patreon")
+    expect(user.patreon_member_id).to eq("m1")
+    expect(user.patreon_user_id).to eq("u1")
+    expect(user.patreon_status).to eq("active_patron")
+    expect(user.patreon_synced_at).to be_present
+  end
+
+  it "grants by linked patreon_user_id even when the email differs" do
+    user = create(:user, email: "fpc@example.com", patreon_user_id: "u99", patron: false)
+    stub_members([member(member_id: "m1", user_id: "u99", email: "different@example.com")])
+
+    described_class.new.perform
+
+    expect(user.reload.patron).to be(true)
+  end
+
+  it "ignores members that do not match any user" do
+    create(:user, email: "someone@example.com", patron: false)
+    stub_members([member(member_id: "m1", user_id: "u1", email: "nobody@example.com")])
+
+    expect { described_class.new.perform }.not_to(change { User.where(patron: true).count })
+  end
+
+  it "leaves admin-pinned (manual) users untouched" do
+    user = create(:user, email: "manual@example.com", patron: true, patron_source: "manual")
+    stub_members([])
+
+    described_class.new.perform
+
+    user.reload
+    expect(user.patron).to be(true)
+    expect(user.patron_source).to eq("manual")
+  end
+
+  it "revokes patrons it previously granted once they are no longer active" do
+    user =
+      create(
+        :user,
+        email: "churned@example.com",
+        patron: true,
+        patron_source: "patreon",
+        patreon_member_id: "m1"
+      )
+    stub_members([]) # no active members this run
+
+    described_class.new.perform
+
+    user.reload
+    expect(user.patron).to be(false)
+    expect(user.patreon_status).to eq("former_patron")
+  end
+
+  it "never revokes legacy/unmanaged (NULL source) patrons" do
+    user = create(:user, email: "legacy@example.com", patron: true, patron_source: nil)
+    stub_members([])
+
+    described_class.new.perform
+
+    expect(user.reload.patron).to be(true)
+  end
+
+  it "treats declined or zero-pledge members as inactive" do
+    create(:user, email: "declined@example.com", patron: false)
+    stub_members(
+      [member(member_id: "m1", email: "declined@example.com", status: "declined_patron")]
+    )
+
+    described_class.new.perform
+
+    expect(User.find_by(email: "declined@example.com").patron).to be(false)
+  end
+
+  it "does nothing when no credential is configured" do
+    user = create(:user, email: "x@example.com", patron: false)
+    expect(PatreonClient).not_to receive(:new)
+
+    described_class.new.perform
+
+    expect(user.reload.patron).to be(false)
+  end
+end


### PR DESCRIPTION
## What

Automatically keeps the `patron` flag in sync with the Patreon campaign's active members, so paid Patrons get their user level set without manual admin work. This is **Option A** (email/identity matching, zero user action). Option B (let users link their Patreon account) lands in a follow-up PR and reuses this plumbing.

## How it works

A daily Sidekiq job (`SyncPatreonPatrons`) fetches the campaign members via the Patreon v2 API and matches each active member to an FPC user:

1. **`patreon_user_id`** — set when a user links their account (Option B). Authoritative; survives email changes on either side.
2. **email** — case-insensitive fallback for users who use the same address on both sides.

## Not stomping admin data

New `patron_source` column:

| value | meaning | sync behaviour |
|-------|---------|----------------|
| `NULL` | legacy / unmanaged | never auto-revoked |
| `manual` | admin pinned (set only when an admin actually changes the checkbox) | never auto-managed |
| `patreon` | granted by the sync | the **only** patrons the sync will auto-revoke on churn |

So the sync can only ever revoke patrons it granted itself. Manually comped patrons who aren't matchable on Patreon are safe.

## Admin reconciliation

New `Admins::Patreon` page (linked from the dashboard) lists active Patreon members and whether each matched an FPC user. Unmatched members (different email, not yet linked) are surfaced for manual handling — this is the safety net for the email-mismatch gap.

## Setup required before it does anything

- ENV: `PATREON_CAMPAIGN_ID`, `PATREON_CLIENT_ID`, `PATREON_CLIENT_SECRET`
- Seed one `PatreonCredential` row with the creator access/refresh tokens from the Patreon developer portal. Tokens auto-refresh (refresh tokens rotate, so they're persisted, not in ENV).

The job and admin page are no-ops until both are configured.