### PR TITLE
Remove temporary Patreon test-grant email hook

### DIFF
--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -5,11 +5,6 @@
 class PatreonConnectionsController < ApplicationController
   before_action :authenticate_user!
 
-  # TEMPORARY test affordance: there is no way to be an active patron of one's
-  # own campaign, so to verify the grant path end-to-end with a real login we
-  # treat this specific Patreon email as entitled. Remove once verified.
-  TEST_GRANT_EMAIL = "urban@bettong.net".freeze
-
   def connect
     state = SecureRandom.hex(24)
     session[:patreon_oauth_state] = state
@@ -70,10 +65,8 @@ class PatreonConnectionsController < ApplicationController
 
   def entitled?(identity)
     campaign_id = ENV["PATREON_CAMPAIGN_ID"]
-    on_campaign =
-      campaign_id.present? &&
-        identity.memberships.any? { |m| m.campaign_id == campaign_id && m.active? }
-    on_campaign || identity.email&.casecmp?(TEST_GRANT_EMAIL)
+    campaign_id.present? &&
+      identity.memberships.any? { |m| m.campaign_id == campaign_id && m.active? }
   end
 
   def reject(message)

--- a/spec/requests/patreon_connections_controller_spec.rb
+++ b/spec/requests/patreon_connections_controller_spec.rb
@@ -82,18 +82,6 @@ describe PatreonConnectionsController do
       expect(user.patron).to be(false)
     end
 
-    it "grants for the temporary test email even without a membership" do
-      state = connect_and_state
-      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
-      allow(PatreonClient).to receive(:new).and_return(
-        instance_double(PatreonClient, identity: identity_double(email: "urban@bettong.net"))
-      )
-
-      get patreon_callback_path(code: "c", state: state)
-
-      expect(user.reload.patron).to be(true)
-    end
-
     it "does not downgrade an admin-pinned (manual) patron's source" do
       user.update!(patron: true, patron_source: "manual")
       state = connect_and_state


### PR DESCRIPTION
Drops the `TEST_GRANT_EMAIL` affordance added in #3595. Account linking has been verified live (OAuth round-trip + `patreon_user_id` storage work); patron is now granted only for a genuine active membership on the campaign.

Follow-up to #3595.