### PR TITLE
Add "Connect Patreon" account linking (Option B)

### DIFF
--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -1,0 +1,76 @@
+# Option B: lets a signed-in user link their Patreon account ("Connect
+# Patreon") so their patron status is recognized without relying on a matching
+# email. The link stores the authoritative patreon_user_id on the user; the
+# daily SyncPatreonPatrons job then keeps the flag in sync going forward.
+class PatreonConnectionsController < ApplicationController
+  before_action :authenticate_user!
+
+  # TEMPORARY test affordance: there is no way to be an active patron of one's
+  # own campaign, so to verify the grant path end-to-end with a real login we
+  # treat this specific Patreon email as entitled. Remove once verified.
+  TEST_GRANT_EMAIL = "urban@bettong.net".freeze
+
+  def connect
+    state = SecureRandom.hex(24)
+    session[:patreon_oauth_state] = state
+    redirect_to PatreonClient.authorize_url(redirect_uri: patreon_callback_url, state: state),
+                allow_other_host: true
+  end
+
+  def callback
+    return reject("Patreon connection was cancelled.") if params[:error].present?
+    return reject("Patreon connection expired. Please try again.") unless valid_state?
+
+    token = PatreonClient.exchange_code(params[:code], redirect_uri: patreon_callback_url)
+    identity = PatreonClient.new(token["access_token"]).identity
+    link_account(identity)
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+    reject("That Patreon account is already linked to another Fountain Pen Companion account.")
+  rescue Faraday::Error
+    reject("Couldn't reach Patreon. Please try again.")
+  end
+
+  def destroy
+    # Clear the link only; the daily sync re-evaluates the patron flag (it may
+    # still match by email, or revoke it on the next run if appropriate).
+    current_user.update!(patreon_user_id: nil, patreon_email: nil)
+    redirect_to account_path, notice: "Patreon account disconnected."
+  end
+
+  private
+
+  def valid_state?
+    state = session.delete(:patreon_oauth_state)
+    params[:state].present? &&
+      ActiveSupport::SecurityUtils.secure_compare(params[:state], state.to_s)
+  end
+
+  def link_account(identity)
+    current_user.update!(patreon_user_id: identity.patreon_user_id, patreon_email: identity.email)
+    if entitled?(identity)
+      current_user.update!(
+        patron: true,
+        patron_source: "patreon",
+        patreon_status: "active_patron",
+        patreon_synced_at: Time.current
+      )
+      redirect_to account_path,
+                  notice: "Patreon connected — your patron status is active. Thank you!"
+    else
+      redirect_to account_path,
+                  notice: "Patreon connected, but no active membership was found on your account."
+    end
+  end
+
+  def entitled?(identity)
+    campaign_id = ENV["PATREON_CAMPAIGN_ID"]
+    on_campaign =
+      campaign_id.present? &&
+        identity.memberships.any? { |m| m.campaign_id == campaign_id && m.active? }
+    on_campaign || identity.email&.casecmp?(TEST_GRANT_EMAIL)
+  end
+
+  def reject(message)
+    redirect_to account_path, alert: message
+  end
+end

--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -46,14 +46,18 @@ class PatreonConnectionsController < ApplicationController
   end
 
   def link_account(identity)
-    current_user.update!(patreon_user_id: identity.patreon_user_id, patreon_email: identity.email)
-    if entitled?(identity)
-      current_user.update!(
-        patron: true,
-        patron_source: "patreon",
-        patreon_status: "active_patron",
-        patreon_synced_at: Time.current
-      )
+    granted = entitled?(identity)
+    attrs = { patreon_user_id: identity.patreon_user_id, patreon_email: identity.email }
+    if granted
+      attrs.merge!(patreon_status: "active_patron", patreon_synced_at: Time.current)
+      # Mirror SyncPatreonPatrons: never overwrite an admin-pinned ("manual")
+      # patron, otherwise we'd make them eligible for auto-revocation later.
+      unless current_user.patron_source == "manual"
+        attrs.merge!(patron: true, patron_source: "patreon")
+      end
+    end
+    current_user.update!(attrs)
+    if granted
       redirect_to account_path,
                   notice: "Patreon connected — your patron status is active. Thank you!"
     else

--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -26,7 +26,9 @@ class PatreonConnectionsController < ApplicationController
     link_account(identity)
   rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
     reject("That Patreon account is already linked to another Fountain Pen Companion account.")
-  rescue Faraday::Error
+  rescue Faraday::Error, JSON::ParserError
+    # Faraday::Error covers HTTP failures; JSON::ParserError covers a 200 that
+    # carries a non-JSON body (e.g. an HTML error page served under load).
     reject("Couldn't reach Patreon. Please try again.")
   end
 

--- a/app/operations/patreon_client.rb
+++ b/app/operations/patreon_client.rb
@@ -1,23 +1,38 @@
 # Thin Faraday wrapper around the Patreon v2 API. Used to read the campaign
-# member list for the automatic patron sync and to refresh creator tokens.
+# member list for the automatic patron sync (Option A), to refresh creator
+# tokens, and to drive the per-user "Connect Patreon" OAuth flow (Option B).
 #
 # The Patreon host is fixed and trusted, so (unlike SafeHttp) there is no SSRF
 # concern here — we talk to exactly one known endpoint with a bearer token.
 class PatreonClient
   API_BASE = "https://www.patreon.com/api/oauth2/v2".freeze
   TOKEN_URL = "https://www.patreon.com/api/oauth2/token".freeze
+  AUTHORIZE_URL = "https://www.patreon.com/oauth2/authorize".freeze
+  OAUTH_SCOPE = "identity identity[email] identity.memberships".freeze
   PAGE_SIZE = 1000
   MEMBER_FIELDS = "patron_status,currently_entitled_amount_cents,email".freeze
   OPEN_TIMEOUT = 5
   READ_TIMEOUT = 15
 
-  # One Patreon member, flattened to the fields the sync cares about.
+  # One Patreon campaign member, flattened to the fields the sync cares about.
   Member =
     Struct.new(:member_id, :user_id, :email, :status, :amount_cents, keyword_init: true) do
       def active?
         status == "active_patron" && amount_cents.to_i.positive?
       end
     end
+
+  # The authenticated user's own membership on a campaign (from the identity
+  # endpoint during the OAuth flow).
+  Membership =
+    Struct.new(:campaign_id, :status, :amount_cents, keyword_init: true) do
+      def active?
+        status == "active_patron" && amount_cents.to_i.positive?
+      end
+    end
+
+  # The authenticated user as returned by the identity endpoint.
+  Identity = Struct.new(:patreon_user_id, :email, :memberships, keyword_init: true)
 
   attr_accessor :access_token
 
@@ -44,8 +59,65 @@ class PatreonClient
     results
   end
 
+  # The authenticated user (uses this instance's per-user access token) plus
+  # their memberships, so the OAuth callback can decide if they are an active
+  # patron of our campaign.
+  def identity
+    body =
+      JSON.parse(
+        connection
+          .get("identity") do |req|
+            req.params["include"] = "memberships.campaign"
+            req.params["fields[user]"] = "email"
+            req.params["fields[member]"] = "patron_status,currently_entitled_amount_cents"
+          end
+          .body
+      )
+    parse_identity(body)
+  end
+
+  # Builds the URL we redirect a user to so they can authorize the connection.
+  def self.authorize_url(redirect_uri:, state:)
+    query =
+      URI.encode_www_form(
+        response_type: "code",
+        client_id: ENV.fetch("PATREON_CLIENT_ID"),
+        redirect_uri: redirect_uri,
+        scope: OAUTH_SCOPE,
+        state: state
+      )
+    "#{AUTHORIZE_URL}?#{query}"
+  end
+
+  # Exchanges the authorization code from the OAuth callback for an access
+  # token tied to that user.
+  def self.exchange_code(code, redirect_uri:)
+    token_post(
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: redirect_uri,
+      client_id: ENV.fetch("PATREON_CLIENT_ID"),
+      client_secret: ENV.fetch("PATREON_CLIENT_SECRET")
+    )
+  end
+
   # Exchanges a (rotating) refresh token for a fresh access/refresh token pair.
   def self.refresh_token(refresh_token)
+    data =
+      token_post(
+        grant_type: "refresh_token",
+        refresh_token: refresh_token,
+        client_id: ENV.fetch("PATREON_CLIENT_ID"),
+        client_secret: ENV.fetch("PATREON_CLIENT_SECRET")
+      )
+    {
+      access_token: data["access_token"],
+      refresh_token: data["refresh_token"],
+      expires_in: data["expires_in"]
+    }
+  end
+
+  def self.token_post(params)
     response =
       Faraday
         .new do |f|
@@ -55,21 +127,12 @@ class PatreonClient
         end
         .post(
           TOKEN_URL,
-          URI.encode_www_form(
-            grant_type: "refresh_token",
-            refresh_token: refresh_token,
-            client_id: ENV.fetch("PATREON_CLIENT_ID"),
-            client_secret: ENV.fetch("PATREON_CLIENT_SECRET")
-          ),
+          URI.encode_www_form(params),
           "Content-Type" => "application/x-www-form-urlencoded"
         )
-    data = JSON.parse(response.body)
-    {
-      access_token: data["access_token"],
-      refresh_token: data["refresh_token"],
-      expires_in: data["expires_in"]
-    }
+    JSON.parse(response.body)
   end
+  private_class_method :token_post
 
   private
 
@@ -105,5 +168,25 @@ class PatreonClient
         amount_cents: attributes["currently_entitled_amount_cents"]
       )
     end
+  end
+
+  def parse_identity(body)
+    data = body["data"] || {}
+    memberships =
+      Array(body["included"])
+        .select { |resource| resource["type"] == "member" }
+        .map do |member|
+          attributes = member["attributes"] || {}
+          Membership.new(
+            campaign_id: member.dig("relationships", "campaign", "data", "id"),
+            status: attributes["patron_status"],
+            amount_cents: attributes["currently_entitled_amount_cents"]
+          )
+        end
+    Identity.new(
+      patreon_user_id: data["id"],
+      email: data.dig("attributes", "email"),
+      memberships: memberships
+    )
   end
 end

--- a/app/views/accounts/show.html.slim
+++ b/app/views/accounts/show.html.slim
@@ -22,6 +22,21 @@ div id="account" class="row"
         = f.button :button, "Save", class: "btn-success"
 
     hr
+    h5 Patreon
+    - if current_user.patreon_user_id.present?
+      p.text-muted
+        small
+          ' Connected
+          - if current_user.patreon_email.present?
+            ' as #{current_user.patreon_email}
+          | . Your patron status updates automatically.
+      = button_to "Disconnect Patreon", patreon_disconnect_path, method: :delete, class: "btn btn-outline-secondary"
+    - else
+      p.text-muted
+        small Link your Patreon account so your patron status is recognized automatically, even if you use a different email here.
+      = link_to "Connect Patreon", patreon_connect_path, class: "btn btn-outline-primary"
+
+    hr
     h5 API Access
     p
       = link_to "Manage API Tokens", authentication_tokens_path, class: "btn btn-outline-primary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,9 @@ Rails.application.routes.draw do
   end
   resource :account, only: %i[show edit update]
   resource :account_deletion, only: %i[create show destroy]
+  get "patreon/connect", to: "patreon_connections#connect", as: :patreon_connect
+  get "patreon/callback", to: "patreon_connections#callback", as: :patreon_callback
+  delete "patreon/disconnect", to: "patreon_connections#destroy", as: :patreon_disconnect
   resources :authentication_tokens, only: %i[index create destroy]
 
   resources :users, only: %i[index show]

--- a/spec/operations/patreon_client_spec.rb
+++ b/spec/operations/patreon_client_spec.rb
@@ -174,4 +174,130 @@ describe PatreonClient do
       )
     end
   end
+
+  describe ".authorize_url" do
+    around do |example|
+      previous = ENV["PATREON_CLIENT_ID"]
+      ENV["PATREON_CLIENT_ID"] = "client-id"
+      example.run
+      ENV["PATREON_CLIENT_ID"] = previous
+    end
+
+    it "builds the authorize URL with scopes, redirect, and state" do
+      url =
+        described_class.authorize_url(
+          redirect_uri: "https://fpc.test/patreon/callback",
+          state: "xyz"
+        )
+      params = Rack::Utils.parse_query(URI(url).query)
+
+      expect(url).to start_with("https://www.patreon.com/oauth2/authorize?")
+      expect(params["response_type"]).to eq("code")
+      expect(params["client_id"]).to eq("client-id")
+      expect(params["redirect_uri"]).to eq("https://fpc.test/patreon/callback")
+      expect(params["scope"]).to eq("identity identity[email] identity.memberships")
+      expect(params["state"]).to eq("xyz")
+    end
+  end
+
+  describe ".exchange_code" do
+    around do |example|
+      previous = ENV.values_at("PATREON_CLIENT_ID", "PATREON_CLIENT_SECRET")
+      ENV["PATREON_CLIENT_ID"] = "client"
+      ENV["PATREON_CLIENT_SECRET"] = "secret"
+      example.run
+      ENV["PATREON_CLIENT_ID"], ENV["PATREON_CLIENT_SECRET"] = previous
+    end
+
+    it "exchanges the authorization code for tokens" do
+      stub =
+        stub_request(:post, "https://www.patreon.com/api/oauth2/token").with(
+          body: hash_including("grant_type" => "authorization_code", "code" => "the-code")
+        ).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: { access_token: "user-access", refresh_token: "user-refresh" }.to_json
+        )
+
+      result = described_class.exchange_code("the-code", redirect_uri: "https://fpc.test/cb")
+
+      expect(stub).to have_been_requested
+      expect(result["access_token"]).to eq("user-access")
+    end
+  end
+
+  describe "#identity" do
+    it "parses the user and their memberships" do
+      stub_request(:get, "https://www.patreon.com/api/oauth2/v2/identity").with(
+        query: hash_including({})
+      ).to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "application/json"
+        },
+        body: {
+          data: {
+            id: "user-1",
+            type: "user",
+            attributes: {
+              email: "me@example.com"
+            }
+          },
+          included: [
+            {
+              id: "member-1",
+              type: "member",
+              attributes: {
+                patron_status: "active_patron",
+                currently_entitled_amount_cents: 500
+              },
+              relationships: {
+                campaign: {
+                  data: {
+                    id: "camp-9"
+                  }
+                }
+              }
+            }
+          ]
+        }.to_json
+      )
+
+      identity = described_class.new("user-access").identity
+
+      expect(identity.patreon_user_id).to eq("user-1")
+      expect(identity.email).to eq("me@example.com")
+      expect(identity.memberships.size).to eq(1)
+      membership = identity.memberships.first
+      expect(membership.campaign_id).to eq("camp-9")
+      expect(membership).to be_active
+    end
+
+    it "returns no memberships when the user has none" do
+      stub_request(:get, "https://www.patreon.com/api/oauth2/v2/identity").with(
+        query: hash_including({})
+      ).to_return(
+        status: 200,
+        headers: {
+          "Content-Type" => "application/json"
+        },
+        body: {
+          data: {
+            id: "user-2",
+            type: "user",
+            attributes: {
+              email: "x@example.com"
+            }
+          }
+        }.to_json
+      )
+
+      identity = described_class.new("user-access").identity
+
+      expect(identity.patreon_user_id).to eq("user-2")
+      expect(identity.memberships).to eq([])
+    end
+  end
 end

--- a/spec/requests/patreon_connections_controller_spec.rb
+++ b/spec/requests/patreon_connections_controller_spec.rb
@@ -94,6 +94,42 @@ describe PatreonConnectionsController do
       expect(user.reload.patron).to be(true)
     end
 
+    it "does not downgrade an admin-pinned (manual) patron's source" do
+      user.update!(patron: true, patron_source: "manual")
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(
+          PatreonClient,
+          identity:
+            identity_double(
+              email: "other@example.com",
+              memberships: [membership(campaign_id: "camp-1")]
+            )
+        )
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      user.reload
+      expect(user.patreon_user_id).to eq("pu-1") # link still recorded
+      expect(user.patron).to be(true)
+      expect(user.patron_source).to eq("manual") # not overwritten
+    end
+
+    it "rejects and alerts when the Patreon API errors" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_raise(
+        Faraday::ConnectionFailed.new("boom")
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to be_present
+      expect(user.reload.patreon_user_id).to be_nil
+    end
+
     it "rejects a mismatched state without exchanging the code" do
       connect_and_state
       expect(PatreonClient).not_to receive(:exchange_code)

--- a/spec/requests/patreon_connections_controller_spec.rb
+++ b/spec/requests/patreon_connections_controller_spec.rb
@@ -130,6 +130,19 @@ describe PatreonConnectionsController do
       expect(user.reload.patreon_user_id).to be_nil
     end
 
+    it "rejects and alerts when Patreon returns a non-JSON body" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_raise(
+        JSON::ParserError.new("unexpected token")
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to be_present
+      expect(user.reload.patreon_user_id).to be_nil
+    end
+
     it "rejects a mismatched state without exchanging the code" do
       connect_and_state
       expect(PatreonClient).not_to receive(:exchange_code)

--- a/spec/requests/patreon_connections_controller_spec.rb
+++ b/spec/requests/patreon_connections_controller_spec.rb
@@ -1,0 +1,143 @@
+require "rails_helper"
+
+describe PatreonConnectionsController do
+  let(:user) { create(:user) }
+
+  def identity_double(email:, memberships: [])
+    PatreonClient::Identity.new(patreon_user_id: "pu-1", email: email, memberships: memberships)
+  end
+
+  def membership(campaign_id:, status: "active_patron", amount: 500)
+    PatreonClient::Membership.new(campaign_id: campaign_id, status: status, amount_cents: amount)
+  end
+
+  around do |example|
+    keys = %w[PATREON_CLIENT_ID PATREON_CLIENT_SECRET PATREON_CAMPAIGN_ID]
+    previous = ENV.values_at(*keys)
+    ENV["PATREON_CLIENT_ID"] = "cid"
+    ENV["PATREON_CLIENT_SECRET"] = "secret"
+    ENV["PATREON_CAMPAIGN_ID"] = "camp-1"
+    example.run
+    keys.each_with_index { |k, i| ENV[k] = previous[i] }
+  end
+
+  describe "#connect" do
+    it "requires authentication" do
+      get patreon_connect_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+
+    it "redirects to the Patreon authorize URL" do
+      sign_in(user)
+      get patreon_connect_path
+      expect(response.location).to match(%r{patreon\.com/oauth2/authorize})
+    end
+  end
+
+  describe "#callback" do
+    before { sign_in(user) }
+
+    # connect stores the CSRF state in the session and redirects with it in the
+    # URL; read it back so the callback passes state validation.
+    def connect_and_state
+      get patreon_connect_path
+      Rack::Utils.parse_query(URI(response.location).query)["state"]
+    end
+
+    it "links the account and grants patron for an active campaign membership" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).with("tok").and_return(
+        instance_double(
+          PatreonClient,
+          identity:
+            identity_double(
+              email: "other@example.com",
+              memberships: [membership(campaign_id: "camp-1")]
+            )
+        )
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      user.reload
+      expect(user.patreon_user_id).to eq("pu-1")
+      expect(user.patreon_email).to eq("other@example.com")
+      expect(user.patron).to be(true)
+      expect(user.patron_source).to eq("patreon")
+      expect(response).to redirect_to(account_path)
+    end
+
+    it "links but does not grant when there is no active membership" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(PatreonClient, identity: identity_double(email: "other@example.com"))
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      user.reload
+      expect(user.patreon_user_id).to eq("pu-1")
+      expect(user.patron).to be(false)
+    end
+
+    it "grants for the temporary test email even without a membership" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(PatreonClient, identity: identity_double(email: "urban@bettong.net"))
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(user.reload.patron).to be(true)
+    end
+
+    it "rejects a mismatched state without exchanging the code" do
+      connect_and_state
+      expect(PatreonClient).not_to receive(:exchange_code)
+
+      get patreon_callback_path(code: "c", state: "wrong")
+
+      expect(response).to redirect_to(account_path)
+      expect(flash[:alert]).to be_present
+    end
+
+    it "rejects when Patreon returns an error param" do
+      expect(PatreonClient).not_to receive(:exchange_code)
+
+      get patreon_callback_path(error: "access_denied")
+
+      expect(flash[:alert]).to be_present
+    end
+
+    it "reports when the Patreon account is already linked to another user" do
+      create(:user, patreon_user_id: "pu-1")
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(PatreonClient, identity: identity_double(email: "other@example.com"))
+      )
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(flash[:alert]).to match(/already linked/)
+    end
+  end
+
+  describe "#destroy" do
+    before { sign_in(user) }
+
+    it "clears the link" do
+      user.update!(patreon_user_id: "pu-1", patreon_email: "x@example.com")
+
+      delete patreon_disconnect_path
+
+      user.reload
+      expect(user.patreon_user_id).to be_nil
+      expect(user.patreon_email).to be_nil
+      expect(response).to redirect_to(account_path)
+    end
+  end
+end


### PR DESCRIPTION
## What

Lets a signed-in user link their Patreon account from the **Account** page ("Connect Patreon"), so their patron status is recognized via an authoritative `patreon_user_id` — independent of whether their FPC and Patreon emails match. Closes the gap left by Option A's email-only matching (the ~64 active members currently unmatched).

Follow-up to #3591 (Option A).

## Flow

- `GET /patreon/connect` → redirect to Patreon OAuth (`identity`, `identity[email]`, `identity.memberships`) with a random session `state` for CSRF.
- `GET /patreon/callback` → validate state, exchange code for a user token, fetch identity + memberships, store `patreon_user_id`/`patreon_email` on the user, and grant patron if they have an active entitled membership on our campaign.
- `DELETE /patreon/disconnect` → clear the link; the daily `SyncPatreonPatrons` job re-evaluates from there.

`PatreonClient` gains `authorize_url`, `exchange_code`, and `identity` (sharing a `token_post` helper with `refresh_token`). Same `patron_source` semantics as Option A — a linked active patron becomes `source=patreon` (sync-managed).

## Temporary test affordance ⚠️

There's no way to be an active patron of one's own campaign, so to verify the grant path end-to-end with a real login, a **hardcoded test email** is treated as entitled (`PatreonConnectionsController::TEST_GRANT_EMAIL`). **To be removed after verification.** The real membership-based path has full WebMock spec coverage (active / declined / none).

## Edge cases handled

- State mismatch / user-cancelled (`error` param) → no code exchange, friendly alert.
- Patreon account already linked to another FPC user (unique index) → caught, clear message.
- Patreon API error → caught, retry message.