### PR TITLE
Prevent duplicate enqueueing of ink review checks

### DIFF
--- a/app/workers/enqueue_ink_review_checks.rb
+++ b/app/workers/enqueue_ink_review_checks.rb
@@ -7,11 +7,20 @@ class EnqueueInkReviewChecks
   STAGGER_INTERVAL = 36 # seconds between enqueued jobs (~1 hour for full batch)
 
   def perform
-    InkReview
-      .due_for_check
-      .order(:next_check_at)
-      .limit(BATCH_SIZE)
-      .pluck(:id)
-      .each_with_index { |id, i| CheckInkReview.perform_in((i * STAGGER_INTERVAL).seconds, id) }
+    ids = InkReview.due_for_check.order(:next_check_at).limit(BATCH_SIZE).pluck(:id)
+
+    # Claim the batch by pushing next_check_at past the stagger window so a
+    # subsequent run (this worker is scheduled more often than the batch takes
+    # to drain) does not re-enqueue reviews that are still in flight. The real
+    # next_check_at is set by InkReviewChecker once each check actually runs.
+    InkReview.where(id: ids).update_all(next_check_at: claim_until)
+
+    ids.each_with_index { |id, i| CheckInkReview.perform_in((i * STAGGER_INTERVAL).seconds, id) }
+  end
+
+  private
+
+  def claim_until
+    (BATCH_SIZE * STAGGER_INTERVAL).seconds.from_now
   end
 end

--- a/spec/workers/enqueue_ink_review_checks_spec.rb
+++ b/spec/workers/enqueue_ink_review_checks_spec.rb
@@ -33,6 +33,19 @@ describe EnqueueInkReviewChecks do
     expect(jobs[2]["at"] - now).to be_within(2).of(EnqueueInkReviewChecks::STAGGER_INTERVAL * 2)
   end
 
+  it "claims enqueued reviews by pushing next_check_at past the stagger window" do
+    due = create(:ink_review, approved_at: Time.now, next_check_at: 1.hour.ago)
+    span = EnqueueInkReviewChecks::BATCH_SIZE * EnqueueInkReviewChecks::STAGGER_INTERVAL
+    subject.perform
+    expect(due.reload.next_check_at).to be_within(5.seconds).of(span.seconds.from_now)
+  end
+
+  it "does not re-enqueue in-flight reviews on a subsequent run" do
+    create(:ink_review, approved_at: Time.now, next_check_at: 1.hour.ago)
+    subject.perform
+    expect { subject.perform }.not_to change(CheckInkReview.jobs, :length)
+  end
+
   it "processes oldest-due reviews first" do
     older = create(:ink_review, approved_at: Time.now, next_check_at: 2.days.ago)
     newer = create(:ink_review, approved_at: Time.now, next_check_at: 1.hour.ago)


### PR DESCRIPTION
`EnqueueInkReviewChecks` runs every 15 minutes but staggers a 100-job batch over ~1 hour, and `next_check_at` only advances once each `CheckInkReview` actually runs — so reviews still scheduled in the stagger window stayed `due_for_check` and got re-enqueued (and re-checked) up to 4× per hour. This claims the batch by pushing `next_check_at` past the stagger window when scheduling; `InkReviewChecker` overwrites it with the real value once the check runs.