### PR TITLE
Resolve thumbnail URL before attaching it in ReviewApprover

### DIFF
--- a/app/agents/review_approver.rb
+++ b/app/agents/review_approver.rb
@@ -112,9 +112,9 @@ class ReviewApprover
     `summarize` — call it for borderline cases or when `has_captions` is true and you want the
     transcript-derived content.
 
-    A thumbnail image of the video or page is attached to this message. Use it to confirm the ink
-    identity when the text is ambiguous — many ink-review thumbnails show the ink bottle and/or the
-    ink name as a text overlay.
+    When available, a thumbnail image of the video or page is attached to this message. Use it to
+    confirm the ink identity when the text is ambiguous — many ink-review thumbnails show the ink
+    bottle and/or the ink name as a text overlay.
   TEXT
 
   def initialize(ink_review_id)
@@ -123,7 +123,7 @@ class ReviewApprover
 
   def perform
     ink_review.ensure_youtube_metadata!
-    ask!(user_prompt, with: ink_review.image.presence)
+    ask!(user_prompt, with: resolved_image_url)
     agent_log.update!(extra_data: ink_review.extra_data)
     agent_log.waiting_for_approval!
   end
@@ -142,6 +142,14 @@ class ReviewApprover
       RejectReview.new(ink_review),
       Summarize.new(ink_review, agent_log)
     ]
+  end
+
+  # Resolves the stored thumbnail URL before attaching it: the URL may redirect
+  # (e.g. http -> https) or lack a file extension, and RubyLLM cannot determine a
+  # MIME type in that case, which would abort the whole run. Returns nil when the
+  # URL does not serve an image, in which case no thumbnail is attached.
+  def resolved_image_url
+    ResolveImageUrl.new(ink_review.image).perform
   end
 
   def user_prompt

--- a/spec/agents/review_approver_spec.rb
+++ b/spec/agents/review_approver_spec.rb
@@ -126,6 +126,12 @@ RSpec.describe ReviewApprover do
     ink_review_submission # Create the submission
   end
 
+  before do
+    allow(ResolveImageUrl).to receive(:new) do |passed_url|
+      double("ResolveImageUrl", perform: passed_url.presence)
+    end
+  end
+
   subject { described_class.new(ink_review.id) }
 
   def user_message_text(body)
@@ -471,6 +477,97 @@ RSpec.describe ReviewApprover do
               end
           }
           .at_least_once
+      end
+
+      it "attaches the resolved URL rather than the stored one" do
+        resolved = "https://cdn.example.com/resolved.jpg"
+        allow(ResolveImageUrl).to receive(:new).with(ink_review.image).and_return(
+          double(perform: resolved)
+        )
+
+        subject.perform
+
+        expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+          .with { |req|
+            body = JSON.parse(req.body)
+            user_msg = body["messages"].find { |m| m["role"] == "user" }
+            parts = user_msg["content"]
+
+            parts.is_a?(Array) &&
+              parts.any? { |p| p["type"] == "image_url" && p["image_url"]["url"] == resolved }
+          }
+          .at_least_once
+      end
+
+      context "when ResolveImageUrl returns nil (e.g. a redirecting or extensionless URL)" do
+        before { allow(ResolveImageUrl).to receive(:new).and_return(double(perform: nil)) }
+
+        it "sends a plain string user message instead of failing" do
+          subject.perform
+
+          expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+            .with { |req|
+              body = JSON.parse(req.body)
+              user_msg = body["messages"].find { |m| m["role"] == "user" }
+              user_msg["content"].is_a?(String)
+            }
+            .at_least_once
+        end
+
+        it "still reaches a decision" do
+          subject.perform
+
+          expect(ink_review.reload.approved_at).to be_present
+        end
+      end
+
+      # Regression: an http:// thumbnail that redirects to https and whose path has
+      # no file extension used to raise RubyLLM::UnsupportedAttachmentError, because
+      # RubyLLM's MIME sniffing does not follow redirects and so saw an empty body.
+      context "with a redirecting, extensionless thumbnail URL" do
+        let(:stored_url) { "http://static.example.com/t/thumbnail?format=1500w" }
+        let(:final_url) { "https://static.example.com/t/thumbnail?format=1500w" }
+
+        before do
+          allow(ResolveImageUrl).to receive(:new).and_call_original
+          ink_review.update_column(:image, stored_url)
+
+          stub_request(:head, stored_url).to_return(
+            status: 301,
+            headers: {
+              "Location" => final_url
+            }
+          )
+          stub_request(:head, final_url).to_return(
+            status: 200,
+            headers: {
+              "Content-Type" => "image/jpeg"
+            }
+          )
+          stub_request(:get, final_url).to_return(
+            status: 200,
+            body: "\xFF\xD8\xFF\xE0 JFIF  ".b,
+            headers: {
+              "Content-Type" => "image/jpeg"
+            }
+          )
+        end
+
+        it "attaches the redirect target and reaches a decision" do
+          expect { subject.perform }.not_to raise_error
+
+          expect(ink_review.reload.approved_at).to be_present
+          expect(WebMock).to have_requested(:post, "https://api.openai.com/v1/chat/completions")
+            .with { |req|
+              body = JSON.parse(req.body)
+              user_msg = body["messages"].find { |m| m["role"] == "user" }
+              parts = user_msg["content"]
+
+              parts.is_a?(Array) &&
+                parts.any? { |p| p["type"] == "image_url" && p["image_url"]["url"] == final_url }
+            }
+            .at_least_once
+        end
       end
 
       context "when the review has a blank image" do


### PR DESCRIPTION
Fixes Honeybadger [131112159](https://app.honeybadger.io/projects/107098/faults/131112159) — `RubyLLM::UnsupportedAttachmentError: Unsupported attachment type: application/octet-stream`, 14 notices since 2026-06-04, last seen 2026-08-10.

## Cause

`ReviewApprover#perform` passed the stored `ink_review.image` straight to `ask!`, unlike `YoutubeSummarizer` and `ReviewFinder`, which both resolve the URL through `ResolveImageUrl` first.

That breaks for thumbnails whose URL redirects *and* whose path has no file extension. Squarespace-hosted blogs — penaddict.com among them — produce exactly that shape:

```
http://static1.squarespace.com/static/.../Some+Ink+Name?format=1500w
```

The chain:

1. Basename is `Some+Ink+Name` — `?format=1500w` is query, not path — so Marcel guesses `application/octet-stream` from the name.
2. RubyLLM falls back to sniffing the response body (`attachment.rb:147`) using `RubyLLM::Connection.basic`, which does **not** follow redirects. It received the `http` → `https` 301 with an empty body.
3. Sniffing an empty body yields `application/octet-stream` again → `type == :unknown` → `openai/media.rb:47` raises.

The failure aborted the entire run rather than degrading. Sidekiq retries were exhausted, the `AgentLog` stayed in `processing`, and the review was never approved or rejected.

## Fix

Use the existing `ResolveImageUrl` operation. Its `SafeHttp.head` follows up to 5 redirects, requires an `image/` content type, and returns the post-redirect URL — so RubyLLM's own sniffing fetch now gets a real 200 with image bytes. It returns `nil` when the URL does not serve an image, in which case no thumbnail is attached and the agent still reaches a decision instead of wedging.

Side benefits: the SSRF filtering the other two agents already had, and consistency across all three.

The system directive's "A thumbnail image ... is attached" became "When available, a thumbnail image ...", since resolution can now legitimately return nil.

## Blast radius

Checked against production: 1 wedged `AgentLog` (69317, review 43819) and 2 undecided reviews with suspect thumbnail URLs, both penaddict.com. Small today, but recurring for every Squarespace-hosted review going forward.

Review 43819 needs a nudge after deploy. Its wedged log still holds the old prompt, so the transcript is cleared first — otherwise `restore_transcript` replays it and `ask!` appends a duplicate user message:

```ruby
AgentLog.find(69317).update!(transcript: [])
RunAgent.perform_async("ReviewApprover", 43819)
```