### PR TITLE
Skip LLM clustering for blacklisted ink brands

### DIFF
--- a/app/workers/update_micro_cluster.rb
+++ b/app/workers/update_micro_cluster.rb
@@ -1,12 +1,20 @@
 class UpdateMicroCluster
   include Sidekiq::Worker
 
+  # Simplified brand names that are never enqueued for clustering from this
+  # worker, e.g. brands that are really a single user's own ink mixes. The
+  # blacklist wins over admin actions: unignoring or unassigning such a micro
+  # cluster ignores it again rather than sending it back to the clusterer.
+  IGNORED_BRANDS = %w[sirius].freeze
+
   def perform(id)
     cluster = MicroCluster.find(id)
     return if cluster.ignored?
 
     if cluster.macro_cluster_id
       UpdateMacroCluster.perform_async(cluster.macro_cluster_id)
+    elsif IGNORED_BRANDS.include?(cluster.simplified_brand_name)
+      cluster.update!(ignored: true)
     else
       RunInkClustererAgent.perform_in(InkClusterer::DEBOUNCE_WINDOW, "InkClusterer", cluster.id)
     end

--- a/spec/workers/update_micro_cluster_spec.rb
+++ b/spec/workers/update_micro_cluster_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+describe UpdateMicroCluster do
+  let(:ignored_brand) { described_class::IGNORED_BRANDS.first }
+
+  it "updates the macro cluster when the micro cluster is assigned" do
+    macro_cluster = create(:macro_cluster)
+    micro_cluster = create(:micro_cluster, macro_cluster: macro_cluster)
+    Sidekiq::Worker.clear_all
+
+    described_class.new.perform(micro_cluster.id)
+
+    expect(UpdateMacroCluster.jobs.map { |job| job["args"] }).to eq([[macro_cluster.id]])
+    expect(RunInkClustererAgent.jobs).to be_empty
+  end
+
+  it "runs the clusterer for an unassigned micro cluster" do
+    micro_cluster = create(:micro_cluster)
+
+    described_class.new.perform(micro_cluster.id)
+
+    expect(RunInkClustererAgent.jobs.map { |job| job["args"] }).to eq(
+      [["InkClusterer", micro_cluster.id]]
+    )
+    expect(micro_cluster.reload).not_to be_ignored
+  end
+
+  it "does nothing for an already ignored micro cluster" do
+    micro_cluster = create(:micro_cluster, ignored: true)
+
+    described_class.new.perform(micro_cluster.id)
+
+    expect(RunInkClustererAgent.jobs).to be_empty
+    expect(UpdateMacroCluster.jobs).to be_empty
+  end
+
+  context "with a micro cluster of an ignored brand" do
+    it "ignores the micro cluster instead of running the clusterer" do
+      micro_cluster = create(:micro_cluster, simplified_brand_name: ignored_brand)
+
+      described_class.new.perform(micro_cluster.id)
+
+      expect(micro_cluster.reload).to be_ignored
+      expect(RunInkClustererAgent.jobs).to be_empty
+    end
+
+    it "ignores it again after an admin has unignored it" do
+      micro_cluster = create(:micro_cluster, simplified_brand_name: ignored_brand, ignored: false)
+      micro_cluster.agent_logs.create!(
+        name: "InkClusterer",
+        state: AgentLog::REJECTED,
+        transcript: [],
+        extra_data: {
+          action: "ignore_ink"
+        }
+      )
+
+      described_class.new.perform(micro_cluster.id)
+
+      expect(micro_cluster.reload).to be_ignored
+      expect(RunInkClustererAgent.jobs).to be_empty
+    end
+
+    it "leaves a micro cluster that is already assigned to a macro cluster alone" do
+      macro_cluster = create(:macro_cluster)
+      micro_cluster =
+        create(:micro_cluster, simplified_brand_name: ignored_brand, macro_cluster: macro_cluster)
+      Sidekiq::Worker.clear_all
+
+      described_class.new.perform(micro_cluster.id)
+
+      expect(micro_cluster.reload).not_to be_ignored
+      expect(UpdateMacroCluster.jobs.map { |job| job["args"] }).to eq([[macro_cluster.id]])
+    end
+  end
+end


### PR DESCRIPTION
One user keeps adding their own homemade "Sirius" ink mixes, and each one spawns a micro cluster that gets handed to the LLM clusterer even though it can never be clustered — clogging the queue. A brand blacklist in `UpdateMicroCluster` marks those micro clusters as ignored instead. The blacklist deliberately wins over admin actions: unignoring or unassigning such a cluster ignores it again rather than sending it back to the clusterer.