### PR TITLE
Sync public inks table filters to URL query params

### DIFF
--- a/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
+++ b/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
@@ -82,4 +82,47 @@ describe("Table component", () => {
     expect(within(table).getByText("Brand")).toBeInTheDocument();
     expect(within(table).getByText("Ink")).toBeInTheDocument();
   });
+
+  describe("URL filter sync", () => {
+    afterEach(() => {
+      window.history.replaceState(null, "", "/users/1");
+    });
+
+    it("initializes filters from known query params and ignores unknown ones", () => {
+      window.history.replaceState(null, "", "/users/1?kind=sample&utm_source=foo");
+      const instance = new Table({});
+      expect(instance.state.filtered).toEqual([{ id: "kind", value: "sample" }]);
+    });
+
+    it("starts with no filters when no query params are present", () => {
+      window.history.replaceState(null, "", "/users/1");
+      const instance = new Table({});
+      expect(instance.state.filtered).toEqual([]);
+    });
+
+    it("writes active filters to the URL and drops 'all' and empty values", () => {
+      window.history.replaceState(null, "", "/users/1?utm_source=foo");
+      const instance = new Table({});
+      instance.setState = jest.fn();
+      instance.onFilteredChange([
+        { id: "kind", value: "bottle" },
+        { id: "comparison", value: "all" },
+        { id: "brand_name", value: "" }
+      ]);
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get("kind")).toEqual("bottle");
+      expect(params.has("comparison")).toBe(false);
+      expect(params.has("brand_name")).toBe(false);
+      // preserves unrelated query params
+      expect(params.get("utm_source")).toEqual("foo");
+    });
+
+    it("clears a filter param when its value is reset", () => {
+      window.history.replaceState(null, "", "/users/1?kind=sample");
+      const instance = new Table({});
+      instance.setState = jest.fn();
+      instance.onFilteredChange([]);
+      expect(window.location.search).toEqual("");
+    });
+  });
 });

--- a/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
+++ b/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
@@ -137,6 +137,19 @@ describe("Table component", () => {
       expect(params.get("kind")).toEqual("bottle");
     });
 
+    it("applies a kind filter from the URL without crashing on null-kind rows", async () => {
+      window.history.replaceState(null, "", "/users/1?kind=sample");
+      const mixedData = [
+        { ...data[0], ink_id: 1, ink_name: "InkA", kind: "sample" },
+        { ...data[0], ink_id: 2, ink_name: "InkB", kind: null }
+      ];
+      render(<Table data={mixedData} additionalData={true} name="Test User" />);
+      const table = await screen.findByRole("grid");
+      // matching row shown, null-kind row filtered out, no TypeError thrown
+      expect(within(table).getByText("InkA")).toBeInTheDocument();
+      expect(within(table).queryByText("InkB")).not.toBeInTheDocument();
+    });
+
     it("clears a filter param when its value is reset", () => {
       window.history.replaceState(null, "", "/users/1?kind=sample");
       const instance = new Table({});

--- a/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
+++ b/app/javascript/src/public_inks/__tests__/public_inks.spec.jsx
@@ -117,6 +117,26 @@ describe("Table component", () => {
       expect(params.get("utm_source")).toEqual("foo");
     });
 
+    it("never syncs the viewer-relative comparison filter to the URL", () => {
+      window.history.replaceState(null, "", "/users/1?comparison=you");
+      const instance = new Table({});
+      // a hand-crafted ?comparison value is not restored as a filter
+      expect(instance.state.filtered).toEqual([]);
+    });
+
+    it("does not write the comparison filter to the URL", () => {
+      window.history.replaceState(null, "", "/users/1");
+      const instance = new Table({});
+      instance.setState = jest.fn();
+      instance.onFilteredChange([
+        { id: "comparison", value: "you" },
+        { id: "kind", value: "bottle" }
+      ]);
+      const params = new URLSearchParams(window.location.search);
+      expect(params.has("comparison")).toBe(false);
+      expect(params.get("kind")).toEqual("bottle");
+    });
+
     it("clears a filter param when its value is reset", () => {
       window.history.replaceState(null, "", "/users/1?kind=sample");
       const instance = new Table({});

--- a/app/javascript/src/public_inks/table.jsx
+++ b/app/javascript/src/public_inks/table.jsx
@@ -5,8 +5,33 @@ import ReactTable from "react-table-6";
 export default class Table extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = { filtered: this.filtersFromUrl() };
   }
+
+  filterableIds() {
+    return ["comparison", "brand_name", "line_name", "ink_name", "maker", "kind", "comment"];
+  }
+
+  filtersFromUrl() {
+    let params = new URLSearchParams(window.location.search);
+    let allowed = this.filterableIds();
+    return allowed.filter((id) => params.has(id)).map((id) => ({ id, value: params.get(id) }));
+  }
+
+  onFilteredChange = (filtered) => {
+    this.setState({ filtered });
+    let params = new URLSearchParams(window.location.search);
+    let allowed = this.filterableIds();
+    allowed.forEach((id) => params.delete(id));
+    filtered.forEach(({ id, value }) => {
+      if (allowed.includes(id) && value && value !== "all") {
+        params.set(id, value);
+      }
+    });
+    let query = params.toString();
+    let url = query ? `${window.location.pathname}?${query}` : window.location.pathname;
+    window.history.replaceState(null, "", url);
+  };
 
   calculateWidth = () => {
     this.setState({ width: window.innerWidth });
@@ -199,7 +224,9 @@ export default class Table extends React.Component {
         return rowData.match(new RegExp(searchData, "i"));
       },
       defaultSorted: [{ id: "brand_name" }, { id: "line_name" }, { id: "ink_name" }],
-      filterable: true
+      filterable: true,
+      filtered: this.state.filtered,
+      onFilteredChange: this.onFilteredChange
     };
     let hidden = this.hiddenColumns();
     if (hidden.length) {

--- a/app/javascript/src/public_inks/table.jsx
+++ b/app/javascript/src/public_inks/table.jsx
@@ -9,7 +9,9 @@ export default class Table extends React.Component {
   }
 
   filterableIds() {
-    return ["comparison", "brand_name", "line_name", "ink_name", "maker", "kind", "comment"];
+    // "comparison" is intentionally excluded: its values are relative to the
+    // logged-in viewer, so it isn't a meaningful shareable/bookmarkable filter.
+    return ["brand_name", "line_name", "ink_name", "maker", "kind", "comment"];
   }
 
   filtersFromUrl() {

--- a/app/javascript/src/public_inks/table.jsx
+++ b/app/javascript/src/public_inks/table.jsx
@@ -221,7 +221,7 @@ export default class Table extends React.Component {
       columns: this.columnConfig(),
       data: this.props.data,
       defaultFilterMethod: (filter, row) => {
-        let rowData = row[filter.id].replace(/\W/g, "");
+        let rowData = (row[filter.id] || "").replace(/\W/g, "");
         let searchData = filter.value.replace(/\W/g, "");
         return rowData.match(new RegExp(searchData, "i"));
       },


### PR DESCRIPTION
Filter selections on the public user inks table were in-memory only, so a filtered view (e.g. inks of a given type) couldn't be shared or bookmarked. Active filters are now persisted to the URL query string and restored on load, enabling links like `/users/1?kind=sample`. Uses `replaceState` so filtering doesn't pollute back-button history; unknown query params are ignored.