### PR TITLE
Group Patreon link under Users dropdown in admin header

### DIFF
--- a/app/views/admins/dashboards/show.html.slim
+++ b/app/views/admins/dashboards/show.html.slim
@@ -1,6 +1,3 @@
-p class="mb-3"
-  = link_to "Patreon reconciliation", admins_patreon_path, class: "btn btn-outline-secondary btn-sm"
-
 table class="table table-striped"
   thead
     th Name

--- a/app/views/admins/patreon/show.html.slim
+++ b/app/views/admins/patreon/show.html.slim
@@ -1,7 +1,5 @@
 - content_for :title, "Patreon reconciliation"
 
-h1 class="mb-4" Patreon reconciliation
-
 - unless @configured
   div class="alert alert-warning"
     | Patreon is not configured. Set the

--- a/app/views/layouts/admin/_header.html.slim
+++ b/app/views/layouts/admin/_header.html.slim
@@ -9,7 +9,11 @@ nav class="fpc-header navbar navbar-dark navbar-expand-md" id="header"
     div class="collapse navbar-collapse" id="header-menu"
       ul class="navbar-nav me-auto flex-grow-1 mb-2 mb-lg-0"
         li= link_to "Dashboard", admins_dashboard_path, class: "nav-link"
-        li= link_to "Users", admins_users_path, class: "nav-link"
+        li class="nav-item dropdown"
+          a href="#" class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" Users
+          ul class="dropdown-menu"
+            li= link_to "Users", admins_users_path, class: "dropdown-item"
+            li= link_to "Patreon", admins_patreon_path, class: "dropdown-item"
         li class="nav-item dropdown"
           a href="#" class="nav-link dropdown-toggle" role="button" data-bs-toggle="dropdown" aria-expanded="false" Inks
           ul class="dropdown-menu"


### PR DESCRIPTION
Makes the Patreon reconciliation page discoverable from the admin header.

- "Users" becomes a dropdown (matching the Inks/Pens pattern) containing **Users** (the list) and **Patreon** (reconciliation).
- Removes the standalone "Patreon reconciliation" button from the dashboard added in #3591 — the header dropdown replaces it.

Follow-up to #3591.