### PR TITLE
Clarify ReviewApprover directive around System submissions

### DIFF
--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -78,18 +78,31 @@ class ReviewApprover
 
   SYSTEM_DIRECTIVE = <<~TEXT
     Your task is to check if the given data is a review of the ink specified or not.
-    At then end you can either approve or reject the review.
+    At the end you MUST call exactly one of `approve_review` or `reject_review` — never
+    both. Your `explanation_of_decision` must match the tool you call: do not call
+    `reject_review` while arguing for approval, or vice versa.
+
+    Apply these rules in order:
 
     * Reject reviews that are not related to the ink.
-    * Approve reviews that are related to the ink.
     * Reject reviews that are instagram posts.
     * Reject reviews that are unboxing, currently inked, or live videos or blog posts
-      UNLESS the ink in question has no reviews at all.
-    * For YouTube videos that are not shorts, approve the review if it is related to the ink.
-    * For YouTube videos that are shorts, approve the review if it is related to the ink AND there are no reviews for the ink, yet.
-    * Before rejecting a review that was not submitted by "System", double check with the `summarize` function
-      that the ink does not appear in the review, after all.
-    * Reviews that are not submitted by user "System" have a higher likelihood of being correct.
+      UNLESS the ink has no reviews at all (`number_of_reviews` is 0).
+    * For YouTube videos that are NOT shorts, approve the review if it is related to the ink.
+    * For YouTube videos that ARE shorts, approve the review if it is related to the ink AND
+      the ink has no reviews yet (`number_of_reviews` is 0); otherwise reject it.
+    * Otherwise, approve reviews that are related to the ink.
+
+    About who submitted the review (the `user` field):
+
+    * `user` is "System" when the review was found and submitted automatically by our
+      review-finding agent. Any other value is a real, human submitter.
+    * Who submitted the review does NOT change the rules above — apply them identically
+      regardless of the `user` value. In particular, a "System" submission is NOT a reason
+      to reject a review that the rules above say to approve.
+    * One exception: before rejecting a review submitted by a human (`user` is not "System")
+      as unrelated, first call the `summarize` function to double check that the ink does
+      not appear in the review, after all.
 
     For both web pages and Youtube videos you can call the `summarize` function to get a summary.
     For Youtube videos the summary draws on the video's captions (when available) and thumbnail.


### PR DESCRIPTION
## Problem

The second-level ink reviewer (`ReviewApprover`) was getting confused by how automated reviews are labeled. Reviews found and submitted automatically by the first-level `ReviewFinder` agent are passed to the model with `user: "System"`. The directive said non-System reviews "have a higher likelihood of being correct" and only described a double-check step for non-System reviews — giving the model a vague reliability prior that biased it toward rejecting System submissions.

On a clear-cut approval (a YouTube short for an ink with zero prior reviews, which the rules say to approve), the model talked itself into approving in prose but fired `reject_review`, producing a reject action with an explanation that argued for approval.

## Change

Rewrote `SYSTEM_DIRECTIVE`:

- Rules are now ordered, hard rules first, and reference the concrete `number_of_reviews` field instead of "no reviews at all".
- Requires calling exactly one tool with an explanation that matches it — no more reject-tool-with-approve-prose mismatch.
- New section defining `user: "System"` as auto-submitted by the review-finding agent, stating the submitter does NOT change the decision and a System submission is not a reason to reject.
- Kept the human-review summarize double-check as the lone exception.
- Fixed an "At then end" typo.

Existing `review_approver_spec.rb` passes (51 examples, 0 failures).