### PR TITLE
Stagger review fetching to smooth DB load

### DIFF
--- a/app/workers/fetch_reviews.rb
+++ b/app/workers/fetch_reviews.rb
@@ -1,9 +1,18 @@
 class FetchReviews
   include Sidekiq::Worker
 
+  STAGGER_INTERVAL = 30 # seconds between enqueued source jobs
+
   def perform
-    feeds.each { |url| FetchReviews::GenericRss.perform_async(url) }
-    youtube_channels.each { |channel_id| FetchReviews::YoutubeChannel.perform_async(channel_id) }
+    jobs = feeds.map { |url| [FetchReviews::GenericRss, url] }
+    jobs += youtube_channels.map { |channel_id| [FetchReviews::YoutubeChannel, channel_id] }
+
+    # Spread the per-source jobs out instead of enqueueing them all at once. Each
+    # source can fan out into embedding-heavy ProcessWebPageForReview work, so
+    # bunching them at the top of the hour is what spikes the DB.
+    jobs.each_with_index do |(worker, arg), i|
+      worker.perform_in((i * STAGGER_INTERVAL).seconds, arg)
+    end
   end
 
   private

--- a/app/workers/fetch_reviews/process_web_page_for_review.rb
+++ b/app/workers/fetch_reviews/process_web_page_for_review.rb
@@ -3,7 +3,11 @@ class FetchReviews
     include Sidekiq::Worker
     include Sidekiq::Throttled::Worker
 
-    sidekiq_throttle concurrency: { limit: 1 }
+    # ReviewFinder runs the non-performant MacroCluster.embedding_search (three
+    # pgvector scans over every ink embedding). Cap concurrency at 1 and rate
+    # limit so these heavy scans space out over time rather than running
+    # back-to-back when a fetch fans out many pages at once.
+    sidekiq_throttle concurrency: { limit: 1 }, threshold: { limit: 1, period: 30 }
     sidekiq_options queue: "reviews"
 
     def perform(page_id)

--- a/spec/workers/fetch_reviews_spec.rb
+++ b/spec/workers/fetch_reviews_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe FetchReviews do
+  it "enqueues a GenericRss job per feed and a YoutubeChannel job per channel" do
+    channel = create(:you_tube_channel)
+    allow(YouTubeChannel).to receive(:channel_ids_for_reviews).and_return([channel.channel_id])
+
+    subject.perform
+
+    rss_args = FetchReviews::GenericRss.jobs.map { |j| j["args"] }
+    expect(rss_args.length).to eq(13)
+    expect(FetchReviews::YoutubeChannel.jobs.map { |j| j["args"] }).to eq([[channel.channel_id]])
+  end
+
+  it "staggers the source jobs by STAGGER_INTERVAL seconds" do
+    channel = create(:you_tube_channel)
+    allow(YouTubeChannel).to receive(:channel_ids_for_reviews).and_return([channel.channel_id])
+
+    subject.perform
+
+    now = Time.now.to_f
+    interval = FetchReviews::STAGGER_INTERVAL
+    rss_jobs = FetchReviews::GenericRss.jobs
+    expect(rss_jobs.first["at"]).to be_nil # first feed runs immediately
+    expect(rss_jobs.last["at"] - now).to be_within(2).of(interval * 12) # 13th feed
+
+    # YouTube channels are staggered after the feeds
+    yt_job = FetchReviews::YoutubeChannel.jobs.first
+    expect(yt_job["at"] - now).to be_within(2).of(interval * 13)
+  end
+end


### PR DESCRIPTION
The DB spikes at the top of every hour because `FetchReviews` enqueues all feed and YouTube-channel jobs at once, each fanning out into `ProcessWebPageForReview` jobs that run the non-performant `MacroCluster.embedding_search` (three pgvector scans over every ink embedding). This spreads the per-source jobs out and adds a rate threshold to `ProcessWebPageForReview` so those heavy scans space out over time instead of bunching. This is a load-smoothing first step; the `embedding_search` query itself is still the underlying cost and worth optimizing separately.