### PR TITLE
Email the admin a Patreon badge-delivery to-do digest

### DIFF
--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -54,10 +54,10 @@ class PatreonConnectionsController < ApplicationController
       end
     end
     current_user.update!(attrs)
-    # Tell the admin to mark the badge benefit delivered (no-op unless this
-    # actually granted patron via Patreon and hasn't been reported yet).
-    PatreonBadgeReporter.call([current_user]) if granted
     if granted
+      # Tell the admin to mark the badge benefit delivered (no-op for an
+      # admin-pinned patron or one already reported).
+      PatreonBadgeReporter.new([current_user]).perform
       redirect_to account_path,
                   notice: "Patreon connected — your patron status is active. Thank you!"
     else

--- a/app/controllers/patreon_connections_controller.rb
+++ b/app/controllers/patreon_connections_controller.rb
@@ -54,6 +54,9 @@ class PatreonConnectionsController < ApplicationController
       end
     end
     current_user.update!(attrs)
+    # Tell the admin to mark the badge benefit delivered (no-op unless this
+    # actually granted patron via Patreon and hasn't been reported yet).
+    PatreonBadgeReporter.call([current_user]) if granted
     if granted
       redirect_to account_path,
                   notice: "Patreon connected — your patron status is active. Thank you!"

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,4 +3,12 @@ class AdminMailer < ApplicationMailer
     @body = body
     mail(to: "hello@fountainpencompanion.com", subject: subject)
   end
+
+  def patreon_badges_to_deliver(users)
+    @users = users
+    mail(
+      to: "hello@fountainpencompanion.com",
+      subject: "#{users.size} Patreon badge(s) to mark delivered"
+    )
+  end
 end

--- a/app/operations/patreon_badge_reporter.rb
+++ b/app/operations/patreon_badge_reporter.rb
@@ -6,9 +6,15 @@
 # stamped), via the nightly sync or immediately on manual connect. The flag is
 # reset when a patron is revoked, so a returning patron is reported again.
 class PatreonBadgeReporter
+  attr_accessor :users
+
   # Accepts users or a relation; reports only those that are confirmed Patreon
   # patrons not yet reported, so callers can pass a broad set safely.
-  def self.call(users)
+  def initialize(users)
+    self.users = users
+  end
+
+  def perform
     pending =
       Array(users).select do |user|
         user.patron? && user.patron_source == "patreon" && user.patreon_badge_reported_at.nil?

--- a/app/operations/patreon_badge_reporter.rb
+++ b/app/operations/patreon_badge_reporter.rb
@@ -22,6 +22,11 @@ class PatreonBadgeReporter
     return if pending.empty?
 
     AdminMailer.patreon_badges_to_deliver(pending).deliver_later
+    # Stamped on enqueue, so "report once" is really "at most once": if the
+    # mail job exhausts its retries the digest is lost and these patrons won't
+    # resurface (only a Patreon revoke resets the flag). Acceptable for an
+    # admin digest — a dropped email is low-stakes and the /admins/patreon
+    # reconciliation page is a backstop.
     User.where(id: pending.map(&:id)).update_all(patreon_badge_reported_at: Time.current)
   end
 end

--- a/app/operations/patreon_badge_reporter.rb
+++ b/app/operations/patreon_badge_reporter.rb
@@ -1,0 +1,21 @@
+# Emails the admin a digest of confirmed Patreon patrons whose "Add badge"
+# benefit still needs to be marked delivered in the Patreon dashboard.
+#
+# Patreon exposes no API to read or write per-member deliverable status, so we
+# track this on our side: a patron is reported once (patreon_badge_reported_at
+# stamped), via the nightly sync or immediately on manual connect. The flag is
+# reset when a patron is revoked, so a returning patron is reported again.
+class PatreonBadgeReporter
+  # Accepts users or a relation; reports only those that are confirmed Patreon
+  # patrons not yet reported, so callers can pass a broad set safely.
+  def self.call(users)
+    pending =
+      Array(users).select do |user|
+        user.patron? && user.patron_source == "patreon" && user.patreon_badge_reported_at.nil?
+      end
+    return if pending.empty?
+
+    AdminMailer.patreon_badges_to_deliver(pending).deliver_later
+    User.where(id: pending.map(&:id)).update_all(patreon_badge_reported_at: Time.current)
+  end
+end

--- a/app/views/admin_mailer/patreon_badges_to_deliver.html.erb
+++ b/app/views/admin_mailer/patreon_badges_to_deliver.html.erb
@@ -1,0 +1,26 @@
+<p style="margin: 0 0 16px; line-height: 1.6;">
+  Mark the &ldquo;Add badge&rdquo; benefit delivered in Patreon for these patrons:
+</p>
+
+<table cellpadding="6" cellspacing="0" border="0" style="border-collapse: collapse; line-height: 1.5;">
+  <thead>
+    <tr>
+      <th align="left" style="border-bottom: 1px solid #ccc;">Name</th>
+      <th align="left" style="border-bottom: 1px solid #ccc;">FPC email</th>
+      <th align="left" style="border-bottom: 1px solid #ccc;">Patreon email</th>
+      <th align="left" style="border-bottom: 1px solid #ccc;">Patreon user</th>
+      <th align="left" style="border-bottom: 1px solid #ccc;">FPC admin</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= user.name.presence || "(no name)" %></td>
+        <td><%= user.email %></td>
+        <td><%= user.patreon_email.presence || "(unknown)" %></td>
+        <td><%= user.patreon_user_id %></td>
+        <td><%= link_to "open", admins_user_url(user) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin_mailer/patreon_badges_to_deliver.text.erb
+++ b/app/views/admin_mailer/patreon_badges_to_deliver.text.erb
@@ -1,0 +1,9 @@
+Mark the "Add badge" benefit delivered in Patreon for these patrons:
+
+<% @users.each do |user| %>
+- <%= user.name.presence || "(no name)" %>
+  FPC email:     <%= user.email %>
+  Patreon email: <%= user.patreon_email.presence || "(unknown)" %>
+  Patreon user:  <%= user.patreon_user_id %>
+  FPC admin:     <%= admins_user_url(user) %>
+<% end %>

--- a/app/workers/sync_patreon_patrons.rb
+++ b/app/workers/sync_patreon_patrons.rb
@@ -61,9 +61,9 @@ class SyncPatreonPatrons
   # Email the admin the confirmed Patreon patrons whose "Add badge" benefit
   # still needs marking delivered (Patreon has no API for this).
   def report_pending_badges
-    PatreonBadgeReporter.call(
+    PatreonBadgeReporter.new(
       User.where(patron: true, patron_source: "patreon", patreon_badge_reported_at: nil)
-    )
+    ).perform
   end
 
   def client

--- a/app/workers/sync_patreon_patrons.rb
+++ b/app/workers/sync_patreon_patrons.rb
@@ -20,6 +20,7 @@ class SyncPatreonPatrons
     active_members = client.members(campaign_id).select(&:active?)
     matched_user_ids = grant(User.match_patreon_members(active_members))
     revoke_churned(matched_user_ids)
+    report_pending_badges
   end
 
   private
@@ -50,9 +51,19 @@ class SyncPatreonPatrons
         user.update!(
           patron: false,
           patreon_status: "former_patron",
-          patreon_synced_at: Time.current
+          patreon_synced_at: Time.current,
+          # so a returning patron is reported to the admin again
+          patreon_badge_reported_at: nil
         )
       end
+  end
+
+  # Email the admin the confirmed Patreon patrons whose "Add badge" benefit
+  # still needs marking delivered (Patreon has no API for this).
+  def report_pending_badges
+    PatreonBadgeReporter.call(
+      User.where(patron: true, patron_source: "patreon", patreon_badge_reported_at: nil)
+    )
   end
 
   def client

--- a/db/migrate/20260626130000_add_patreon_badge_reported_at_to_users.rb
+++ b/db/migrate/20260626130000_add_patreon_badge_reported_at_to_users.rb
@@ -1,0 +1,9 @@
+class AddPatreonBadgeReportedAtToUsers < ActiveRecord::Migration[8.1]
+  def change
+    # When we last emailed the admin to mark this patron's "Add badge" benefit
+    # delivered on Patreon. NULL = not yet reported (Patreon has no API to read
+    # or write deliverable status, so we track the to-do on our side). Reset to
+    # NULL when a patron is revoked so a returning patron is reported again.
+    add_column :users, :patreon_badge_reported_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1102,7 +1102,8 @@ CREATE TABLE public.users (
     patreon_email character varying,
     patreon_status character varying,
     patron_source character varying,
-    patreon_synced_at timestamp(6) without time zone
+    patreon_synced_at timestamp(6) without time zone,
+    patreon_badge_reported_at timestamp(6) without time zone
 );
 
 
@@ -2454,6 +2455,7 @@ ALTER TABLE ONLY public.collected_inks
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260626130000'),
 ('20260625120200'),
 ('20260625120100'),
 ('20260625120000'),

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe AdminMailer do
+  describe "#patreon_badges_to_deliver" do
+    let(:user) do
+      create(
+        :user,
+        name: "Pat Ron",
+        email: "pat@example.com",
+        patreon_user_id: "pu-42",
+        patreon_email: "pat@patreon.example"
+      )
+    end
+    let(:mail) { described_class.patreon_badges_to_deliver([user]) }
+
+    it "sends to the admin address" do
+      expect(mail.to).to eq(["hello@fountainpencompanion.com"])
+    end
+
+    it "puts the count in the subject" do
+      expect(mail.subject).to eq("1 Patreon badge(s) to mark delivered")
+    end
+
+    it "lists each patron's details" do
+      body = mail.body.encoded
+      expect(body).to include("Pat Ron")
+      expect(body).to include("pat@example.com")
+      expect(body).to include("pat@patreon.example")
+      expect(body).to include("pu-42")
+    end
+
+    it "mentions the benefit to mark delivered" do
+      expect(mail.body.encoded).to match(/Add badge/)
+    end
+  end
+end

--- a/spec/operations/patreon_badge_reporter_spec.rb
+++ b/spec/operations/patreon_badge_reporter_spec.rb
@@ -16,7 +16,7 @@ describe PatreonBadgeReporter do
       mailer
     end
 
-    described_class.call([user])
+    described_class.new([user]).perform
 
     expect(user.reload.patreon_badge_reported_at).to be_present
   end
@@ -27,7 +27,7 @@ describe PatreonBadgeReporter do
     not_patron = patron(patron: false, patron_source: "patreon")
     expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
 
-    described_class.call([manual, legacy, not_patron])
+    described_class.new([manual, legacy, not_patron]).perform
 
     expect(manual.reload.patreon_badge_reported_at).to be_nil
   end
@@ -36,7 +36,7 @@ describe PatreonBadgeReporter do
     reported = patron(patreon_badge_reported_at: 1.day.ago)
     expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
 
-    described_class.call([reported])
+    described_class.new([reported]).perform
   end
 
   it "reports only the pending users when given a mix" do
@@ -47,6 +47,6 @@ describe PatreonBadgeReporter do
       double(deliver_later: true)
     end
 
-    described_class.call([pending, reported])
+    described_class.new([pending, reported]).perform
   end
 end

--- a/spec/operations/patreon_badge_reporter_spec.rb
+++ b/spec/operations/patreon_badge_reporter_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe PatreonBadgeReporter do
+  def patron(**attrs)
+    create(
+      :user,
+      { patron: true, patron_source: "patreon", patreon_badge_reported_at: nil }.merge(attrs)
+    )
+  end
+
+  it "emails the admin and stamps reported_at for unreported patreon patrons" do
+    user = patron
+    mailer = double(deliver_later: true)
+    expect(AdminMailer).to receive(:patreon_badges_to_deliver) do |users|
+      expect(users.map(&:id)).to eq([user.id])
+      mailer
+    end
+
+    described_class.call([user])
+
+    expect(user.reload.patreon_badge_reported_at).to be_present
+  end
+
+  it "skips users that are not patreon-sourced patrons" do
+    manual = patron(patron_source: "manual")
+    legacy = patron(patron_source: nil)
+    not_patron = patron(patron: false, patron_source: "patreon")
+    expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
+
+    described_class.call([manual, legacy, not_patron])
+
+    expect(manual.reload.patreon_badge_reported_at).to be_nil
+  end
+
+  it "skips users already reported" do
+    reported = patron(patreon_badge_reported_at: 1.day.ago)
+    expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
+
+    described_class.call([reported])
+  end
+
+  it "reports only the pending users when given a mix" do
+    pending = patron
+    reported = patron(patreon_badge_reported_at: 1.day.ago)
+    expect(AdminMailer).to receive(:patreon_badges_to_deliver) do |users|
+      expect(users.map(&:id)).to eq([pending.id])
+      double(deliver_later: true)
+    end
+
+    described_class.call([pending, reported])
+  end
+end

--- a/spec/requests/patreon_connections_controller_spec.rb
+++ b/spec/requests/patreon_connections_controller_spec.rb
@@ -21,6 +21,12 @@ describe PatreonConnectionsController do
     keys.each_with_index { |k, i| ENV[k] = previous[i] }
   end
 
+  before do
+    allow(AdminMailer).to receive(:patreon_badges_to_deliver).and_return(
+      double(deliver_later: true)
+    )
+  end
+
   describe "#connect" do
     it "requires authentication" do
       get patreon_connect_path
@@ -80,6 +86,42 @@ describe PatreonConnectionsController do
       user.reload
       expect(user.patreon_user_id).to eq("pu-1")
       expect(user.patron).to be(false)
+    end
+
+    it "reports the newly connected patron to the admin and stamps them" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(
+          PatreonClient,
+          identity:
+            identity_double(
+              email: "other@example.com",
+              memberships: [membership(campaign_id: "camp-1")]
+            )
+        )
+      )
+      expect(AdminMailer).to receive(:patreon_badges_to_deliver) do |users|
+        expect(users.map(&:id)).to eq([user.id])
+        double(deliver_later: true)
+      end
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(user.reload.patreon_badge_reported_at).to be_present
+    end
+
+    it "does not report when no active membership is found" do
+      state = connect_and_state
+      allow(PatreonClient).to receive(:exchange_code).and_return("access_token" => "tok")
+      allow(PatreonClient).to receive(:new).and_return(
+        instance_double(PatreonClient, identity: identity_double(email: "other@example.com"))
+      )
+      expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
+
+      get patreon_callback_path(code: "c", state: state)
+
+      expect(user.reload.patreon_badge_reported_at).to be_nil
     end
 
     it "does not downgrade an admin-pinned (manual) patron's source" do

--- a/spec/workers/sync_patreon_patrons_spec.rb
+++ b/spec/workers/sync_patreon_patrons_spec.rb
@@ -24,6 +24,12 @@ describe SyncPatreonPatrons do
     ENV["PATREON_CAMPAIGN_ID"] = previous
   end
 
+  before do
+    allow(AdminMailer).to receive(:patreon_badges_to_deliver).and_return(
+      double(deliver_later: true)
+    )
+  end
+
   it "grants patron status by email match" do
     user = create(:user, email: "match@example.com", patron: false)
     stub_members([member(member_id: "m1", user_id: "u1", email: "Match@Example.com")])
@@ -111,5 +117,52 @@ describe SyncPatreonPatrons do
     described_class.new.perform
 
     expect(user.reload.patron).to be(false)
+  end
+
+  it "reports newly confirmed patrons to the admin and stamps them" do
+    user = create(:user, email: "new@example.com", patron: false)
+    stub_members([member(member_id: "m1", user_id: "u1", email: "new@example.com")])
+    expect(AdminMailer).to receive(:patreon_badges_to_deliver) do |users|
+      expect(users.map(&:id)).to include(user.id)
+      double(deliver_later: true)
+    end
+
+    described_class.new.perform
+
+    expect(user.reload.patreon_badge_reported_at).to be_present
+  end
+
+  it "does not re-report patrons already reported" do
+    create(
+      :user,
+      email: "known@example.com",
+      patron: true,
+      patron_source: "patreon",
+      patreon_user_id: "u1",
+      patreon_badge_reported_at: 1.day.ago
+    )
+    stub_members([member(member_id: "m1", user_id: "u1", email: "known@example.com")])
+    expect(AdminMailer).not_to receive(:patreon_badges_to_deliver)
+
+    described_class.new.perform
+  end
+
+  it "resets the badge report flag when revoking a patron" do
+    user =
+      create(
+        :user,
+        email: "churned@example.com",
+        patron: true,
+        patron_source: "patreon",
+        patreon_member_id: "m1",
+        patreon_badge_reported_at: 1.day.ago
+      )
+    stub_members([])
+
+    described_class.new.perform
+
+    user.reload
+    expect(user.patron).to be(false)
+    expect(user.patreon_badge_reported_at).to be_nil
   end
 end


### PR DESCRIPTION
## What

Patreon exposes **no API** to read or write per-member benefit deliverable status, so the "Add badge" benefit has to be marked delivered by hand in the creator dashboard. This emails the admin the list of patrons that still need ticking — tracked on our side so each patron is reported **once**.

Follow-up to #3591 / #3595.

## How

- New `users.patreon_badge_reported_at`. NULL = not yet reported; reset to NULL on revoke so a returning patron is reported again.
- `PatreonBadgeReporter.call(users)` emails + stamps only **confirmed, not-yet-reported** patrons (`patron && patron_source == "patreon"`) — skips manual/legacy.
- **Nightly:** `SyncPatreonPatrons` reports the pending set at the end of the run.
- **On connect:** the OAuth callback reports the patron immediately when linking grants patron.
- `AdminMailer#patreon_badges_to_deliver` lists name, FPC email, Patreon email, `patreon_user_id`, and an admin link per patron, and says to mark the "Add badge" benefit delivered.

## Heads up

The **first nightly run emails the full current backlog** of `source=patreon` patrons (~230, none reported yet), then shrinks to just new ones. One-time.

## Why on-our-side tracking

The API can't tell us which deliverables are already marked delivered (members endpoint can't include deliverables; benefits expose only aggregate counts; no list-deliverables endpoint). So we can't filter on Patreon's "not delivered" — `patreon_badge_reported_at` is the dedupe instead.